### PR TITLE
Fix "Could not locate registry_rebuild version 7.x-7.x-dev"

### DIFF
--- a/guides/type/php/drupal/rebuild-site-registry.md
+++ b/guides/type/php/drupal/rebuild-site-registry.md
@@ -18,7 +18,7 @@ Second, execute the following commands to download, tweak, and run the
 registry rebuild.
 
 ```bash
-$ drush dl registry_rebuild-7.x --destination=/app/tmp
+$ drush dl registry_rebuild-7.x-2.3 --destination=/app/tmp
 $ sed -i 's/, define_drupal_root()/, '"'"'\/app\/public'"'"'/' /app/tmp/registry_rebuild/registry_rebuild.php
 $ cd /app/public
 $ php ../tmp/registry_rebuild/registry_rebuild.php


### PR DESCRIPTION
The change in #325 did not cover all cases. When inside the root of a D7 site, it seems Drush appends `-7.x-dev` if the version is not fully specified.