### PR TITLE
Solr 6-related documentation

### DIFF
--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -158,4 +158,4 @@ solrsearch:
             core: collection1
 ```
 
-The Solr 6.x Drupal 8 configuration files are reasonably generic and should work in many other circumstance, but explicitly defining a core, configuration, and endpoint is generally recommended.
+The Solr 6.x Drupal 8 configuration files are reasonably generic and should work in many other circumstances, but explicitly defining a core, configuration, and endpoint is generally recommended.

--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -10,6 +10,7 @@ See the [Solr documentation](https://lucene.apache.org/solr/6_3_0/index.html) fo
 
 * 3.6
 * 4.10
+* 6.3
 
 ## Relationship
 
@@ -34,7 +35,7 @@ In your ``.platform/services.yaml``:
 
 ```yaml
 mysearch:
-    type: solr:4.10
+    type: solr:6.3
     disk: 1024
 ```
 
@@ -64,6 +65,10 @@ foreach ($relationships['solr'] as $endpoint) {
 
 ## Configuration
 
+## Solr 4
+
+For Solr 4, Platform.sh supports only a single core per server called `collection1`.
+
 If you want to provide your own Solr configuration, you can add a `core_config` key in your ``.platform/services.yaml``:
 
 ```yaml
@@ -74,7 +79,7 @@ mysearch:
         core_config: !archive "<directory>"
 ```
 
-The `directory` parameter points to a directory in the Git repository, in or below the `.platform/` folder. This directory needs to contain everything that Solr 4.10 needs to start a core. At the minimum, `solrconfig.xml` and `schema.xml`.  For example, place them in `.platform/solr/conf/` such that the `schema.xml` file is located at `.platform/solr/conf/schema.xml`.   You can then reference that path like this -
+The `directory` parameter points to a directory in the Git repository, in or below the `.platform/` folder. This directory needs to contain everything that Solr needs to start a core. At the minimum, `solrconfig.xml` and `schema.xml`.  For example, place them in `.platform/solr/conf/` such that the `schema.xml` file is located at `.platform/solr/conf/schema.xml`.   You can then reference that path like this -
 
 ```yaml
 mysearch:
@@ -83,3 +88,74 @@ mysearch:
     configuration:
         core_config: !archive "solr/conf"
 ```
+
+## Solr 6
+
+For Solr 6 and later Platform.sh supports multiple cores via different endpoints.  Cores and endpoints are defined separately, with endpoints referencing cores.  Each core may have its own configuration or share a configuration.  It is best illustrated with an example.
+
+```yaml
+solrsearch:
+    type: solr:6.3
+    disk: 1024
+    configuration:
+        cores:
+            mainindex: !archive "core1-conf"
+            extraindex: !archive "core2-conf"
+        endpoints:
+            main:
+              core: mainindex
+            extra:
+              core: extraindex
+```
+
+The above definition defines a single Solr 6.3 server.  That server has 2 cores defined: `maincore` &mdash; the configuration for which is in the `.platform/core1-conf` directory &mdash; and `extracore` &mdash; the configuration for which is in the `.platform/core2-conf` directory.
+
+It then defines two endpoints: `main` is connected to the `mainindex` core while `extra` is connected to the `extraindex` core.  Two endpoints may be connected to the same core but at this time there would be no reason to do so.  Additional options may be defined in the future.  
+
+Each endpoint is then available in the relationships definition in `.platform.app.yaml`.  For example, to allow an application to talk to both of the cores defined above its `.platform.app.yaml` file should contain the following:
+ 
+```yaml
+relationships:
+    solr1: 'solrsearch:main'
+    solr2: 'solrsearch:extra'
+```
+
+That is, the application's environment would include a `solr1` relationship that connects to the `main` endpoint, which is the `mainindex` core, and a `solr2` relationship that connects to the `extra` endpoint, which is the `extraindex` core.
+
+The relationships array would then look something like the following:
+
+```json
+{
+    "solr1": [
+        {
+            "path": "solr/mainindex",
+            "host": "248.0.65.197",
+            "scheme": "solr",
+            "port": 8080
+        }
+    ],
+    "solr2": [
+        {
+            "path": "solr/extraindex",
+            "host": "248.0.65.197",
+            "scheme": "solr",
+            "port": 8080
+        }
+    ]
+}
+```
+
+If no configuration is specified, the default configuration is equivalent to:
+
+```yaml
+solrsearch:
+  type: solr:6.3
+  configuration:
+    cores:
+      collection1: <default Drupal 8 configuration>
+    endpoints:
+        solr:
+            core: collection1
+```
+
+The Solr 6.x Drupal 8 configuration files are reasonably generic and should work in many other circumstance, but explicitly defining a core, configuration, and endpoint is generally recommended.

--- a/src/frameworks/drupal7/solr.md
+++ b/src/frameworks/drupal7/solr.md
@@ -2,29 +2,48 @@
 
 ## Requirements
 
-You will need to add the [Search
-API](https://www.drupal.org/project/search_api) and [Search API
-Solr](https://www.drupal.org/project/search_api_solr) modules to your
-project.
+You will need to add the [Search API](https://www.drupal.org/project/search_api) and [Search API
+Solr](https://www.drupal.org/project/search_api_solr) modules to your project. The [Search API Override](https://www.drupal.org/project/search_api_override) module is strongly recommended in order to allow the Solr configuration to be populated from `settings.php`.
 
 If you are using a make file, you can add those lines to your
 `project.make`:
 
 ```ini
-projects[search_api][version] = 1.13
-projects[search_api_solr][version] = 1.x-dev
+projects[entity][version] = 1.8
+projects[search_api][version] = 1.20
+projects[search_api_solr][version] = 1.11
+projects[search_api_override][version] = 1.0-rc1
 ```
 
 ## Configuration
 
-Go to `/admin/config/search/search_api` and click on *Add Server*. Give
-the server a name and a description.
+The Search API module includes recommended configuration files to use with Drupal.  See the [Solr](/configuration/services/solr.md) configuration page for details of how to configure your Solr server to use the Drupal configuration files.  Note that the module does not include Drupal configuration files for Solr 6.  The Drupal 8 version of the module does, however, and should work acceptably.  It can also be customized as desired.
 
--   Server class: *Solr service*
--   Solr host: `solr.internal`
--   Solr port: `8080`
--   Solr path: `/solr`
+The Search API Override module (listed above) allows Search API configuration to be overridden from `settings.php`.  Once it has been enabled, add the following to your `settings.platformsh.php` file:
 
-> **note**
-> The name of the host depends on the name you gave the relationship in `.platform.app.yaml`. If
-> you called the relationship `solrsearch` instead, then the hostname will be `solrsearch.internal`.
+```php
+if (isset($_ENV['PLATFORM_RELATIONSHIPS'])) {
+  $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
+
+  if (!empty($relationships['solr'])) {
+    // Override search API server settings fetched from default configuration.
+    $conf['search_api_override_mode'] = 'load';
+    foreach ($relationships['solr'] as $endpoint) {
+      $conf['search_api_override_servers'] = array(
+        'MACHINE_NAME_OF_SOLR_SERVER' => array(
+          'options' => array(
+            'host' => $endpoint['host'],
+            'port' => $endpoint['port'],
+            'path' => '/' . $endpoint['path'],
+            'http_method' => 'POST',
+          ),
+        ),
+      );
+    }
+  }
+}
+```
+
+Replace `MACHINE_NAME_OF_SOLR_SERVER` with the Drupal machine name of the server you want to override.  The solr server must already be defined in Drupal and ideally exported to a Feature.
+
+If you did not name the relationship `solr` in your `.platform.app.yaml` file, adjust the name accordingly above.  Also, if you have multiple Solr cores defined the above `foreach()` loop will not work.  Most likely you will want to name the relationships by the machine name of the Search API server they should map to and then map each one individually.

--- a/src/frameworks/drupal7/solr.md
+++ b/src/frameworks/drupal7/solr.md
@@ -17,7 +17,7 @@ projects[search_api_override][version] = 1.0-rc1
 
 ## Configuration
 
-The Search API module includes recommended configuration files to use with Drupal.  See the [Solr](/configuration/services/solr.md) configuration page for details of how to configure your Solr server to use the Drupal configuration files.  Note that the module does not include Drupal configuration files for Solr 6.  The Drupal 8 version of the module does, however, and should work acceptably.  It can also be customized as desired.
+The Search API module includes recommended configuration files to use with Drupal.  See the [Solr](/configuration/services/solr.md) configuration page for details of how to configure your Solr server to use the Drupal configuration files.  Note that the Drupal 7 version of Search API Solr does not include configuration files for Solr 6.  The Drupal 8 version of the module does, however, and should work acceptably.  It can also be customized as desired.
 
 The Search API Override module (listed above) allows Search API configuration to be overridden from `settings.php`.  Once it has been enabled, add the following to your `settings.platformsh.php` file:
 

--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -25,3 +25,6 @@ the server a name and a description.
 > **note**
 > The name of the host depends on the name you gave the relationship in `.platform.app.yaml`. If
 > you called the relationship `solrsearch` instead, then the hostname will be `solrsearch.internal`.
+
+> **note**
+> At this time, bugs in Drupal 8 prevent the Solr configuration from being managed from `settings.platformsh.php`.  See [these](https://www.drupal.org/node/2682369) [issues](https://www.drupal.org/node/2744057) for more information.


### PR DESCRIPTION
I've tested the Drupal 7 documentation using Solr 6.  The Drupal 8 note is based on my earlier attempts to make Solr anything work on Drupal 8, which are blocked by core bugs.  I'm a little uncertain of the phrasing there, as I don't want to make it sound dismissive but, well, it's a bug upstream and not something we can fix on our end.  Suggestions welcome there.