### PR TITLE
Replace ga with gtm

### DIFF
--- a/book.json
+++ b/book.json
@@ -6,7 +6,6 @@
   "plugins": [
     "anchors",
     "reveal",
-    "collapsible-menu",
     "codesnippet",
     "ga",
     "edit-link",

--- a/book.json
+++ b/book.json
@@ -7,7 +7,7 @@
     "anchors",
     "reveal",
     "codesnippet",
-    "ga",
+    "gtm",
     "edit-link",
     "-sharing"
   ],
@@ -16,8 +16,9 @@
       "base": "https://github.com/platformsh/platformsh-docs/edit/master/src",
       "label": "Edit Page"
     },
-    "ga": {
-      "token": "UA-4064131-10"
+    "gtm": {
+      "token": "GTM-MR3BJL",
+      "virtualPageViews": true
     }
   }
 }

--- a/src/_layouts/layout.html
+++ b/src/_layouts/layout.html
@@ -20,6 +20,7 @@
 <script src="/scripts/user-widget/user-widget.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.18/angular.min.js"></script>
 <script src="/scripts/user-widget/app.js"></script>
+<script src="/scripts/collapsible-menu.js"></script>
 
 
 {% endblock %}

--- a/src/scripts/collapsible-menu.js
+++ b/src/scripts/collapsible-menu.js
@@ -1,0 +1,11 @@
+$(document).ready(function () {
+
+  require(["gitbook"], function(gitbook) {
+    gitbook.events.bind("page.change", function() {
+      $('.book-summary ul.summary li li').addClass('hidden');
+      // $('ul.summary li').find('li.active').parent().children().show();
+      $('.book-summary ul.summary li li.active').parents().children().removeClass('hidden');
+      $('.book-summary ul.summary li.active > ul > li').removeClass('hidden');
+    });
+  });
+});


### PR DESCRIPTION
Turns out the issue wasn't caused by GTM, but exposed by it. The collapsible menu plugin seems to have been adding styles to random things on the page, including header, script, and maybe more. The GTM script was more noticeable because it was at the top of the page and the others at the bottom of the page are hidden by the positioning of the content. The dev branches had the same code but defaulted to display: none, where production was defaulting to display: block. Not sure why, but I used add/remove class instead of show()/hide() and it seems to work as expected.