### PR TITLE
Remove the reference to Domain Access on the Drupal 8 Redis page

### DIFF
--- a/reference/toolstacks/php/drupal/redis-drupal-8.md
+++ b/reference/toolstacks/php/drupal/redis-drupal-8.md
@@ -162,8 +162,3 @@ Run this command in a SSH session in your environment `redis-cli -h redis.intern
 This should give you a baseline of activity on your Redis installation. There should be very little memory allocated to the Redis cache.
 
 After you push this code, you should run the command and notice that allocated memory will start jumping.
-
-> **note**
-> If you use Domain Access and Redis, ensure that your Redis settings (particularly `$settings['cache']`)
-> are included before the Domain Access `settings.inc` file - see
-> [this Drupal.org issue](https://www.drupal.org/node/2008486#comment-7782941) for more information.


### PR DESCRIPTION
As it is no longer necessary due to changes in Domain Access.

(Ken Rickard, the DA maintainer, informed me of this at GovCon.)