### PR TITLE
Revert "replace ga with gtm"

### DIFF
--- a/book.json
+++ b/book.json
@@ -8,7 +8,7 @@
     "reveal",
     "collapsible-menu",
     "codesnippet",
-    "gtm",
+    "ga",
     "edit-link",
     "-sharing"
   ],
@@ -17,9 +17,8 @@
       "base": "https://github.com/platformsh/platformsh-docs/edit/master/src",
       "label": "Edit Page"
     },
-    "gtm": {
-      "token": "GTM-MR3BJL",
-      "virtualPageViews": true
+    "ga": {
+      "token": "UA-4064131-10"
     }
   }
 }


### PR DESCRIPTION
Reverts platformsh/platformsh-docs#423

The GTM module is not configured correctly so it is showing the JS rather than executing it, which is causing layout errors.