### PR TITLE
Add note for when to tweak sizing hints

### DIFF
--- a/src/development/troubleshoot.md
+++ b/src/development/troubleshoot.md
@@ -22,7 +22,6 @@ Otherwise, you may check if the following options are applicable:
 
 * Find the most visited pages and see if they can be cached and/or put behind a CDN.  You may refer to [how caching works](/configuration/routes/cache.md).
 * Upgrade your subscription on Platform.sh to get more computing resources.  To do so, log into your [account](https://accounts.platform.sh) and edit the project.
-* Provide [sizing hints](/languages/php.md#php-worker-sizing-hints) to PHP FPM workers.
 
 
 ## MySQL lock wait timeout

--- a/src/languages/php.md
+++ b/src/languages/php.md
@@ -165,7 +165,7 @@ While you can call it manually that is generally not necessary.  Note that PHP-F
 
 ## PHP Worker sizing hints
 
-Platform.sh uses a heuristic to automatically set the number of workers of a PHP runtime based on the memory available in the container. This heuristic is based on assumptions about the memory necessary on average to process a request. You can tweak those assumptions if your application will typically use considerably more or less memory.  In most cases, however, you should not need to change them.
+Platform.sh uses a heuristic to automatically set the number of workers of a PHP runtime based on the memory available in the container. This heuristic is based on assumptions about the memory necessary on average to process a request. You can tweak those assumptions if your application will typically use considerably more memory.  In most cases, however, you should not need to change them unless your application container is swapping a lot.
 
 ### The heuristic
 


### PR DESCRIPTION
The original intent for adjusting PHP worker sizing is to prevent the
application container from swapping. Even though the customer can get
more PHP workers if the application needs few memory, they are not going
to get more juice out of it since we also have CPU limit. Also, a slow
application will not be benefited from having more workers. There is very
little point in trying to increase the number of FPM workers.