### PR TITLE
Fix missing /app in rsync command

### DIFF
--- a/toolstacks/php/drupal/migrating-an-existing-site.rst
+++ b/toolstacks/php/drupal/migrating-an-existing-site.rst
@@ -131,4 +131,4 @@ Go to your files folder on your local machine and synchronise them to your remot
 
 .. code-block:: console
 
-   $ rsync -r files/. [project-id]-master@ssh.eu.platform.sh:/public/sites/default/files/
+   $ rsync -r files/. [project-id]-master@ssh.eu.platform.sh:/app/public/sites/default/files/


### PR DESCRIPTION
Note: The edit on github links on https://docs.platform.sh/toolstack/php/drupal/003-migrating-an-existing-site.html don't work, the 003 part doesn't match.
