### PR TITLE
Symfony2: Being very specific about the steps following a platform clone.

### DIFF
--- a/toolstacks/php/symfony/faq.rst
+++ b/toolstacks/php/symfony/faq.rst
@@ -33,3 +33,18 @@ Then, add this line at the top of your ``app_dev.php``:
 
 .. seealso::
   * :ref:`configuration_files`
+
+
+Why does my newly cloned Symfony install throw errors?
+--------------------------------------------------------------------------------------
+
+You may encounter the WSOD (white screen of death) when you first clone a new Symfony2 project from your platform. This is likely because you forgot to install dependencies.
+
+You will need to install composer first and then run the following command:
+
+.. code-block:: console
+	
+	php composer.phar install
+
+.. seealso::
+  * `Install Composer <https://getcomposer.org/download/>`_


### PR DESCRIPTION
I'm not sure if this is the proper file for this but it seems to fit. Basically the issue is that once you clone your newly created platform from platform.sh obviously it doesn't contain vendor packages. Sadly that wasn't super obvious to me so I'm hoping to save someone a bit of handwringing.

I've added a note in the FAQ for Symfony2 that, if you're dense like me, you should run composer install once you get the repo locally. :)