### PR TITLE
Remove outdated instructions to use Drush 8 RC

### DIFF
--- a/reference/toolstacks/php/drupal/README.md
+++ b/reference/toolstacks/php/drupal/README.md
@@ -146,12 +146,3 @@ crons:
 You can find some working example on GitHub:
 * [Drupal 7](https://github.com/platformsh/platformsh-example-drupal/tree/7.x)
 * [Drupal 8](https://github.com/platformsh/platformsh-example-drupal/tree/8.x)
-
-For Drupal 8, your `.platform.app.yaml` should install Drush 8 RC as a build-time dependency:
-
-```yaml
-# .platform.app.yaml
-dependencies:
-    php:
-        "drush/drush": "8.0.0-rc2"
-```


### PR DESCRIPTION
Because 8-stable is out, and Drupal 8 shouldn't even be using the Drush make build flavor anyway anymore.