### PR TITLE
Tutorials

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -83,3 +83,7 @@
 * [Symfony](frameworks/symfony.md)
   * [Migrating](frameworks/symfony/migrating.md)
   * [FAQ](frameworks/symfony/faq.md)
+
+## Tutorials
+
+* [Exporting data](/tutorials/exporting.md)

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -71,7 +71,7 @@ foreach ($relationships['database'] as $endpoint) {
 
 ## Exporting data
 
-The most straightforward way to export data from a MongoDB database is to open an SSH tunnel to it and simply export the data directly using MongoDB's tools.  First, open an ssh tunnel with the Platform CLI:
+The most straightforward way to export data from a MongoDB database is to open an SSH tunnel to it and simply export the data directly using MongoDB's tools.  First, open an SSH tunnel with the Platform.sh CLI:
 
 ```bash
 platform tunnel:open

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -68,3 +68,24 @@ foreach ($relationships['database'] as $endpoint) {
   $container->setParameter('database_password', $endpoint['password']);
 }
 ```
+
+## Exporting data
+
+The most straightforward way to export data from a MongoDB database is to open an SSH tunnel to it and simply export the data directly using MongoDB's tools.  First, open an ssh tunnel with the Platform CLI:
+
+```bash
+platform tunnel:open
+```
+
+That will open an SSH tunnel to all services on your current environment, and produce output something like the following:
+
+```text
+SSH tunnel opened on port 30000 to relationship: mongodb
+SSH tunnel opened on port 30001 to relationship: redis
+```
+
+The port may vary in your case.  Then, simply connect to that port locally using `mongodump` (or your favorite MongoDB tools) to export all data in that server:
+
+```bash
+mongodbump --port 30000
+```

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -89,3 +89,23 @@ mysql -h database.internal -u user main
 ```
 
 Outside the application container, you can use Platform CLI `platform sql`.
+
+## Exporting data
+
+The easiest way to download all data in a MariaDB instance is with the Platform CLI.  If you have a single SQL database, the following command will export all data using the `mysqldump` command to a local file:
+
+```bash
+platform db:dump
+```
+
+If you have multiple SQL databases it will prompt you which one to export. You can also specify one by relationship name explicitly:
+
+```bash
+platform db:dump --relationship database
+```
+
+By default the file will be uncompressed.  If you want to compress it, direct the output to stdout and pipe it to gzip or bzip2 locally:
+
+```bash
+platform db:dump --relationship database --stdout | bzip2 > dump.bz2
+ ```

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -92,7 +92,7 @@ Outside the application container, you can use Platform CLI `platform sql`.
 
 ## Exporting data
 
-The easiest way to download all data in a MariaDB instance is with the Platform CLI.  If you have a single SQL database, the following command will export all data using the `mysqldump` command to a local file:
+The easiest way to download all data in a MariaDB instance is with the Platform.sh CLI.  If you have a single SQL database, the following command will export all data using the `mysqldump` command to a local file:
 
 ```bash
 platform db:dump

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -78,6 +78,27 @@ foreach ($relationships['database'] as $endpoint) {
 }
 ```
 
+## Exporting data
+
+The easiest way to download all data in a PostgreSQL instance is with the Platform CLI.  If you have a single SQL database, the following command will export all data using the `pg_dump` command to a local file:
+
+```bash
+platform db:dump
+```
+
+If you have multiple SQL databases it will prompt you which one to export. You can also specify one by relationship name explicitly:
+
+```bash
+platform db:dump --relationship database
+```
+
+By default the file will be uncompressed.  If you want to compress it, direct the output to stdout and pipe it to gzip or bzip2 locally:
+
+```bash
+platform db:dump --relationship database --stdout | bzip2 > dump.bz2
+ ```
+
+
 ## PostgreSQL Extensions
 We have full support for running PostgreSQL Extensions on Platform.sh. In your `services.yaml` 
 file you can simply add a configuration subkey with the following structure:

--- a/src/development/faq.md
+++ b/src/development/faq.md
@@ -4,9 +4,9 @@
 
 Platform or Platform.sh is the infrastructure which is running all your projects.
 
-A project is the site that you're working on. Each project can contain multiple applications and be deployed in environments.
+A project is the site that you're working on. Each project can contain multiple applications and be deployed in their own environments.
 
-An environment is a standalone copy of your live site (the Master environment) which can be used for testing, implementing new features...
+An environment is a standalone copy of your site, complete with code, data, and running services. The master branch is the production environment, while any other branch can be setup as an otherwise identical testing environment.
 
 ## How can I cancel my subscription?
 
@@ -34,22 +34,6 @@ Then, perform the Git push as follows:
 ```
 PLATFORMSH_PUSH_NO_WAIT=1 git push
 ```
-
-## How can I export my data?
-
-If you have file mounts, you can keep a copy of the files using `rsync` like below.
-
-```
-rsync -r [SSH-URL]:/app/private/ .
-```
-
-Data stored in database can be copied to you local file system via [Platform.sh CLI](https://docs.platform.sh/user_guide/overview/cli/index.html).
-
-```
-platform sql-dump
-```
-
-Regarding the data in Solr, if you have to make a copy, you have to use `platform tunnel` from [Platform.sh CLI](https://docs.platform.sh/user_guide/overview/cli/index.html) and then run [Solr replication](http://wiki.apache.org/solr/SolrReplication) moving your data to local box. Though, if the data are just the search index of your site, you can always rebuild that from scratch easily.
 
 ## Do you support MySQL?
 

--- a/src/development/faq.md
+++ b/src/development/faq.md
@@ -39,10 +39,6 @@ PLATFORMSH_PUSH_NO_WAIT=1 git push
 
 [Platform.sh](https://platform.sh) uses MariaDB to manage and store your databases. It's a fork of MySQL which is more stable and has more interesting features.
 
-## Do you support other database services?
-
-We support PostgreSQL, Elasticsearch, Redis and MongoDB Out of the box. Batteries included.No need for add-ons. We aim to support all the most popular database services...
-
 ## Does branching an environment duplicate services?
 
 Yes ! Branching an environment creates an exact copy (snapshot) of the parent environment, containing the files, the database, the services...

--- a/src/tutorials/exporting.md
+++ b/src/tutorials/exporting.md
@@ -18,20 +18,14 @@ mounts:
     '/private': 'shared:files/private'
 ```
 
-First, get the SSH URL of your application and environment:
+To use `rsync` to download each directory, we can use the following commands.  The `platform ssh --pipe` command will return the SSH URL for the current environment as an inline string that `rsync` can recognize. To use a non-default environment, use the `-e` switch after `--pipe`.  Note that the trailing slash on the remote path means `rsync` will copy just the files inside the specified directory, not the directory itself, .
 
 ```bash
-platform ???
+rsync -az `platform ssh --pipe`:/app/private/ ./private/
+rsync -az `platform ssh --pipe`:/app/web/uploads ./uploads/
 ```
 
-Then, use `rsync` to download each directory.  Note that the trailing slash on the remote path means `rsync` will copy just the files inside the specified directory, not the directory itself, .
-
-```bash
-rsync -az [SSH-URL]:/app/private/ ./private/
-rsync -az [SSH-URL]:/app/web/uploads ./uploads/
-```
-
-See the [`rsync` documentation]() for more details on how to adjust the download process.
+See the [`rsync` documentation](http://linuxcommand.org/man_pages/rsync1.html) for more details on how to adjust the download process.
 
 ## Download data from services
 

--- a/src/tutorials/exporting.md
+++ b/src/tutorials/exporting.md
@@ -18,7 +18,7 @@ mounts:
     '/private': 'shared:files/private'
 ```
 
-To use `rsync` to download each directory, we can use the following commands.  The `platform ssh --pipe` command will return the SSH URL for the current environment as an inline string that `rsync` can recognize. To use a non-default environment, use the `-e` switch after `--pipe`.  Note that the trailing slash on the remote path means `rsync` will copy just the files inside the specified directory, not the directory itself, .
+To use `rsync` to download each directory, we can use the following commands.  The `platform ssh --pipe` command will return the SSH URL for the current environment as an inline string that `rsync` can recognize. To use a non-default environment, use the `-e` switch after `--pipe`.  Note that the trailing slash on the remote path means `rsync` will copy just the files inside the specified directory, not the directory itself.
 
 ```bash
 rsync -az `platform ssh --pipe`:/app/private/ ./private/
@@ -29,6 +29,6 @@ See the [`rsync` documentation](http://linuxcommand.org/man_pages/rsync1.html) f
 
 ## Download data from services
 
-The mechanism for downloading from each service (such as your database) varies.  For services designed to hold non-persistent information (such as Redis or Solr) it's generally not necessary to download data as it can be rebuilt off of the primary data store.
+The mechanism for downloading from each service (such as your database) varies.  For services designed to hold non-persistent information (such as Redis or Solr) it's generally not necessary to download data as it can be rebuilt from the primary data store.
 
 To download data from persistent services ([MySQL](/configuration/services/mysql.md), [PostgreSQL](/configuration/services/postgresql.md), or [MongoDB](/configuration/services/mongodb.md)), see each service's page for instructions.

--- a/src/tutorials/exporting.md
+++ b/src/tutorials/exporting.md
@@ -1,6 +1,6 @@
 # Exporting data
 
-Platform.sh aims to be a great host, but we never want to lock you in to our service. Your code and your data belong to you, and you should always be able to download your entire site's dataset for local development, backup, or to "take your data elsewhere".
+Platform.sh aims to be a great host, but we never want to lock you in to our service. Your code and your data belong to you, and you should always be able to download your site's data for local development, backup, or to "take your data elsewhere".
 
 ## Downloading code
 

--- a/src/tutorials/exporting.md
+++ b/src/tutorials/exporting.md
@@ -1,0 +1,40 @@
+# Exporting data
+
+Platform.sh aims to be a great host, but we never want to lock you in to our service. Your code and your data belong to you, and you should always be able to download your entire site's dataset for local development, backup, or to "take your data elsewhere".
+
+## Downloading code
+
+Your application's code is maintained in Git.  Because Git is a distributed system it is trivial to download your entire code history with a simple `git clone` or `platform get` command.
+
+## Downloading files
+
+Your application runs on a read-only file system, so it cannot be edited.  That means there's nothing to download from most of it that isn't already in your Git repository.
+
+The only files to download are from any writeable file mounts you may have defined in your `.platform.app.yaml` file.  The easiest way to download those is using the `rsync` tool.  For instance, suppose you have a mounts section that defines one web-accessible directory and one non-web-accessible directory:
+
+```yaml
+mounts:
+    '/web/uploads': 'shared:files/uploads'
+    '/private': 'shared:files/private'
+```
+
+First, get the SSH URL of your application and environment:
+
+```bash
+platform ???
+```
+
+Then, use `rsync` to download each directory.  Note that the trailing slash on the remote path means `rsync` will copy just the files inside the specified directory, not the directory itself, .
+
+```bash
+rsync -az [SSH-URL]:/app/private/ ./private/
+rsync -az [SSH-URL]:/app/web/uploads ./uploads/
+```
+
+See the [`rsync` documentation]() for more details on how to adjust the download process.
+
+## Download data from services
+
+The mechanism for downloading from each service (such as your database) varies.  For services designed to hold non-persistent information (such as Redis or Solr) it's generally not necessary to download data as it can be rebuilt off of the primary data store.
+
+To download data from persistent services ([MySQL](/configuration/services/mysql.md), [PostgreSQL](/configuration/services/postgresql.md), or [MongoDB](/configuration/services/mongodb.md)), see each service's page for instructions.


### PR DESCRIPTION
Add a section for tutorials.  The first tutorial is on exporting data.  More will be added in time.

Question: Should we mention exporting via ssh tunnel on the main exporting tutorial page?

Question: Should Tutorials be listed before or after Featured Frameworks?  I figure Framework-specific tutorials should go with the Framework; this section is for framework agnostic tutorials.