### PR TITLE
supplement redirect documentation

### DIFF
--- a/reference/redirects.md
+++ b/reference/redirects.md
@@ -1,15 +1,18 @@
 # Redirects
 
-Managing redirection rules is a common requirement for web applications, especially in cases where you do not want to lose incoming links that have changed or been removed over time.
-
-You can manage redirection rules on your Platform.sh projects in three different ways:
-
+Managing redirection rules is a common requirement for web applications,
+especially in cases where you do not want to lose incoming links that have
+changed or been removed over time. You can manage redirection rules on your
+Platform.sh projects in two different ways, which we describe here. If neither
+of these options satisfy your redirection needs, you can still implement redirects
+directly from within your application, which if implemented with the appropriate caching headers
+would be almost as efficient as using the configuration options provided by Platform.sh.
 
 ## Whole-route redirects
 
-In the [`.platform/routes.yaml`](routes-yaml.html) file you can configure routes whose sole purpose is to redirect.
-
-A typical use case for this type of route is adding or removing a `www.` prefix to your domain, like this:
+Using whole-route redirects, you can define very basic routes in your [`.platform/routes.yaml`](routes-yaml.html)
+file whose sole purpose is to redirect. A typical use case for this type of route is adding or removing a `www.`
+prefix to your domain, as the following example shows:
 
 ```yaml
 http://{default}/:
@@ -17,10 +20,10 @@ http://{default}/:
     to: http://www.{default}/
 ```
 
-
 ## Partial redirects
 
-In the [`.platform/routes.yaml`](routes-yaml.html) file you can also add redirect rules to any existing route:
+In the [`.platform/routes.yaml`](routes-yaml.html) file you can also add partial redirect rules
+to existing routes:
 
 ```yaml
 http://{default}/:
@@ -32,38 +35,81 @@ http://{default}/:
       "/regexp/(.*)/matching": { "to": "http://example.com/$1", regexp: true }
 ```
 
-This format is much richer and works with any type of route, including routes served directly by the application.
+This format is more rich and works with any type of route, including routes served directly by the application.
 
 Two keys are available under `redirects`:
 
  * `expires`: optional, the duration the redirect will be cached. Examples of valid values include `3600s`, `1d`, `2w`, `3m`.
  * `paths`: the paths to apply redirections to.
 
-Each rule in `paths` is defined by its key describing the expression to match against the
-request path and a value object describing both the destination to redirect to and
-details about how to handle the redirection. The value object is defined with the following
+Each rule under `paths` is defined by its key describing the expression to match against the
+request path and a value object describing both the destination to redirect to with
+detail on how to handle the redirection. The value object is defined with the following
 keys:
 
  * `to`: required, a partial (`"/destination"` or `"//destination"`) or full URL (`"http://example.com/"`).
- * `regexp`: optional, specifies whether the path key should be interpreted as a PCRE regular expression. Defaults to `false`.
- * `prefix`: optional, specifies whether we should redirect both the path and all its children (`true`) or only the path itself (`false`). Defaults to `true`, but not supported if `regexp` is `true`. For example,
+ * `regexp`: optional, defaults to `false`. Specifies whether the path key should be interpreted as
+   a PCRE regular expression. In the following example, a request to `http://example.com/regexp/a/b/c/match`
+   would redirect to `http://example.com/a/b/c`:
 
    ```yaml
    http://{default}/:
-     # [...]
+     type: upstream
      redirects:
        paths:
-         "/from": { "to": "http://example.com/", partial: true }
+         "/regexp/(.*)/match":
+            to: "http://example.com/$1"
+            regexp: true
    ```
-   with `partial` set to `true`, both `/from` and `/from/child/path` will redirect. If `partial` is set to `false` then only `/from` trigger a redirect.
- * `append_suffix`: optional, determines if the suffix is carried over with the redirect. Defaults to `true`, but not supported if `regexp` is `true` or if `prefix` is `false`. Re-using the example from above, if `true` then `/from/child/path` would redirect to `http://example.com/child/path`, otherwise `/from/child/path` would redirect to `http://example.com/`.
+
+ * `prefix`: optional, specifies whether we should redirect both the path and all its children or just the path itself. Defaults to `true`, but not supported if `regexp` is `true`. For example,
+
+   ```yaml
+   http://{default}/:
+     type: upstream
+     redirects:
+       paths:
+         "/from":
+            to: "http://{default}/to"
+            partial: true
+   ```
+   with `partial` set to `true`, `/from` will redirect to `/to` and `/from/another/path` will redirect to `/to/another/path`.
+   If `partial` is set to `false` then `/from` will trigger a redirect, but `/from/another/path` will not.
+ * `append_suffix`: optional, determines if the suffix is carried over with the redirect. Defaults to `true`, but not supported if `regexp` is `true` or if `prefix` is `false`.
+   If we redirect with `append_suffix` set to `false`, for example, then the following
+
+   ```yaml
+   http://{default}/:
+     type: upstream
+     redirects:
+       paths:
+         "/from":
+            to: "http://{default}/to"
+            append_suffix: false
+   ```
+   would result in `/from/path/suffix` redirecting to just `/to`. If `append_suffix` was left on its default value of `true`, then `/from/path/suffix` would have redirected to `/to/path/suffix`.
  * `code`: optional, HTTP status code. Valid status codes are `301`, `302`, `307`, and `308`. Defaults to `302`.
- * `expires`: optional, the duration the redirect will be cached for. Defaults to the `expires` value defined directly under the `redirects` key, but can be fine-tuned at the path level.
+ * `expires`: optional, the duration the redirect will be cached for. Defaults to the `expires` value defined directly under the `redirects` key, but at this level we can fine-tune the expiration of individual partial redirects:
+
+   ```yaml
+   http://{default}/:
+     type: upstream
+     redirects:
+       expires: 1d
+       paths:
+         "/from": { "to": "http://example.com/" }
+         "/here": { "to": "http://example.com/there", "expires": "2w" }
+   ```
+   In this example, redirects from `/from` would be set to expire in one day, but redirects from `/here` would
+   expire in two weeks.
+
 
 ## Application-driven redirects
 
-If none of the above options satisfy your redirection needs, you can still
+If neither of the above options satisfy your redirection needs, you can still
 implement redirects directly in your application. If sent with the appropriate
-caching headers, it would be almost as efficient as the options provided by
-Platform.sh.
+caching headers, this is nearly as efficient as implementing the redirect through
+one of the two configurations described above. Implementing application-driven
+redirects depends on your own code or framework and is beyond the scope of this
+documentation.
 

--- a/reference/redirects.md
+++ b/reference/redirects.md
@@ -1,13 +1,13 @@
 # Redirects
 
-Managing redirection rules is a common requirement for web applications, especially those that have been around for a while and do not want to lose the benefit of the rich incoming links that they gathered over time.
+Managing redirection rules is a common requirement for web applications, especially in cases where you do not want to lose incoming links that have changed or been removed over time.
 
-Redirection rules on Platform.sh can be managed in three different ways:
+You can manage redirection rules on your Platform.sh projects in three different ways:
 
 
 ## Whole-route redirects
 
-In the [`.platform/routes.yaml`](routes-yaml.html) file, you can configure routes that are pure redirects.
+In the [`.platform/routes.yaml`](routes-yaml.html) file you can configure routes whose sole purpose is to redirect.
 
 A typical use case for this type of route is adding or removing a `www.` prefix to your domain, like this:
 
@@ -20,7 +20,7 @@ http://{default}/:
 
 ## Partial redirects
 
-In the [`.platform/routes.yaml`](routes-yaml.html) file, you can also add redirect rules to any existing route:
+In the [`.platform/routes.yaml`](routes-yaml.html) file you can also add redirect rules to any existing route:
 
 ```yaml
 http://{default}/:
@@ -36,16 +36,17 @@ This format is much richer and works with any type of route, including routes se
 
 Two keys are available under `redirects`:
 
- * `expires`: optional, the duration the redirect will be cached;
+ * `expires`: optional, the duration the redirect will be cached. Examples of valid values include `3600s`, `1d`, `2w`, `3m`.
  * `paths`: the paths to apply redirections to.
 
-Each rule in `paths` is made of a key, which is a string or a PCRE regular
-expression to match the request path against, and a value object made of the
-following keys:
+Each rule in `paths` is defined by its key describing the expression to match against the
+request path and a value object describing both the destination to redirect to and
+details about how to handle the redirection. The value object is defined with the following
+keys:
 
- * `to`: required, a partial (`"/destination"` or `"//destination"`) or full URL (`"http://example.com/"`)
- * `regexp`: optional, determines if the path is a regular expression. Defaults to `false`.
- * `prefix`: optional, determines whether we redirect both the path and all its children (`true`) or only the path by itself (`false`). Defaults to `true`, but not supported if regexp is enabled.
+ * `to`: required, a partial (`"/destination"` or `"//destination"`) or full URL (`"http://example.com/"`).
+ * `regexp`: optional, specifies whether the path key should be interpreted as a PCRE regular expression. Defaults to `false`.
+ * `prefix`: optional, specifies whether we should redirect both the path and all its children (`true`) or only the path itself (`false`). Defaults to `true`, but not supported if `regexp` is `true`. For example,
 
    ```yaml
    http://{default}/:
@@ -54,11 +55,10 @@ following keys:
        paths:
          "/from": { "to": "http://example.com/", partial: true }
    ```
-   With `partial` set to `true`, both `/from` and `/from/child/path` will redirect. If `partial` is set to `false` then only `/from` will be matched for redirection. 
-
+   with `partial` set to `true`, both `/from` and `/from/child/path` will redirect. If `partial` is set to `false` then only `/from` trigger a redirect.
  * `append_suffix`: optional, determines if the suffix is carried over with the redirect. Defaults to `true`, but not supported if `regexp` is `true` or if `prefix` is `false`. Re-using the example from above, if `true` then `/from/child/path` would redirect to `http://example.com/child/path`, otherwise `/from/child/path` would redirect to `http://example.com/`.
- * `code`: optional, defaults to `302` (Can be one of `301`, `302`, `307`, `308`)
- * `expires`: optional, the duration the redirect will be cached (defaults to the `expires` value defined directly under the `redirects` key.)
+ * `code`: optional, HTTP status code. Valid status codes are `301`, `302`, `307`, and `308`. Defaults to `302`.
+ * `expires`: optional, the duration the redirect will be cached for. Defaults to the `expires` value defined directly under the `redirects` key, but can be fine-tuned at the path level.
 
 ## Application-driven redirects
 

--- a/reference/redirects.md
+++ b/reference/redirects.md
@@ -1,4 +1,3 @@
-
 # Redirects
 
 Managing redirection rules is a common requirement for web applications, especially those that have been around for a while and do not want to lose the benefit of the rich incoming links that they gathered over time.
@@ -33,7 +32,7 @@ http://{default}/:
       "/regexp/(.*)/matching": { "to": "http://example.com/$1", regexp: true }
 ```
 
-This format is much richer, and works with any type of route, including a route that is served directly by an application.
+This format is much richer and works with any type of route, including routes served directly by the application.
 
 Two keys are available under `redirects`:
 
@@ -44,10 +43,20 @@ Each rule in `paths` is made of a key, which is a string or a PCRE regular
 expression to match the request path against, and a value object made of the
 following keys:
 
- * `to`: required, a partial (`"/toto"` or `"//toto"`) or full URL (`"http://example.com/"`)
- * `regexp`: optional, determines if the path is a regular expression. (Defaults to `false`.)
- * `prefix`: optional, determines if the redirect applies to just the path, oralso to all children of the path. (Defaults to `true` if regexp is false`, not supported when regexp is `true`.)
- * `append_suffix`: optional, determines if the suffix is carried over with the redirect (Defaults to `true` if regexp is `false`, not supported when regexp is `true`.)
+ * `to`: required, a partial (`"/destination"` or `"//destination"`) or full URL (`"http://example.com/"`)
+ * `regexp`: optional, determines if the path is a regular expression. Defaults to `false`.
+ * `prefix`: optional, determines whether we redirect both the path and all its children (`true`) or only the path by itself (`false`). Defaults to `true`, but not supported if regexp is enabled.
+
+   ```yaml
+   http://{default}/:
+     # [...]
+     redirects:
+       paths:
+         "/from": { "to": "http://example.com/", partial: true }
+   ```
+   With `partial` set to `true`, both `/from` and `/from/child/path` will redirect. If `partial` is set to `false` then only `/from` will be matched for redirection. 
+
+ * `append_suffix`: optional, determines if the suffix is carried over with the redirect. Defaults to `true`, but not supported if `regexp` is `true` or if `prefix` is `false`. Re-using the example from above, if `true` then `/from/child/path` would redirect to `http://example.com/child/path`, otherwise `/from/child/path` would redirect to `http://example.com/`.
  * `code`: optional, defaults to `302` (Can be one of `301`, `302`, `307`, `308`)
  * `expires`: optional, the duration the redirect will be cached (defaults to the `expires` value defined directly under the `redirects` key.)
 
@@ -57,3 +66,4 @@ If none of the above options satisfy your redirection needs, you can still
 implement redirects directly in your application. If sent with the appropriate
 caching headers, it would be almost as efficient as the options provided by
 Platform.sh.
+


### PR DESCRIPTION
I examined the code platform/container/router/templates/nginx.conf.mako, there is nothing implemented that isn't already documented, so I supplemented the documentation with examples of 'prefix' and 'append_suffix' usage, and with example values for the 'expires' property (which I'm not sure about). I said "Examples of valid values include 3600s, 1d, 2w, 3m." -- I assume that's right, if somebody can confirm. I did some minor refactor in wording. The platform is up here: https://master-2vh7mcnp5eakq.eu.platform.sh/user_guide/reference/redirects.html

For some reason some of the `code` strings are highlighted red and some are grey -- I have no idea why.