### PR TITLE
Correct minor typo in configure-project.md

### DIFF
--- a/overview/web-ui/configure-project.md
+++ b/overview/web-ui/configure-project.md
@@ -23,7 +23,7 @@ The `Users` screen allows you to manage users access on your project.
 
 You can invite new users to your project by clicking the `Add user` link
 and entering their email address, or modify permissions of existing
-users by clicking the `Edit` link when hovering the user.
+users by clicking the `Edit` link when hovering over the user.
 
 ![Project configure icon](/images/ui-conf-project-users.png)
 

--- a/reference/environment-variables.md
+++ b/reference/environment-variables.md
@@ -3,7 +3,7 @@
 Platform.sh exposes environment variables which you can interact with. There are
 two sources for these. There are the ones that are set by Platform.sh itself
 and that give you all the context you need about the environment (how to 
-connect to you database for example). And there are the ones you can set
+connect to your database for example). And there are the ones you can set
 yourself through the web interface or the CLI.
 
 When you're logged in via SSH to an environment (with the cli: `platform ssh`), 


### PR DESCRIPTION
This could also use "hovering above the user", but I think that "over" is more common in this context.