### PR TITLE
Mention PLATFORM_RELATIONSHIPS and port in sample usage

### DIFF
--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -146,11 +146,10 @@ configuration:
 
 ## Access your MariaDB service
 
-Assuming your MariaDB relationship is named `database`, you can access it by connecting
-to a host named `database.internal` using the MySQL command line client.
+Assuming your MariaDB relationship is named `database`, the host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `database.internal` and `3306`. Open an [SSH session](/development/ssh.md) and run the MySQL command line client.
 
 ```bash
-mysql -h database.internal -u user main
+mysql -h database.internal -P 3306 -u user main
 ```
 
 Outside the application container, you can use Platform CLI `platform sql`.

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -93,9 +93,8 @@ if (getenv('PLATFORM_RELATIONSHIPS')) {
 
 ## Using redis-cli to access your Redis service
 
-Assuming your Redis relationship is named `rediscache`, you can access it by
-connecting to a host named `rediscache.internal` using the redis-cli tool. Open an [SSH session](/development/ssh.md) and access the Redis server as follows:
+Assuming your Redis relationship is named `rediscache`, the host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `rediscache.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
 
 ```bash
-redis-cli -h rediscache.internal
+redis-cli -h rediscache.internal -p 6379
 ```


### PR DESCRIPTION
User should always refer to PLATFORM_RELATIONSHIPS for hostname and port
number of a service. Our sample usage should not skip them.