### PR TITLE
Drop links to old examples page

### DIFF
--- a/overview/deployment.md
+++ b/overview/deployment.md
@@ -22,9 +22,7 @@ of the operations in the Git session (because you are talking to their Git
 server) but you can follow on whats happening in their interface, our in Platform.sh's Web Interface.
 
 The only modification you need to do to your application is to tell it
-to load its configuration from the environment (and we supply [all the
-examples you need](https://github.com/platformsh/platformsh-examples)) instead
-of hardcoded values.
+to load its configuration from the environment instead of hardcoded values.
 
 There are a couple of "dot files" in YAML format you  put at the root
 of your application that will describe its dependencies. You can say for

--- a/reference/toolstacks/README.md
+++ b/reference/toolstacks/README.md
@@ -5,7 +5,9 @@ to the configuration and operation of specific Frameworks and Toolstacks.
 It is noteworthy that Platform.sh provids specific tooling to help you be more productive
 (through built-in composer support or built-in drush support).
 
-> **note**
-> Find many examples for those configuration files on the [platformsh-examples repository on 
-GitHub](https://github.com/platformsh/platformsh-examples).
-> with many examples for Drupal, Symfony, Custom PHP Applications (with multi apps), Wordpress, Magento, Prestashop, Laravel...
+You may find a list of examples here:
+
+* Drupal - https://github.com/platformsh/platformsh-example-drupal
+* Symfony - https://github.com/platformsh/platformsh-example-symfony
+* Wordpress - https://github.com/platformsh/platformsh-example-wordpress
+* eZ Platform - https://github.com/platformsh/platformsh-example-ezpublish

--- a/reference/toolstacks/php/drupal/drush.md
+++ b/reference/toolstacks/php/drupal/drush.md
@@ -57,7 +57,7 @@ since it only contains your custom code.
 Your make file can be called: `project.make` or `drupal-org.make`.
 
 You can find an example make file on
-[GitHub](https://github.com/platformsh/platformsh-examples/blob/drupal/7.x/project.make).
+[GitHub](https://github.com/platformsh/platformsh-example-drupal/blob/7.x/project.make).
 
 When building as a profile, you **need a make file for Drupal core**
 called: `project-core.make`:

--- a/reference/upgrade/README.md
+++ b/reference/upgrade/README.md
@@ -79,7 +79,7 @@ still supported, but customers are invited to move to the new format.
 
 For an example upgrade path, see the [Drupal 7.x branch of the
 Platformsh-examples
-repository](https://github.com/platformsh/platformsh-examples/blob/drupal/7.x/.platform.app.yaml)
+repository](https://github.com/platformsh/platformsh-example-drupal/blob/7.x/.platform.app.yaml)
 on GitHub.
 
 Configuration items for PHP that previously was part of


### PR DESCRIPTION
https://github.com/platformsh/platformsh-examples/ is no longer available, switching to new examples on docs.