### PR TITLE
Unclear multi-app plans.

### DIFF
--- a/src/configuration/app/multi-app.md
+++ b/src/configuration/app/multi-app.md
@@ -1,6 +1,6 @@
 # Multiple Applications
 
-Platform.sh supports building multiple applications per project (for example RESTful web services with a front-end, or a main website and a blog).  For resource allocation reasons, however, that is only supported on Medium and larger plans.
+Platform.sh supports building multiple applications per project (for example RESTful web services with a front-end, or a main website and a blog).  For resource allocation reasons, however, that is not supported on Standard plan.
 
 ## Introduction
 


### PR DESCRIPTION
The development plan allows up to 10 services at the lowest container size, so multi-app works in them. In practice, only the standard plan can't use multi-app.