### PR TITLE
Drupal faq updates

### DIFF
--- a/toolstacks/php/drupal/faq.rst
+++ b/toolstacks/php/drupal/faq.rst
@@ -10,30 +10,10 @@ In order for Platform to automatically detect your make file, you need to call i
 
 You can also have a **specific make file for Drupal core** called **\`project-core.make\`**
 
-
-
-Can I run Drupal 8 in Platform?
--------------------------------
-
-Drush 7 is required to build Drupal 8, so you won't be able to build a Drupal 8 make file.
-
-But you can still commit Drupal 8 as a complete project (commit the whole core directory) and it'll work fine.
-
-How do I import a database in an environment without drush aliases?
--------------------------------------------------------------------
-
-.. todo::
-    This should go somewhere to the **import existing site** section.
-
-.. code-block:: console
-
-  $ scp LOCAL_DB.sql REMOTE_PHP_SERVER:/tmp
-  $ mysql -h database.internal main < /tmp/LOCAL_DB.sql
-
 When I push changes to a make file, does Platform.sh run the update?
 --------------------------------------------------------------------
 
-After a push, Platform will rebuild your environment and download all the modules that are in your make file.
+After a push, Platform.sh will rebuild your environment and download all the modules that are in your make file.
 
 If an update function (hook_update) needs to run, you'll have to manually trigger it by going to ``/update.php`` or use the :ref:`deployment hooks <deployment_hooks>` to automatically run the updates.
 


### PR DESCRIPTION
https://docs.platform.sh/toolstacks/php/drupal/faq/
- [x] robots.txt are now moved by default, so the provided build hook is no longer valid
- [x] the page says Drupal 8 cannot be built from a make file, this is [out-of-date](https://github.com/platformsh/platformsh-examples/tree/drupal/8.x)
- [x] the page duplicates database import instructions which belong on [this page](https://docs.platform.sh/toolstacks/php/drupal/migrate-existing-site/#without-drush)
- [x] we probably should still answer a "Can I run Drupal 8" question, linking to the platformsh-example
