### PR TITLE
Adding links to Drupal-Redis subpages

### DIFF
--- a/reference/toolstacks/php/drupal/redis.md
+++ b/reference/toolstacks/php/drupal/redis.md
@@ -1,3 +1,7 @@
 # Using Redis with Drupal
 
 The Redis configuration will depend on your Drupal version.
+
+- [Drupal 6](redis-drupal-6.html)
+- [Drupal 7](redis-drupal-7.html)
+- [Drupal 8](redis-drupal-8.html)


### PR DESCRIPTION
The Redis landing page for Drupal is sad, so I tried to make it a bit more useful.