### PR TITLE
Simplify logic to find basename of request URI

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@ function matchPath($path, $current_urls){
     }
     if ($location=="/"){ 
         // nothing was matched let's try a shorter match
-        $path = str_replace(["/index.html",".html"],"",array_pop(explode('/', $path)));
+        $path = basename($path);
         foreach ($current_urls as $url) {
             if (stripos($url, $path) !== FALSE ) {
                 $location = $url;


### PR DESCRIPTION
This should suppress the notice which break the search function when visiting https://docs.platform.sh/user_guide/search_index.json.

```
Notice:  Only variables should be passed by reference in /app/_books/index.php on line 21
```