### PR TITLE
Correct mcrypt extension inclusion status in PHP versions.

### DIFF
--- a/src/languages/php.md
+++ b/src/languages/php.md
@@ -55,7 +55,7 @@ The following extensions are enabled by default:
 * gd
 * curl
 * intl
-* mcrypt
+* mcrypt (5.6 and earlier)
 * zendopcache (5.4 only) / opcache (5.5 and later)
 
 You can disable those by adding them to the `disabled_extensions` list.


### PR DESCRIPTION
Fixes #388 