### PR TITLE
Clean up Drupal 7 Redis documentation

### DIFF
--- a/reference/toolstacks/php/drupal/redis-drupal-7.md
+++ b/reference/toolstacks/php/drupal/redis-drupal-7.md
@@ -127,6 +127,13 @@ if (!empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
 }
 ```
 
+### Verifying redis is running
+Run this command in a SSH session in your environment `redis-cli -h redis.internal info`. You should run it before you push all this new code to your repository.
+
+This should give you a baseline of activity on your Redis installation. There should be very little memory allocated to the Redis cache.
+
+After you push this code, you should run the command and notice that allocated memory will start jumping.
+
 > **note**
 > If you use Domain Access and Redis, ensure that your Redis settings (particularly `$conf['cache_backends']`)
 > are included before the Domain Access `settings.inc` file - see

--- a/reference/toolstacks/php/drupal/redis-drupal-7.md
+++ b/reference/toolstacks/php/drupal/redis-drupal-7.md
@@ -18,10 +18,10 @@ add or uncomment the following:
 
 ```yaml
 rediscache:
-    type: redis:2.8
+    type: redis:3.0
 ```
 
-That will create a service named `rediscache`, of type `redis`, specifically version `2.8`.
+That will create a service named `rediscache`, of type `redis`, specifically version `3.0`.
 
 ### Expose the Redis service to your application
 


### PR DESCRIPTION
Per https://github.com/platformsh/platformsh-docs/issues/214, the Redis docs could use work.

I tested this by running through an install myself, and correcting everything I found that didn't work as advertised.  I also decided to officially recommend PhpRedis, as the C extension should be faster according to Benchmarks Found on the Internet(tm).