### PR TITLE
Adjust 'sendmail' to 'mail' in Symfony email example

### DIFF
--- a/src/administration/web/email.md
+++ b/src/administration/web/email.md
@@ -27,7 +27,7 @@ In Symfony, if you use the default `SwiftMailer` service, we recommend the follo
 
 ```yaml
 parameters:
-  mailer_transport: sendmail
+  mailer_transport: mail
   mailer_host: null
   mailer_user: null
   mailer_password: null


### PR DESCRIPTION
I didn't get it working with 'sendmail', but 'mail' does the trick. I think it cannot find the path to sendmail (`which sendmail` returns nothing).