### PR TITLE
Update submodule and trigger datalayer push on page change

### DIFF
--- a/src/scripts/user-widget.js
+++ b/src/scripts/user-widget.js
@@ -1,5 +1,20 @@
 $(document).ready(function () {
 
+  require(["gitbook"], function(gitbook) {
+    gitbook.events.bind("page.change", function(e) {
+      if (gitbook.state.config.pluginsConfig.gtm.virtualPageViews) {
+        var thisPath = window.location.pathname;
+        var str = thisPath.split("/");
+        var category = str[1].charAt(0).toUpperCase() + str[1].slice(1) || 'Home';
+        var dataLayer = window.dataLayer || [];
+        dataLayer.push({
+          'PageTitle': gitbook.state.page.title,
+          'PageCategory': category
+        });
+      }
+    });
+  });
+
   // Hard-code the values for the Documentation setup in particular.
   var sourcePath = '\'/scripts/user-widget/';
   var containerWrapper = '#platform-bar';


### PR DESCRIPTION
To test this without having access to the GTM account for the debugger, you can type 'dataLayer' in the console and see what is available. You'll be looking for PageTitle and PageCategory in particular. Then when you click another page, type 'dataLayer' again and check the last object in the array to see that the PageTitle and PageCategory values have changed.