### PR TITLE
Fix php.ini comment sign and language

### DIFF
--- a/toolstacks/php/README.md
+++ b/toolstacks/php/README.md
@@ -40,8 +40,8 @@ the application (normally the repository root).
 
 For example, if you need to increase the PHP memory limit:
 
-```php
-# php.ini
+```ini
+; php.ini
 ; Increase PHP memory limit
 memory_limit = 256M
 ```


### PR DESCRIPTION
A customer left in the `#` comment, and ended up with an error whenever php-cli ran.