### PR TITLE
Drop no-ops passthru settings in example

### DIFF
--- a/reference/platform-app-yaml.md
+++ b/reference/platform-app-yaml.md
@@ -216,7 +216,6 @@ It has a few subkeys, which are:
             # front-controller.
             "/sites/default/files":
                 expires: 300
-                passthru: true
                 allow: true
 
 ### Disk


### PR DESCRIPTION
Since the example is using PHP (running fastcgi), `passthru: true` will have no effect at all (reset to false internally).