### PR TITLE
Clean up and document the .platform.app.yaml file to serve as an example

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -4,21 +4,48 @@
 # The name of this app. Must be unique within a project.
 name: app
 
-# The toolstack used to build the application.
+# There is no no-runtime container, so any container would do here.
 type: php:7.0
+# Because there is no composer.json file we deactivate the build flavor.
 build:
     flavor: none
 
-# The configuration of app when it is exposed to the web.
+# The documentation is built using GitBook. Install the latest version
+# of it globally.
+dependencies:
+  nodejs:
+    gitbook-cli: "*"
+
+# Use a build hook to install the GitBook plugins specified by the book.json file,
+# then build the book. The generated files will be placed in the _book directory
+# by default.
+hooks:
+    build: |
+      gitbook install
+      gitbook build
+      # Gitbook doesn't allow for a custom favicon except through a theme plugin. So Plan B.
+      cp src/images/favicon.ico _book/gitbook/images/favicon.ico
+
+# There is no need for a writeable file mount, so set it to the smallest possible size.
+disk: 256
+
+# Configure the web server to serve our static site.
 web:
     locations:
         "/":
+            # The generated static site lives in _book, so make that the docroot.
             root: "_book"
             index:
                 - "index.html"
+            # Set a 5 minute cache lifetime on all static files.
             expires: 300s
-            scripts: true
+            # Disable all scripts, since we don't have any anyway.
+            scripts: false
+            # By default do not allow any files to be served.
             allow: false
+            # Whitelist common image file formats, plus HTML files, robots.txt, and
+            # The search_index.json file that is used by GitBook's search plugin.
+            # All other requests will be rejected.
             rules:
                 \.(css|js|gif|jpe?g|png|ttf|eot|woff2?|otf|html|ico|svg?)$:
                     allow: true
@@ -26,18 +53,3 @@ web:
                     allow: true
                 search_index\.json$:
                     allow: true
-# The size of the persistent disk of the application (in MB).
-disk: 2048
-
-# Build time dependencies.
-dependencies:
-  nodejs:
-    gitbook-cli: "*"
-
-# The hooks that will be performed when the package is deployed.
-hooks:
-    build: |
-      gitbook install
-      gitbook build
-      # Gitbook doesn't allow for a custom favicon except through a theme plugin. So Plan B.
-      cp src/images/favicon.ico _book/gitbook/images/favicon.ico

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -30,7 +30,7 @@ disk: 256
 web:
     commands:
         # Run a no-op process that uses no CPU resources, since this is a static site.
-        start: sleep 60
+        start: sleep infinity
     locations:
         "/":
             # The generated static site lives in _book, so make that the docroot.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -28,8 +28,6 @@ disk: 256
 
 # Configure the web server to serve our static site.
 web:
-    commands:
-        start: null
     locations:
         "/":
             # The generated static site lives in _book, so make that the docroot.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,6 +1,3 @@
-# This file describes an application. You can have multiple applications
-# in the same project.
-
 # The name of this app. Must be unique within a project.
 name: app
 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -28,6 +28,8 @@ disk: 256
 
 # Configure the web server to serve our static site.
 web:
+    commands:
+        start: sleep 365d
     locations:
         "/":
             # The generated static site lives in _book, so make that the docroot.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -31,6 +31,8 @@ disk: 256
 
 # Configure the web server to serve our static site.
 web:
+    commands:
+        start: null
     locations:
         "/":
             # The generated static site lives in _book, so make that the docroot.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -29,7 +29,8 @@ disk: 256
 # Configure the web server to serve our static site.
 web:
     commands:
-        start: sleep 365d
+        # Run a no-op process that uses no CPU resources, since this is a static site.
+        start: sleep 60
     locations:
         "/":
             # The generated static site lives in _book, so make that the docroot.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -37,6 +37,8 @@ web:
         "/":
             # The generated static site lives in _book, so make that the docroot.
             root: "_book"
+            # Set an index file of "index.html" for any directory. We could also
+            # list multiple fallbacks here if desired.
             index:
                 - "index.html"
             # Set a 5 minute cache lifetime on all static files.


### PR DESCRIPTION
This shouldn't have any functional change, but makes the documentation's build script something we can reference from the documentation as an example of managing a static site, for extra recursion.