### PR TITLE
Revamp the Authenticated Composer repositories tutorial

### DIFF
--- a/src/tutorials/composer-auth.md
+++ b/src/tutorials/composer-auth.md
@@ -1,10 +1,14 @@
 # Authenticated Composer repositories
 
-Some PHP projects may need to leverage a private, third party Composer repository in addition to the public Packagist.org repository.  Often, such third party repositories require authentication in order to download packages, and not everyone is comfortable putting those credentials into their Git repository source code (for obvious reasons).  To handle that situation, you can use [project variables](/development/variables.md#project-variables).
+Some PHP projects may need to leverage a private, third party Composer repository in addition to the public Packagist.org repository.  Often, such third party repositories require authentication in order to download packages, and not everyone is comfortable putting those credentials into their Git repository source code (for obvious reasons). 
+
+To handle that situation, you can define a `env:COMPOSER_AUTH` [project variable](/development/variables.md#project-variables) which allows you to set up authentication as an environment variable. The contents of the variable should be a JSON formatted object containing an `http-basic` object (see [composer-auth specifications](https://getcomposer.org/doc/03-cli.md#composer-auth)).
+
+The advantage is that you can control who in your team has access to those variables.
 
 ## Specify a third party repository in `composer.json`
 
-For this example, consider that there are several packages we want to install from a private repository hosted at `my-private-repos.example.com`.  List that repository in `composer.json`. 
+For this example, consider that there are several packages we want to install from a private repository hosted at `my-private-repos.example.com`.  List that repository in your `composer.json` file. 
 
 ```json
 {
@@ -17,43 +21,28 @@ For this example, consider that there are several packages we want to install fr
 }
 ```
 
-## Set project variable credentials
+## Set the env:COMPOSER_AUTH project variable
 
-Now set the composer authentication key and password as project variables. That can be done through the UI or via the command line, like so:
+Set the Composer authentication by adding a project level variable called `env:COMPOSER_AUTH` as JSON and availabe only during build time. 
+
+That can be done through the web UI or via the command line, like so:
 
 ```bash
-platform project:variable:set env:composer_key abc123 --no-visible-runtime
-platform project:variable:set env:composer_password abc123 --no-visible-runtime
+platform project:variable:set env:COMPOSER_AUTH '{"http-basic": {"my-private-repos.example.com": {"username": "your-username", "password": "your-password"}}}' --json --no-visible-runtime
 ```
 
-The `env:` prefix will make those variables appear as their own Unix environment variables, which makes the next step easier.  The optional `--no-visible-runtime` flag means the variable will only be defined during the build hook, which offers slightly better security.
+The `env:` prefix will make that variable appear as its own Unix environment variable available by Composer during the build process. The optional `--no-visible-runtime` flag means the variable will only be defined during the build hook, which offers slightly better security.
 
-The variable names used here are arbitrary, as long as they match what's in the build hook below.
+## Build your application with Composer
 
-## Use a custom Composer command
-
-You'll need to run your own custom Composer command, so first disable the default composer build mode.  Add or modify the following in `.platform.app.yaml`:
+You simply need to enable the default Composer build mode in your `.platform.app.yaml`:
 
 ```yaml
 build:
-    flavor: "none"
+    flavor: "composer"
 ```
 
-Then in your build hook set the authentication information for the remote server, using the environment variables defined above.  Then run `composer install` as normal.
-
-
-```yaml
-hooks:
-    build: |
-        set -e
-        composer config http-basic.my-private-repos.example.com $COMPOSER_KEY $COMPOSER_PASSWORD
-        composer install --no-dev --prefer-dist --no-progress --no-interaction --optimize-autoloader
-  ```
-
-The specific switches in the `composer install` line are what Platform.sh would run by default, but you can customize that as needed.  They important part is the `composer config` line, which tells composer to use the key and password from the environment when connecting to `my-private-repos.example.com`, and to do so using `http-auth`.  (See the [Composer documentation](https://getcomposer.org/doc/06-config.md#http-basic) for other possible authentication options.)
-
-From here on, everything should proceed as normal.  Composer will download all listed packages from whatever repositories are appropriate, authenticating against them as needed, build the application, and then it will deploy as normal.  Because the variables are defined above to not be visible at runtime they will not appear at all in the running application.
-
+In that case, Composer will be able to authenticate and download dependencies from your authenticated repository.
 
 ## Private repository hosting
 


### PR DESCRIPTION
We have a much cleaner way to use authenticated Composer repositories which I documented here.

In addition I propose that we add a dedicated section on how to use a custom Composer command to bypass the default Composer build mode).