### PR TITLE
Correct description of who can enable integrations

### DIFF
--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -35,7 +35,7 @@ Note that for the integration to work, your GitHub user needs to have permission
 
 ### 2. Enable the integration
 
-Note that only `project owner` or `project admin` can manage the integrations.
+Note that only `project owner` can manage the integrations.
 
 Open a terminal window (you need to have the Platform.sh CLI installed). Enable the GitHub integration as follows:
 


### PR DESCRIPTION
Because admins can't, only owners.