### PR TITLE
Rename remaining app container examples to app

### DIFF
--- a/guides/configuration/drupal_application.md
+++ b/guides/configuration/drupal_application.md
@@ -5,8 +5,9 @@ Create a ``.platform.app.yaml`` file at the root of your Git repository.
 Open this file and paste this content:
 
 ```yaml
-name: php
-type: php
+name: app
+
+type: php:5.6
 build:
     flavor: drupal
 access:

--- a/reference/toolstacks/php/drupal7/README.md
+++ b/reference/toolstacks/php/drupal7/README.md
@@ -112,9 +112,10 @@ Add a `.platform.app.yaml` at the root of your drupal folder.
 Here is an example of a Drupal configuration:
 ```yaml
 # .platform.app.yaml
-name: php
+name: app
 
-type: php
+type: php:5.6
+
 build:
     flavor: drupal
 


### PR DESCRIPTION
That way we're consistent everywhere.