### PR TITLE
Opt-out redis integration during installation

### DIFF
--- a/src/frameworks/drupal8/redis.md
+++ b/src/frameworks/drupal8/redis.md
@@ -70,7 +70,7 @@ The example below is intended as a "most common case".  (Note: This example assu
 if (!empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
   $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
 
-  if (!empty($relationships['redis'][0]) && !drupal_installation_attempted() && extension_loaded('redis') ) {
+  if (!empty($relationships['redis'][0]) && !drupal_installation_attempted() && extension_loaded('redis')) {
     $redis = $relationships['redis'][0];
 
     // Set Redis as the default backend for any cache bin not otherwise specified.

--- a/src/frameworks/drupal8/redis.md
+++ b/src/frameworks/drupal8/redis.md
@@ -67,10 +67,10 @@ The example below is intended as a "most common case".  (Note: This example assu
 
 ```php
 // Set redis configuration.
-if (!empty($_ENV['PLATFORM_RELATIONSHIPS']) && extension_loaded('redis')) {
+if (!empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
   $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
 
-  if (!empty($relationships['redis'][0])) {
+  if (!empty($relationships['redis'][0]) && !drupal_installation_attempted() && extension_loaded('redis') ) {
     $redis = $relationships['redis'][0];
 
     // Set Redis as the default backend for any cache bin not otherwise specified.


### PR DESCRIPTION
Per changes here, recommended by Berdir: https://github.com/md-systems/platformsh-example-thunder/pull/1/files/6189b0cd5e88cf772c1aa5f20e7835d2f7f07c40..60d6d1f04771145457a44699d07872e057d61e09

This lets the Redis code work correctly during install, in case someone wants to start with Redis from the get-go.  (Which we probably do want anyway.)