### PR TITLE
Add reference to machine name

### DIFF
--- a/src/development/going-live.md
+++ b/src/development/going-live.md
@@ -95,7 +95,9 @@ Configure your DNS provider to point your domain to your
 
 Once you've checked with your registrar about where to change your DNS
 settings, add a CNAME record that references the Master environment's
-hostname: `<environment>-<project>.<region>.platform.sh`
+hostname: `<environment>-<project>.<region>.platform.sh` in which
+`<environment>` is the **machine name** of the environment. The best way
+to find the machine name is to use `platform environment:info`.
 
 If you use multiple hostnames for your site, you need to add a CNAME
 record for each of them. For example:


### PR DESCRIPTION
In the CNAME record the machine name of the environments needs to be used. This was not clear to me first as the example has 'master' as the environment name were my actual projects have machine names like 'master-7rqtwti'. First I left out the '-7rqtwti' part.