### PR TITLE
Update vanilla drupal description

### DIFF
--- a/src/frameworks/drupal7.md
+++ b/src/frameworks/drupal7.md
@@ -88,19 +88,24 @@ translations/
 
 ### Vanilla mode
 
-Platform.sh accepts your project's files. You are expected to have an
-`index.php` file at the root of your repository.
+In Vanilla mode, Platform.sh just takes your repository as-is without any additional reorganization.  This is the behavior when there is no `.make` or `.profile` file, or when the build mode is set to `none` or `composer` rather than to `drupal`.
+
+It's best to keep your docroot separate from your repository root, as that allows you to store private files outside of the docroot when needed.  For example, your repository layout will likely resemble the following:
 
 ```
 .git/
-index.php
-... (other Drupal core files)
-sites/
-  all/
-    modules/
-    themes/
-  default/
+private/
+web/
+  index.php
+  ... (other Drupal core files)
+  sites/
+    all/
+      modules/
+      themes/
+    default/
 ```
+
+If you already have a Drupal 7 site built from a `tar.gz` download from Drupal.org, this is likely the best path forward.
 
 ## Configuring Platform.sh for Drupal
 

--- a/src/frameworks/drupal7.md
+++ b/src/frameworks/drupal7.md
@@ -2,30 +2,19 @@
 
 ## Structure your files
 
-Platform.sh is very flexible and allows you to structure your files as
-you wish within your Git repository, and will build your project based
-on how your files are organized.
+Platform.sh is very flexible and allows you to structure your files as you wish within your Git repository, and will build your project based on how your files are organized.
 
 Here are the three build modes that can be used:
 
--   **Profile**: Platform.sh builds your project like Drupal.org does
-    for distributions.
--   **Project**: Platform.sh builds your make file using *drush make*.
-    You don't need any Drupal core files nor any contributed modules,
-    themes or libraries within your Git repository.
--   **Vanilla**: Platform.sh builds your project as it is in your Git
-    repository. You can push all Drupal files and contributed modules,
-    themes or libraries.
+-   **Profile**: Platform.sh builds your project like Drupal.org does for distributions.
+-   **Project**: Platform.sh builds your make file using *drush make*. You don't need any Drupal core files nor any contributed modules, themes or libraries within your Git repository.
+-   **Vanilla**: Platform.sh builds your project as it is in your Git repository. You can push all Drupal files and contributed modules, themes or libraries.
 
 ### Profile mode
 
-If your repository contains a `.profile` file, Platform.sh builds your
-project in profile mode. This is similar to what Drupal.org does to
-build distributions. Everything you have in your repository will be
-copied to your `profiles/[name]` folder.
+If your repository contains a `.profile` file, Platform.sh builds your project in profile mode. This is similar to what Drupal.org does to build distributions. Everything you have in your repository will be copied to your `profiles/[name]` folder.
 
-This build mode supports having a `project.make` file for your
-contributed modules, themes or libraries.
+This build mode supports having a `project.make` file for your contributed modules, themes or libraries.
 
 > **note**
 > When building as a profile, you **need a make file for Drupal core** called: `project-core.make`. See
@@ -59,10 +48,7 @@ translations/
 
 ### Project mode
 
-If your repository doesn’t contain a `.profile` file, but contains a
-make file called: `project.make` (or even `drupal-org.make`),
-Platform.sh builds your project using Drush make. Everything you have in
-your repository will be copied to your `sites/default` folder.
+If your repository doesn’t contain a `.profile` file, but contains a make file called: `project.make` (or even `drupal-org.make`), Platform.sh builds your project using Drush make. Everything you have in your repository will be copied to your `sites/default` folder.
 
 ```
 .git/


### PR DESCRIPTION
Per conversation with @acervulus, we shouldn't be recommending putting the docroot in the git root, ever.

I also did some whitespace cleanup in the same file while I was there, but made it a separate commit.