### PR TITLE
Specify 7.x version for registry-rebuild

### DIFF
--- a/guides/type/php/drupal/rebuild-site-registry.md
+++ b/guides/type/php/drupal/rebuild-site-registry.md
@@ -18,7 +18,7 @@ Second, execute the following commands to download, tweak, and run the
 registry rebuild.
 
 ```bash
-$ drush dl registry_rebuild --destination=/app/tmp
+$ drush dl registry_rebuild-7.x --destination=/app/tmp
 $ sed -i 's/, define_drupal_root()/, '"'"'\/app\/public'"'"'/' /app/tmp/registry_rebuild/registry_rebuild.php
 $ cd /app/public
 $ php ../tmp/registry_rebuild/registry_rebuild.php


### PR DESCRIPTION
Running the documented command on a project with drush 8.x fails:

```
$ drush dl registry_rebuild --destination=/app/tmp
No release history available for registry_rebuild 8.x.                                                                                                         [error]
Could not download requested project(s).
```