### PR TITLE
Correct default variable behavior at build time

### DIFF
--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -12,7 +12,7 @@ See the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsea
 
 ## Relationship
 
-The format exposed in the `$PLATFORM_RELATIONSHIPS` [environment variable](/development/environment-variables.md):
+The format exposed in the `$PLATFORM_RELATIONSHIPS` [environment variable](/development/variables.md):
 
 ```json
 {

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -10,7 +10,7 @@ See the [MongoDB documentation](https://docs.mongodb.com/manual/) for more infor
 
 ## Relationship
 
-The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
+The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md):
 
 ```json
 {

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -11,7 +11,7 @@ See the [MariaDB documentation](https://mariadb.org/learn/) or [MySQL documentat
 
 ## Relationship
 
-The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
+The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md):
 
 ```json
 {

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -11,7 +11,7 @@ See the [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/static/in
 
 ## Relationship
 
-The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
+The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md):
 
 ```json
 {

--- a/src/configuration/services/rabbitmq.md
+++ b/src/configuration/services/rabbitmq.md
@@ -10,7 +10,7 @@ See the [RabbitMQ documentation](http://www.rabbitmq.com/documentation.html) for
 
 ## Relationship
 
-The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
+The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md):
 
 ```json
 {

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -17,7 +17,7 @@ See the [Redis documentation](https://redis.io/documentation) for more informati
 
 ## Relationship
 
-The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/environment-variables.md):
+The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md):
 
 ```json
 {

--- a/src/development/variables.md
+++ b/src/development/variables.md
@@ -104,18 +104,21 @@ $ platform variables
 
 ### At build time
 
-Only Project variables are available at build time.  They will be exposed as Unix environment variables, with their names forced to uppercase, which can be accessed either from the shell directly or as part of a script.  To access them inline as part of a build hook command prefix the variable with a `$` like so:
+Only Project variables are available at build time.  They will be listed together in a single JSON array and exposed in the `$PLATFORM_VARIABLES` Unix environment variable.
 
 ```bash
-echo $MY_VAR
+echo $PLATFORM_VARIABLES | base64 --decode
+{"my_var": "this is a value"}
 ```
 
-They can also be accessed from within a non-shell script via the language's standard way of accessing environment variables.  For instance, in PHP you would use `getenv('MY_VAR')`. Remember that in some cases they may be base64 JSON strings, and will need to be unpacked.  To do so from the shell, for instance, you would do: 
+They can also be accessed from within a non-shell script via the language's standard way of accessing environment variables.  For instance, in PHP you would use `getenv('PLATFORM_VARIABLES')`. Remember that in some cases they may be base64 JSON strings and will need to be unpacked.  To do so from the shell, for instance, you would do:
 
 ```bash
 echo $PLATFORM_VARIABLES | base64 --decode
 {"myvar": "this is a value"}
 ```
+
+See [below](#top-level-environment-variables) for how to expose a project variable as its own Unix environment variable.
 
 ### At runtime
 

--- a/src/languages/php.md
+++ b/src/languages/php.md
@@ -217,7 +217,7 @@ memory_limit = 256M
 date.timezone = "Europe/Paris"
 ```
 
-Environment-specific `php.ini` configuration directives can be provided via environment variables.  See the note in the [Environment variables](/development/environment-variables.md#php-specific-variables) section.
+Environment-specific `php.ini` configuration directives can be provided via environment variables.  See the note in the [Environment variables](/development/variables.md#php-specific-variables) section.
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
The PLATFORM_VARIABLES vs top-level behavior for project variables is the same as for environment variables. Say that.