### PR TITLE
Clean up services and link to external docs

### DIFF
--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -69,3 +69,36 @@ For example, the current default storage amount per project is 5GB (meaning 5120
 ## Using the services
 
 In order for a service to be available to an application in your project (Platform.sh supports not only multiple backends but also multiple applications in each project) you will need to refer to it in the [.platform.app.yaml](/configuration/app-containers.md) file which configures the *relationships* between applications and services.
+
+## Connecting to a service
+
+Once a service is running and exposed as a relationship, its appropriate credentials (host name, username if appropriate, etc.) will be exposed through the `PLATFORM_RELATIONSHIPS` environment variable.  The structure of each is documented on the appropriate service's page, along with sample code for how to connect to it from your application. Note that different applications manage configuration differently so the exact code will vary from one application to another.
+
+To connect to a remote service from your local computer, the easiest way is to use the [Platform CLI](/overview/cli.md) to open an SSH tunnel.
+
+```bash
+platform tunnel:open
+```
+
+That will open an SSH tunnel to all services on the current environment, and give an output similar to:
+
+```bash
+SSH tunnel opened on port 30000 to relationship: redis
+SSH tunnel opened on port 30001 to relationship: database
+Logs are written to: /home/myuser/.platformsh/tunnels.log
+
+List tunnels with: platform tunnels
+View tunnel details with: platform tunnel:info
+Close tunnels with: platform tunnel:close
+```
+
+In this example, we can now securely connect to the database or redis server on our environment by connecting to the specified local ports.  The `platform tunnels` command will list all open tunnels:
+
+```text
++-------+---------------+-------------+-----------+--------------+
+| Port  | Project       | Environment | App       | Relationship |
++-------+---------------+-------------+-----------+--------------+
+| 30000 | a43m75zns6k4c | master      | [default] | redis        |
+| 30001 | a43m75zns6k4c | master      | [default] | database     |
++-------+---------------+-------------+-----------+--------------+
+```

--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -12,7 +12,7 @@ Elasticsearch is a distributed RESTful search engine built for the cloud.
 
 The format exposed in the `$PLATFORM_RELATIONSHIPS` [environment variable](/development/environment-variables.md):
 
-```bash
+```json
 {
     "elasticsearch": [
         {
@@ -54,3 +54,4 @@ if (isset($_ENV['PLATFORM_RELATIONSHIPS'])) {
   }
 }
 ```
+

--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -2,6 +2,8 @@
 
 Elasticsearch is a distributed RESTful search engine built for the cloud.
 
+See the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html) for more information.
+
 ## Supported versions
 
 * 0.90

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -1,7 +1,8 @@
 # MongoDB (Database service)
 
-MongoDB is a cross-platform document-oriented database. It's classified as a
-NoSQL database.
+MongoDB is a cross-platform document-oriented database.
+
+See the [MongoDB documentation](https://docs.mongodb.com/manual/) for more information.
 
 ## Supported versions
 

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -11,7 +11,7 @@ NoSQL database.
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
 
-```bash
+```json
 {
   "database": [
     {

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -50,7 +50,7 @@ You can then use the service in a configuration file of your application with so
 
 ```php
 <?php
-$relationships = getenv("PLATFORM_RELATIONSHIPS");
+$relationships = getenv('PLATFORM_RELATIONSHIPS');
 if (!$relationships) {
   return;
 }
@@ -61,7 +61,7 @@ foreach ($relationships['database'] as $endpoint) {
   if (empty($endpoint['query']['is_master'])) {
     continue;
   }
-  $container->setParameter('mongodb_server', $endpoint['scheme'] . '://' $endpoint['host'] . ':' $endpoint['port']);
+  $container->setParameter('mongodb_server', $endpoint['scheme'] . '://' . $endpoint['host'] . ':' . $endpoint['port']);
   $container->setParameter('database_name', $endpoint['path']);
   $container->setParameter('database_user', $endpoint['username']);
   $container->setParameter('database_password', $endpoint['password']);

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -1,7 +1,8 @@
 # MariaDB/MySQL (Database service)
 
-Transactional data storage. Based on MariaDB, supporting the XtraDB storage
-engine (equivalent to MySQL with InnoDB).
+MariaDB is a MySQL-compatible relational database system. Its XtraDB storage engine is equivalent to MySQL with InnoDB.
+
+See the [MariaDB documentation](https://mariadb.org/learn/) or [MySQL documentation](https://dev.mysql.com/doc/refman/5.5/en/) for more information.
 
 ## Supported versions
 

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -12,7 +12,7 @@ engine (equivalent to MySQL with InnoDB).
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
 
-```bash
+```json
 {
   "database": [
     {
@@ -83,7 +83,7 @@ foreach ($relationships['database'] as $endpoint) {
 Assuming your MariaDB relationship is named `database`, you can access it by connecting
 to a host named `database.internal` using the MySQL command line client.
 
-```
+```bash
 mysql -h database.internal -u user main
 ```
 

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -60,7 +60,7 @@ foreach ($relationships['database'] as $endpoint) {
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
 
-```bash
+```json
 {
     "database": [
         {
@@ -167,6 +167,7 @@ If your database is too large to duplicate within your plan size, we'd suggest t
 ### Example deploy hook
 
 Here's a sample deploy hook that you can use to implement the migration between versions:
+
 ```yaml
 hooks:
     deploy: |

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -7,6 +7,28 @@ Transactional data storage and the world's most advanced open source database.
 * 9.3
 * 9.6
 
+## Relationship
+
+The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
+
+```json
+{
+    "database": [
+        {
+            "username": "main",
+            "password": "main",
+            "host": "248.0.65.196",
+            "query": {
+                "is_master": true
+            },
+            "path": "main",
+            "scheme": "pgsql",
+            "port": 5432
+        }
+    ]
+}
+```
+
 ## Usage example
 
 In your `.platform/services.yaml` add:
@@ -55,28 +77,6 @@ foreach ($relationships['database'] as $endpoint) {
 ```
 
 (Or the equivalent for your application.)
-
-## Relationship
-
-The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
-
-```json
-{
-    "database": [
-        {
-            "username": "main",
-            "password": "main",
-            "host": "248.0.65.196",
-            "query": {
-                "is_master": true
-            },
-            "path": "main",
-            "scheme": "pgsql",
-            "port": 5432
-        }
-    ]
-}
-```
 
 ## PostgreSQL Extensions
 We have full support for running PostgreSQL Extensions on Platform.sh. In your `services.yaml` 

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -1,6 +1,8 @@
 # PostgreSQL (Database service)
 
-Transactional data storage and the world's most advanced open source database.
+PostgreSQL is a high-performance, standards-compliant relational SQL database.
+
+See the [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/static/index.html) for more information.
 
 ## Supported versions
 

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -76,8 +76,6 @@ foreach ($relationships['database'] as $endpoint) {
 }
 ```
 
-(Or the equivalent for your application.)
-
 ## PostgreSQL Extensions
 We have full support for running PostgreSQL Extensions on Platform.sh. In your `services.yaml` 
 file you can simply add a configuration subkey with the following structure:

--- a/src/configuration/services/rabbitmq.md
+++ b/src/configuration/services/rabbitmq.md
@@ -1,10 +1,8 @@
 # RabbitMQ (Message Queue service)
 
-A high throughput message queue, great for multi-app!
+RabbitMQ is an open source message broker software (sometimes called message-oriented middleware) that implements the Advanced Message Queuing Protocol (AMQP).
 
-RabbitMQ is an open source message broker software (sometimes called
-message-oriented middleware) that implements the Advanced Message Queuing
-Protocol (AMQP).
+See the [RabbitMQ documentation](http://www.rabbitmq.com/documentation.html) for more information.
 
 ## Supported versions
 

--- a/src/configuration/services/rabbitmq.md
+++ b/src/configuration/services/rabbitmq.md
@@ -14,7 +14,7 @@ Protocol (AMQP).
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
 
-```bash
+```json
 {
    "rabbitmq" : [
       {

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -18,7 +18,7 @@ cache area for your application.
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
 
-```bash
+```json
 {
     "redis": [
         {

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -1,7 +1,8 @@
 # Redis (Object cache)
 
-Provides the in-memory object cache for your application. Can be used as a
-cache area for your application.
+Redis is a high-performance in-memory object cache, well-suited for application level caching.
+
+See the [Redis documentation](https://redis.io/documentation) for more information.
 
 ## Supported versions
 
@@ -35,14 +36,7 @@ The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/de
 In your ``.platform/services.yaml``:
 
 ```yaml
-myredis:
-    type: redis:2.8
-```
-
-or something in the lines of:
-
-```yaml
-cache:
+rediscache:
     type: redis:3.0
 ```
 
@@ -54,7 +48,7 @@ runtime:
         - redis
 
 relationships:
-    redis: "myredis:redis"
+    redis: "rediscache:redis"
 ```
 
 You can then use the service in a configuration file of your application with something like:

--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -17,7 +17,7 @@ Support for custom schemas is available for Platform.sh Enterprise customers.
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/configuration/environment-variables.md):
 
-```bash
+```json
 {
     "solr": [
         {

--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -1,12 +1,10 @@
 # Solr (Search Service)
 
-Solr is highly reliable, scalable and fault tolerant, providing distributed
-indexing, replication and load-balanced querying, automated failover and
-recovery, centralized configuration and more.
+Apache Solr is a scalable and fault-tolerant search index.
 
-Solr search with generic schemas provided.
+Solr search with generic schemas provided, and a custom schema is also supported.
 
-Support for custom schemas is available for Platform.sh Enterprise customers.
+See the [Solr documentation](https://lucene.apache.org/solr/6_3_0/index.html) for more information.
 
 ## Supported versions
 


### PR DESCRIPTION
The main change here is that all services pages now link to the service's documentation.  I also did some other cleanup while I was at it, and added a section on how to connect to services via ssh tunnel.

I'd like to also include an example or three for the latter, but I'm not sure how to do so as a clean command given that the name/port for services is not guaranteed and cannot be extracted in a single command.  Suggestions welcome for that.