### PR TITLE
CLI: advise users to install it, not to 'download' it.

### DIFF
--- a/overview/platform-cli.rst
+++ b/overview/platform-cli.rst
@@ -11,11 +11,16 @@ The :ref:`cli` is the official tool to use and manage your Platform.sh projects 
 How do I get it?
 ----------------
 
-You can download the :ref:`cli` from `Github <https://github.com/platformsh/platform-cli>`_. 
+You can install the :ref:`cli` easily using Composer:
+
+.. code-block:: console
+
+  composer global require 'platformsh/cli:1.*'
+
+You can find the system requirements and more information in the `installation instructions on GitHub <https://github.com/platformsh/platformsh-cli/blob/master/README.md>`_.
 
 .. seealso::
   * :ref:`install_cli`
-  * `Installation instructions on Github <https://github.com/platformsh/platformsh-cli/blob/development/README.md>`_.
 
 What can I do with the CLI?
 ---------------------------


### PR DESCRIPTION
- I think 'download' is misleading
- the README link should go to the `master` branch not `development`

I'm not sure if you will like what I've done with the 'see also' block or the `composer` example, but please fix the above two at least.
