### PR TITLE
Replace the "php" endpoint term with "http", as the former is deprecated

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -16,4 +16,4 @@ https://{default}/:
   ssi:
     enabled: false
   type: upstream
-  upstream: php:php
+  upstream: php:http

--- a/reference/cache.md
+++ b/reference/cache.md
@@ -19,7 +19,7 @@ Cache can be enabled in your `.platform/routes.yaml` file like below:
 ```yaml
 http://{default}/:
     type: upstream
-    upstream: php:php
+    upstream: php:http
     cache:
         enabled: true
         headers: [ "Accept", "Accept-Language", "X-Language-Locale" ]
@@ -37,19 +37,19 @@ Here is an example:
 ```yaml
 http://{default}/:
   type: upstream
-  upstream: php:php
+  upstream: php:http
   cache:
     enabled: true
 
 http://{default}/foo/:
   type: upstream
-  upstream: php:php
+  upstream: php:http
   cache:
     enabled: false
 
 http://{default}/foo/bar/:
   type: upstream
-  upstream: php:php
+  upstream: php:http
   cache:
     enabled: true
 ```

--- a/reference/platform-app-yaml-multi-app.md
+++ b/reference/platform-app-yaml-multi-app.md
@@ -74,10 +74,10 @@ like the following (names need to match):
 ```yaml
 "http://back-end.{default}/":
     type: upstream
-    upstream: "drupal:php"
+    upstream: "drupal:http"
 "http://{default}/":
     type: upstream
-    upstream: "angular:php"
+    upstream: "angular:http"
 ```
 
 This will result (if we consider we are on the `http://example.com` domain): 
@@ -162,28 +162,27 @@ The `.platform/routes.yaml` may look like:
 ````yaml
 "http://api.{default}/v1/users":
     type: upstream
-    upstream: "user:php"
+    upstream: "user:http"
     cache:
         enabled: false
 "http://api.{default}/v1/content":
     type: upstream
-    upstream: "content:php"
+    upstream: "content:http"
     cache:
         enabled: false
 "http://{default}/":
     type: upstream
-    upstream: "front:php"
+    upstream: "front:http"
     cache:
         enabled: true
 ```
 
 For the later, we simply tell our router to connect, to a service called `front` and 
-route HTTP traffic to the PHP service running there.
+route HTTP traffic to the application service running there.
 
 > **note** 
-> The upstream currently always ends with `:php` since Platform.sh only supports
-> PHP. In the future Platform.sh will support multiple endpoints per 
-> application.
+> The upstream virtually always ends in `':http`, since Platform.sh only supports
+> HTTP-based applications exposed to the outside world.
 > Learn more on: [routes.yaml](/reference/routes.yaml.md)
 
 ### Services
@@ -244,8 +243,8 @@ name: front
 [...]
 relationships:
     "database": "cache:redis"
-    "user_service": "user:php"
-    "content_service": "content:php"
+    "user_service": "user:http"
+    "content_service": "content:http"
 ```
 
 These relationships allow an application to connect to another, and will expose 

--- a/reference/platform-app-yaml.md
+++ b/reference/platform-app-yaml.md
@@ -64,8 +64,8 @@ must have a **unique name** within a project. The name may only be
 composed of lower case alpha-numeric characters. (a-z0-9).
 
 This name is used in the `.platform/routes.yaml` file to define the HTTP upstream
-(by default `php:php` - if you called your application `app` you will
-need to use `app:php` in the upstream field).
+(by default `php:http` - if you called your application `app` you will
+need to use `app:http` in the upstream field).
 
 You can also use this name in multi-application relationships.
 

--- a/reference/routes-yaml.md
+++ b/reference/routes-yaml.md
@@ -47,7 +47,7 @@ Each route can be configured separately its has the following properties
 * `type` can be:
   * `upstream` serves an application
     * It will then also have an `upstream` property which will be the name of 
-    the application (as defined in `.platform.app.yaml`) followed by ":php" (see
+    the application (as defined in `.platform.app.yaml`) followed by ":http" (see
      examples below).
   * `redirect` redirects to another route
     * It will then be followed by `to` property, this is an HTTP redirection to 
@@ -57,7 +57,7 @@ Each route can be configured separately its has the following properties
 * `redirects` controls [redirect rules](redirects.html) associated with the route.
 
 > **note** for the moment the upstream is always of this form, ending with 
-> ":php" in the  future Platform.sh will support multiple endpoints per 
+> ":http" in the  future Platform.sh will support multiple endpoints per 
 > application. 
 
 ## Routes examples
@@ -65,7 +65,7 @@ Here is an example of a `routes.yaml` file:
 ```yaml
 "http://{default}/":
   type: upstream
-  upstream: "frontend:php"
+  upstream: "frontend:http"
 "http://www.{default}/":
   type: redirect
   to: "http://{default}/"
@@ -80,11 +80,11 @@ but serving from both:
 ```yaml
 "http://{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 
 "http://www.{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 ```
 
 The difference between the two previous examples is that for the first one the
@@ -98,7 +98,7 @@ routes):
 ```yaml
 "http://*.{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 ```
 
 You can see the [Configuring Multiple 
@@ -131,7 +131,7 @@ https://{default}/:
   ssi:
     enabled: false
   type: upstream
-  upstream: php:php
+  upstream: php:http
 ```
 ## Configuring routes on the Web Interface
 For your convenience routes can also be configured using the web interface in
@@ -199,7 +199,7 @@ If you do not have a `routes.yaml` file, the following default one will be loade
 ```yaml
 "http://{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
     cache:
         enabled: true
     ssi:

--- a/reference/ssi.md
+++ b/reference/ssi.md
@@ -8,14 +8,14 @@ You can activate or deactivate SSI on a per-route basis in your
 ```yaml
 "http://{default}/":
     type: upstream
-    upstream: "myapp:php"
+    upstream: "myapp:http"
     cache:
       enabled: false
     ssi:
         enabled: true
 "http://{default}/time.php":
     type: upstream
-    upstream: "myapp:php"
+    upstream: "myapp:http"
     cache:
       enabled: true
 ```

--- a/using/going-live.md
+++ b/using/going-live.md
@@ -34,7 +34,7 @@ need define your `routes.yaml` as follow:
 ```yaml
 "http://{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 
 "http://www.{default}/":
     type: redirect
@@ -53,11 +53,11 @@ Here would be an example of your `routes.yaml` for the
 ```yaml
 "http://{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 
 "http://www.{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 ```
 
 > **note**
@@ -73,7 +73,7 @@ entire site with HTTPS, here is what your routes would look like:
 ```yaml
 "https://{default}/":
     type: upstream
-    upstream: "php:php"
+    upstream: "php:http"
 
 "http://{default}/":
     type: redirect
@@ -85,7 +85,7 @@ entire site with HTTPS, here is what your routes would look like:
 To configure a wildcard domain (*.mydomain.com):
 
 - Add your domain to your project (in form of mydomain.com).
-- Add a route to your master branch serving http://*.mydomain.com with the upstream php:php.
+- Add a route to your master branch serving http://*.mydomain.com with the upstream php:http.
 
 
 ## 3 - DNS


### PR DESCRIPTION
This just updates the documentation for the fact that the "php" endpoint is now just an alias to "http", which is the generic and works for all languages.