### PR TITLE
Add optional arguments to drush core-cron call

### DIFF
--- a/src/configuration/app/cron.md
+++ b/src/configuration/app/cron.md
@@ -23,7 +23,7 @@ crons:
     # Run Drupal's cron tasks every 20 minutes.
     drupal:
         spec: '*/20 * * * *'
-        cmd: 'cd web ; drush core-cron'
+        cmd: 'cd web ; drush core-cron --uri=your.drupalsite.org --root=/web'
     # But also run pending queue tasks every 5 minutes.
     drush-queue:
         spec: '*/5 * * * *'


### PR DESCRIPTION
Added the optional arguments to drush core-cron - these arguments are optional and not necessary in all cases, but it was for me and it would have helped me if it were in this documentation. Hopefully it helps someone else!