### PR TITLE
Add note for relationship name of Drupal database

### DIFF
--- a/src/frameworks/drupal7.md
+++ b/src/frameworks/drupal7.md
@@ -106,5 +106,8 @@ sites/
 
 The ideal `.platform.app.yaml` file will vary from project project, and you are free to customize yours as needed.  A recommended baseline Drupal 7 configuration is listed below, and can also be found in our [Drupal 7 template project](https://github.com/platformsh/platformsh-example-drupal7).
 
+> **note**
+> Your database for Drupal must be named "database" in the `relationships`.
+
 {% codesnippet "https://raw.githubusercontent.com/platformsh/platformsh-example-drupal7/master/.platform.app.yaml", language="yaml" %}{% endcodesnippet %}
 


### PR DESCRIPTION
The generated settings.local.php always use `$relationships['database']` as the database for Drupal.