### PR TITLE
Clean up Robots.txt documentation

### DIFF
--- a/src/administration/web/configure-environment.md
+++ b/src/administration/web/configure-environment.md
@@ -85,6 +85,6 @@ Or to disable it for a specific environment other than the one that is currently
 platform environment:info -e ENVNAME restrict_robots false
 ```
 
-(Where `ENVNAME` is the name of the environment, which is generally the branch associated with it.)  Note that you will need to trigger a new deployment after changing this setting.
+where `ENVNAME` is the name of the environment.
 
 On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`](/configuration/app-container.md#locations).

--- a/src/administration/web/configure-environment.md
+++ b/src/administration/web/configure-environment.md
@@ -66,22 +66,25 @@ project configuration screen.
 
 ## Robots.txt
 
-By default, Platform.sh returns a restrictive `robots.txt` on all environments. If you need to provide a custom `robots.txt`, first disable the default one using the [Platform.sh CLI](/overview/cli.md) command below:
+By default, Platform.sh serves the following default and restrictive `robots.txt` on all non-production environments:
+
+```
+User-agent: *
+Disallow: /
+```
+
+That tells search engines to ignore pre-production sites entirely, even if they are publicly visible.  To disable that feature for pre-production sites use the [Platform.sh CLI](/overview/cli.md) command below:
 
 ```
 platform environment:info restrict_robots false
 ```
 
-Or to disable it for a specific environment rather than production, execute the following:
+Or to disable it for a specific environment other than the one that is currently checked out, execute the following:
 
 ```
 platform environment:info -e ENVNAME restrict_robots false
 ```
 
-(Where `ENVNAME` is the name of the environment, which is generally the branch associated with it.)
+(Where `ENVNAME` is the name of the environment, which is generally the branch associated with it.)  Note that you will need to trigger a new deployment after changing this setting.
 
-Then you have to serve your `robots.txt` by configuring ["/" location in `.platform.app.yaml`](/configuration/app-container.md#locations).
-
-> **note**
-> A deployment is required after running the CLI command to make the changes effective.
-
+On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`](/configuration/app-container.md#locations).

--- a/src/administration/web/configure-environment.md
+++ b/src/administration/web/configure-environment.md
@@ -73,7 +73,7 @@ User-agent: *
 Disallow: /
 ```
 
-That tells search engines to ignore pre-production sites entirely, even if they are publicly visible.  To disable that feature for pre-production sites use the [Platform.sh CLI](/overview/cli.md) command below:
+That tells search engines to ignore sites on non-production environments entirely, even if they are publicly visible.  To disable that feature for a non-production environment, use the [Platform.sh CLI](/overview/cli.md) command below:
 
 ```
 platform environment:info restrict_robots false

--- a/src/frameworks/drupal7/faq.md
+++ b/src/frameworks/drupal7/faq.md
@@ -19,9 +19,9 @@ deployment hooks to automatically run the updates.
 
 ## How can I override the default robots.txt?
 
-Platform.sh allows the use of a custom `robots.txt` file on production. For pre-production environments we provide a [default that blocks all search engines](/administration/web/configure-environment.html#robotstxt) (to keep pre-production sites out of search indexes).
+Platform.sh supports custom `robots.txt` by default in production. For pre-production environments we provide a [default that blocks all search engines](/administration/web/configure-environment.html#robotstxt) (to keep pre-production sites out of search indexes).
 
-If using the `drupal` build mode with a Drush make file, place your `robots.txt` file in your project root, as a sibling of `.platform.app.yaml`.  It will get moved to the appropriate location automatically by the build process.  For all other cases just include the file in your web root normally.
+If using the `drupal` build mode with a Drush make file, place your `robots.txt` file in your application root, as a sibling of `.platform.app.yaml`.  It will get moved to the appropriate location automatically by the build process.  For all other cases just include the file in your web root normally.
 
 ## I'm getting a PDO Exception 'MySQL server has gone away'
 

--- a/src/frameworks/drupal7/faq.md
+++ b/src/frameworks/drupal7/faq.md
@@ -19,22 +19,9 @@ deployment hooks to automatically run the updates.
 
 ## How can I override the default robots.txt?
 
-If your project is using a make file, you will end up with the default
-`robots.txt` provided by Drupal.
+Platform.sh allows the use of a custom `robots.txt` file on production. For pre-production environments we provide a [default that blocks all search engines](/administration/web/configure-environment.html#robotstxt) (to keep pre-production sites out of search indexes).
 
-On your Development environments, Platform.sh automatically overrides
-your `robots.txt` file with:
-
-```bash
-User-agent: *
-Disallow: /
-```
-
-You can customize the `robots.txt` by placing your own version at the
-root of your repository.
-
-To override the behavior of robots.txt for Development environments you would
-currently need to use the API, contact our support for details.
+If using the `drupal` build mode with a Drush make file, place your `robots.txt` file in your project root, as a sibling of `.platform.app.yaml`.  It will get moved to the appropriate location automatically by the build process.  For all other cases just include the file in your web root normally.
 
 ## I'm getting a PDO Exception 'MySQL server has gone away'
 

--- a/src/frameworks/drupal8/faq.md
+++ b/src/frameworks/drupal8/faq.md
@@ -13,25 +13,6 @@ That will automatically run `update.php` and import configuration on every new d
 
 The above configuration is included by default if you used our Drupal 8 example repository or created a project through the UI.
 
-## How can I override the default robots.txt?
-
-If your project is using a make file, you will end up with the default
-`robots.txt` provided by Drupal.
-
-On your Development environments, Platform.sh automatically overrides
-your `robots.txt` file with:
-
-```bash
-User-agent: *
-Disallow: /
-```
-
-You can customize the `robots.txt` by placing your own version at the
-root of your repository.
-
-To override the behavior of robots.txt for Development environments you would
-currently need to use the API, contact our support for details.
-
 ## I'm getting a PDO Exception 'MySQL server has gone away'
 
 Normally, this means there is a problem with the MySQL server container


### PR DESCRIPTION
Our current documentation for robots.txt is wrong and misleading and assumes Drupal 7.  Let's fix all 3 of those.