### PR TITLE
Timezone and sizing

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -29,6 +29,7 @@
   * [Name](configuration/app/name.md)
   * [Type](configuration/app/type.md)
   * [Size](configuration/app/size.md)
+  * [Timezone](configuration/app/timezone.md)
   * [Relationships](configuration/app/relationships.md)
   * [Access](configuration/app/access.md)
   * [Storage](configuration/app/storage.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,6 +28,7 @@
 * [Apps (.platform.app.yaml)](configuration/app-containers.md)
   * [Name](configuration/app/name.md)
   * [Type](configuration/app/type.md)
+  * [Size](configuration/app/size.md)
   * [Relationships](configuration/app/relationships.md)
   * [Access](configuration/app/access.md)
   * [Storage](configuration/app/storage.md)

--- a/src/configuration/app-containers.md
+++ b/src/configuration/app-containers.md
@@ -15,6 +15,7 @@ The basic properties are described on their own pages.
 * [`name`](/configuration/app/name.md) *(required)* - Sets the unique name of the application container.
 * [`type`](/configuration/app/type.md) *(required)* - Sets the container base image to use, including application language.
 * [`size`](/configuration/app/size.md) - Sets an explicit sizing hint for the application.
+* [`timezone`](/configuration/app/timezone.md) - Sets the timezone of the application container.
 * [`relationships`](/configuration/app/relationships.md) - Defines connections to other services and applications.
 * [`access`](/configuration/app/access.md) - Restricts SSH access with more granularity than the UI.
 * [`disk` and `mount`](/configuration/app/storage.md) *(required)* - Defines writeable file directories for the application.

--- a/src/configuration/app-containers.md
+++ b/src/configuration/app-containers.md
@@ -15,7 +15,7 @@ The basic properties are described on their own pages.
 * [`name`](/configuration/app/name.md) *(required)* - Sets the unique name of the application container.
 * [`type`](/configuration/app/type.md) *(required)* - Sets the container base image to use, including application language.
 * [`size`](/configuration/app/size.md) - Sets an explicit sizing hint for the application.
-* [`timezone`](/configuration/app/timezone.md) - Sets the timezone of the application container.
+* [`timezone`](/configuration/app/timezone.md) - Sets the timezone of cron tasks in application container.
 * [`relationships`](/configuration/app/relationships.md) - Defines connections to other services and applications.
 * [`access`](/configuration/app/access.md) - Restricts SSH access with more granularity than the UI.
 * [`disk` and `mount`](/configuration/app/storage.md) *(required)* - Defines writeable file directories for the application.

--- a/src/configuration/app-containers.md
+++ b/src/configuration/app-containers.md
@@ -14,6 +14,7 @@ The basic properties are described on their own pages.
 
 * [`name`](/configuration/app/name.md) *(required)* - Sets the unique name of the application container.
 * [`type`](/configuration/app/type.md) *(required)* - Sets the container base image to use, including application language.
+* [`size`](/configuration/app/size.md) - Sets an explicit sizing hint for the application.
 * [`relationships`](/configuration/app/relationships.md) - Defines connections to other services and applications.
 * [`access`](/configuration/app/access.md) - Restricts SSH access with more granularity than the UI.
 * [`disk` and `mount`](/configuration/app/storage.md) *(required)* - Defines writeable file directories for the application.

--- a/src/configuration/app/cron.md
+++ b/src/configuration/app/cron.md
@@ -5,14 +5,13 @@ Cron jobs allow you to run scheduled tasks at specified times or intervals. The 
 It has a few subkeys listed below:
 
 -   **spec**: The [cron specification](https://en.wikipedia.org/wiki/Cron#CRON_expression). For example: `*/20 * * * *` to run every 20 minutes.
+-   **timezone**: The timezone in which the `spec` should be interpreted.  Its value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.  If not specified UTC time is used.  This entry is only meaningful on cron specs that specify a particular time of day, rather than a "time past each hour".  For example, `25 1 * * *` would run every day at 1:25 am in the timezone specified. 
 -   **cmd**: The command that is executed, for example
     `cd public ; drush core-cron`
 
-The minimum interval between cron runs is 5 minutes, even if specified as less.  Additionally, a variable delay is added to each cron job in each project in order to prevent host overloading at midnight every night when every project runs their nightlies.  Your crons will *not* run exactly at the time that you specify, but will be delayed by 0-300 seconds.
+The minimum interval between cron runs is 5 minutes, even if specified as less.  Additionally, a variable delay is added to each cron job in each project in order to prevent host overloading should every project try to run their nightly tasks at the same time.  Your crons will *not* run exactly at the time that you specify, but will be delayed by 0-300 seconds.
 
 Cron runs are executed using the dash shell, not the bash shell used by normal SSH logins. In most cases that makes no difference but may impact some more involved cron scripts.
-
-All server times are in UTC, and hence so are the cron schedules.
 
 ## How do I setup Cron for a typical Drupal site?
 

--- a/src/configuration/app/cron.md
+++ b/src/configuration/app/cron.md
@@ -5,7 +5,6 @@ Cron jobs allow you to run scheduled tasks at specified times or intervals. The 
 It has a few subkeys listed below:
 
 -   **spec**: The [cron specification](https://en.wikipedia.org/wiki/Cron#CRON_expression). For example: `*/20 * * * *` to run every 20 minutes.
--   **timezone**: The timezone in which the `spec` should be interpreted.  Its value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.  If not specified UTC time is used.  This entry is only meaningful on cron specs that specify a particular time of day, rather than a "time past each hour".  For example, `25 1 * * *` would run every day at 1:25 am in the timezone specified. 
 -   **cmd**: The command that is executed, for example
     `cd public ; drush core-cron`
 

--- a/src/configuration/app/size.md
+++ b/src/configuration/app/size.md
@@ -1,0 +1,24 @@
+# Custom sizing
+
+By default, Platform.sh will automatically select an appropriate resources (CPU and memory) for a container when it's deployed based on the plan size and the number of other containers in the cluster.  The more containers in a project the fewer resources each one gets and vice versa, with similar containers getting similar resources.
+
+Usually that's fine, but sometimes it's undesireable.  You may, for instance, want to have a queue worker container that you know has low memory and CPU needs, so it's helpful to give it fewer resources and another container more.  Or a given service may be very heavily used in your architecture so it needs all the resources it can take.  In those cases you can provide sizing hints to the system on a per-service basis.
+
+Every application container as well as every service in `services.yaml` supports a `size` key, which provides a hint to the system for how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type, as well as the plan size.
+
+Legal values for the `size` key are `AUTO` (the default), `S`, `M`, `L`, `XL`.
+
+Note that in a development environment most combination of sizes will successfully deploy, but on production instances limits on the plan capacity will be enforced.
+
+# How do I make a queue worker container smaller to save resources?
+
+Simply set the `size` key to `S` to ensure that container gets fewer resources, leaving more to be allocated to other containers.
+
+```yaml
+name: worker
+
+type: nodejs:6.10
+size: S
+
+...
+```

--- a/src/configuration/app/size.md
+++ b/src/configuration/app/size.md
@@ -4,11 +4,11 @@ By default, Platform.sh will automatically select appropriate resource sizes (CP
 
 Usually that's fine, but sometimes it's undesirable.  You may, for instance, want to have a queue worker container that you know has low memory and CPU needs, so it's helpful to give that one fewer resources and another container more.  Or a given service may be very heavily used in your architecture so it needs all the resources it can take.  In those cases you can provide sizing hints to the system on a per-service basis.
 
-Every application container as well as every service in `.platform/services.yaml` supports a `size` key, which instructs the system how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type.
+Every application container as well as every service in `.platform/services.yaml` supports a `size` key, which instructs the system how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type, and we may adjust these values over time to give .
 
 Legal values for the `size` key are `AUTO` (the default), `S`, `M`, `L`, `XL`.
 
-Note that in a development environment this value is ignored and always set to `S`.  It will only take effect in a production deployment.  If the total resources requested by all apps and services is smaller than what the plan size allows then a production deployment will fail with an error.
+Note that in a development environment this value is ignored and always set to `S`.  It will only take effect in a production deployment (a master branch with an associated domain).  If the total resources requested by all apps and services is smaller than what the plan size allows then a production deployment will fail with an error.
 
 # How do I make a queue worker container smaller to save resources?
 

--- a/src/configuration/app/size.md
+++ b/src/configuration/app/size.md
@@ -1,10 +1,10 @@
 # Custom sizing
 
-By default, Platform.sh will automatically select an appropriate resources (CPU and memory) for a container when it's deployed based on the plan size and the number of other containers in the cluster.  The more containers in a project the fewer resources each one gets and vice versa, with similar containers getting similar resources.
+By default, Platform.sh will automatically select appropriate resource sizes (CPU and memory) for a container when it's deployed, based on the plan size and the number of other containers in the cluster.  The more containers in a project the fewer resources each one gets, and vice versa, with similar containers getting similar resources.
 
-Usually that's fine, but sometimes it's undesireable.  You may, for instance, want to have a queue worker container that you know has low memory and CPU needs, so it's helpful to give it fewer resources and another container more.  Or a given service may be very heavily used in your architecture so it needs all the resources it can take.  In those cases you can provide sizing hints to the system on a per-service basis.
+Usually that's fine, but sometimes it's undesirable.  You may, for instance, want to have a queue worker container that you know has low memory and CPU needs, so it's helpful to give that one fewer resources and another container more.  Or a given service may be very heavily used in your architecture so it needs all the resources it can take.  In those cases you can provide sizing hints to the system on a per-service basis.
 
-Every application container as well as every service in `services.yaml` supports a `size` key, which instructs the system how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type.
+Every application container as well as every service in `.platform/services.yaml` supports a `size` key, which instructs the system how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type.
 
 Legal values for the `size` key are `AUTO` (the default), `S`, `M`, `L`, `XL`.
 
@@ -12,7 +12,7 @@ Note that in a development environment this value is ignored and always set to `
 
 # How do I make a queue worker container smaller to save resources?
 
-Simply set the `size` key to `S` to ensure that container gets fewer resources, leaving more to be allocated to other containers.
+Simply set the `size` key to `S` to ensure that the container gets fewer resources, leaving more to be allocated to other containers.
 
 ```yaml
 name: worker

--- a/src/configuration/app/size.md
+++ b/src/configuration/app/size.md
@@ -4,11 +4,11 @@ By default, Platform.sh will automatically select an appropriate resources (CPU 
 
 Usually that's fine, but sometimes it's undesireable.  You may, for instance, want to have a queue worker container that you know has low memory and CPU needs, so it's helpful to give it fewer resources and another container more.  Or a given service may be very heavily used in your architecture so it needs all the resources it can take.  In those cases you can provide sizing hints to the system on a per-service basis.
 
-Every application container as well as every service in `services.yaml` supports a `size` key, which provides a hint to the system for how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type, as well as the plan size.
+Every application container as well as every service in `services.yaml` supports a `size` key, which instructs the system how many resources to allocate to it.  The exact CPU and memory allocated will depend on the application or service type.
 
 Legal values for the `size` key are `AUTO` (the default), `S`, `M`, `L`, `XL`.
 
-Note that in a development environment most combination of sizes will successfully deploy, but on production instances limits on the plan capacity will be enforced.
+Note that in a development environment this value is ignored and always set to `S`.  It will only take effect in a production deployment.  If the total resources requested by all apps and services is smaller than what the plan size allows then a production deployment will fail with an error.
 
 # How do I make a queue worker container smaller to save resources?
 

--- a/src/configuration/app/timezone.md
+++ b/src/configuration/app/timezone.md
@@ -6,7 +6,8 @@ All Platform.sh containers default to running in UTC time.  Applications and app
 
 The system timezone for any service or app container may be set with the `timezone` property, whose value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.
 
-Note that setting the timezone of different services differently may result in date mismatches between different services and thus is not recommended.
+> **warning**
+> Note that setting the timezone of different services differently may result in date mismatches between different services and thus is not recommended.
 
 ## Setting an application runtime timezone
 
@@ -15,9 +16,8 @@ The application runtime timezone can also be set, although the mechanism varies 
 * PHP runtime - You can change the timezone by providing a [custom php.ini](https://docs.platform.sh/user_guide/reference/toolstacks/php/configure-php.html#custom-php-ini).
 * Node.js runtime - You can change the timezone by starting the server with `env TZ='<timezone>' node server.js`.
 * Python runtime - You can change the timezone by starting the server with `env TZ='<timezone>' python server.py`.
-* MySQL - You can change the per-connection timezone by running SQL `SET time_zone = <timezone>;`.
-* PostgreSQL - You can change the timezone of current session by running SQL `SET TIME ZONE <timezone>;`.
 
 Setting the application timezone will only affect the application itself, not system operations such as log files.
 
-In the vast majority of cases it's best to leave all timezones in UTC and store user data with an associated timezone instead.
+> **note**
+> In the vast majority of cases it's best to leave all timezones in UTC and store user data with an associated timezone instead.

--- a/src/configuration/app/timezone.md
+++ b/src/configuration/app/timezone.md
@@ -1,13 +1,12 @@
-# System timezone
+# Cron timezone
 
-All Platform.sh containers default to running in UTC time.  Applications and application runtimes may elect to use a different timezone but the container itself runs in UTC.  That is usually fine and a correct configuration but occasionally there is cause to run the server in a specific timezone.
+All Platform.sh containers default to running in UTC time.  Applications and application runtimes may elect to use a different timezone but the container itself runs in UTC.  That includes the `spec` parameter for cron tasks that  
 
-## Setting the system timezone
+That is generally fine but sometimes it's necessary to run cron tasks in a different timezone.
 
-The system timezone for any service or app container may be set with the `timezone` property, whose value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.
+## Setting the system timezone for cron tasks
 
-> **warning**
-> Note that setting the timezone of different services differently may result in date mismatches between different services and thus is not recommended.
+The `timezone` property sets the timezone for which the `spec` property of any [cron tasks](/configuration/app/cron.md) defined by the application will be interpreted.  Its value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.  In most cases it's more self-descriptive to set the timezone on the cron task itself, however.
 
 ## Setting an application runtime timezone
 

--- a/src/configuration/app/timezone.md
+++ b/src/configuration/app/timezone.md
@@ -1,12 +1,14 @@
 # Cron timezone
 
-All Platform.sh containers default to running in UTC time.  Applications and application runtimes may elect to use a different timezone but the container itself runs in UTC.  That includes the `spec` parameter for cron tasks that  
+All Platform.sh containers default to running in UTC time.  Applications and application runtimes may elect to use a different timezone but the container itself runs in UTC.  That includes the `spec` parameter for cron tasks that are defined by the application.
 
 That is generally fine but sometimes it's necessary to run cron tasks in a different timezone.
 
 ## Setting the system timezone for cron tasks
 
-The `timezone` property sets the timezone for which the `spec` property of any [cron tasks](/configuration/app/cron.md) defined by the application will be interpreted.  Its value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.  In most cases it's more self-descriptive to set the timezone on the cron task itself, however.
+The `timezone` property sets the timezone for which the `spec` property of any [cron tasks](/configuration/app/cron.md) defined by the application will be interpreted.  Its value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.  This key will apply to all cron tasks defined in that file.
+
+This entry is only meaningful on cron specs that specify a particular time of day, rather than a "time past each hour".  For example, `25 1 * * *` would run every day at 1:25 am in the timezone specified.
 
 ## Setting an application runtime timezone
 

--- a/src/configuration/app/timezone.md
+++ b/src/configuration/app/timezone.md
@@ -1,0 +1,23 @@
+# System timezone
+
+All Platform.sh containers default to running in UTC time.  Applications and application runtimes may elect to use a different timezone but the container itself runs in UTC.  That is usually fine and a correct configuration but occasionally there is cause to run the server in a specific timezone.
+
+## Setting the system timezone
+
+The system timezone for any service or app container may be set with the `timezone` property, whose value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.
+
+Note that setting the timezone of different services differently may result in date mismatches between different services and thus is not recommended.
+
+## Setting an application runtime timezone
+
+The application runtime timezone can also be set, although the mechanism varies a bit by the runtime.
+
+* PHP runtime - You can change the timezone by providing a [custom php.ini](https://docs.platform.sh/user_guide/reference/toolstacks/php/configure-php.html#custom-php-ini).
+* Node.js runtime - You can change the timezone by starting the server with `env TZ='<timezone>' node server.js`.
+* Python runtime - You can change the timezone by starting the server with `env TZ='<timezone>' python server.py`.
+* MySQL - You can change the per-connection timezone by running SQL `SET time_zone = <timezone>;`.
+* PostgreSQL - You can change the timezone of current session by running SQL `SET TIME ZONE <timezone>;`.
+
+Setting the application timezone will only affect the application itself, not system operations such as log files.
+
+In the vast majority of cases it's best to leave all timezones in UTC and store user data with an associated timezone instead.

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -70,9 +70,7 @@ By default Platform.sh will allocate CPU and memory resources approximately equa
 
 ### Timezone
 
-All services have their system timezone set to UTC by default.  In most cases that is the best option.  If it's necessary to change the system timezone, however, it may be set with the `timezone` property, whose value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.
-
-For SQL servers it's also possible to set the timezone within the application, which will avoid making changes to the system timezone used by loggers and such.
+All services have their system timezone set to UTC by default.  In most cases that is the best option.  For some applications it's possible to change the application timezone, which will affect only the running application itself.
 
 * MySQL - You can change the per-connection timezone by running SQL `SET time_zone = <timezone>;`.
 * PostgreSQL - You can change the timezone of current session by running SQL `SET TIME ZONE <timezone>;`.

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -47,8 +47,6 @@ The `name` you want to give to your service. You are free to name each service a
 
 The `type` of your service. It's using the format ``type:version``.
 
-The version number is optional. If you don't specify a version number, the *default* version will be loaded.
-
 If you specify a version number which is not available, you'll see this error when pushing your changes:
 
 ```bash

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -64,6 +64,10 @@ For example, the current default storage amount per project is 5GB (meaning 5120
 > **notes**
 > Currently we do not support downsizing the persistent disk of a service.
 
+### Size
+
+By default Platform.sh will allocate CPU and memory resources approximately equally to each service and application container.  That is not always optimal, however, and you can customize that behavior on any service or on any application container.  See the [application sizing](/configuration/app/size.md) page for more details.
+
 ## Using the services
 
 In order for a service to be available to an application in your project (Platform.sh supports not only multiple backends but also multiple applications in each project) you will need to refer to it in the [.platform.app.yaml](/configuration/app-containers.md) file which configures the *relationships* between applications and services.

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -66,7 +66,7 @@ For example, the current default storage amount per project is 5GB (meaning 5120
 
 ### Size
 
-By default Platform.sh will allocate CPU and memory resources approximately equally to each service and application container.  That is not always optimal, however, and you can customize that behavior on any service or on any application container.  See the [application sizing](/configuration/app/size.md) page for more details.
+By default, Platform.sh will allocate CPU and memory resources to each container automatically.  Some services are optimized for high CPU load, some for high memory load.  By default, Platform.sh will try to allocate the largest "fair" size possible to all services, given the available resources on the plan.  That is not always optimal, however, and you can customize that behavior on any service or on any application container.  See the [application sizing](/configuration/app/size.md) page for more details.
 
 ## Service timezones
 

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -68,6 +68,15 @@ For example, the current default storage amount per project is 5GB (meaning 5120
 
 By default Platform.sh will allocate CPU and memory resources approximately equally to each service and application container.  That is not always optimal, however, and you can customize that behavior on any service or on any application container.  See the [application sizing](/configuration/app/size.md) page for more details.
 
+### Timezone
+
+All services have their system timezone set to UTC by default.  In most cases that is the best option.  If it's necessary to change the system timezone, however, it may be set with the `timezone` property, whose value is one of the [tz database region codes](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/Paris` or `America/New_York`.
+
+For SQL servers it's also possible to set the timezone within the application, which will avoid making changes to the system timezone used by loggers and such.
+
+* MySQL - You can change the per-connection timezone by running SQL `SET time_zone = <timezone>;`.
+* PostgreSQL - You can change the timezone of current session by running SQL `SET TIME ZONE <timezone>;`.
+
 ## Using the services
 
 In order for a service to be available to an application in your project (Platform.sh supports not only multiple backends but also multiple applications in each project) you will need to refer to it in the [.platform.app.yaml](/configuration/app-containers.md) file which configures the *relationships* between applications and services.

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -36,7 +36,7 @@ database2:
   disk: 1024
 ```
 
-## Name
+### Name
 
 The `name` you want to give to your service. You are free to name each service as you wish
 (*lowercase alphanumeric only*).
@@ -68,7 +68,7 @@ For example, the current default storage amount per project is 5GB (meaning 5120
 
 By default Platform.sh will allocate CPU and memory resources approximately equally to each service and application container.  That is not always optimal, however, and you can customize that behavior on any service or on any application container.  See the [application sizing](/configuration/app/size.md) page for more details.
 
-### Timezone
+## Service timezones
 
 All services have their system timezone set to UTC by default.  In most cases that is the best option.  For some applications it's possible to change the application timezone, which will affect only the running application itself.
 

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -59,7 +59,7 @@ E: Error parsing configuration files:
 
 The `disk` attribute is the size of the persistent disk (in MB) allocated to the service.
 
-For example, the current default storage amount per project is 5GB (meaning 5120MB) which you can distribute between your application (as defined in `.platform.app.yaml`) and each of its services.
+For example, the current default storage amount per project is 5GB (meaning 5120MB) which you can distribute between your application (as defined in `.platform.app.yaml`) and each of its services.  For memory-resident-only services such as `memcache` or `redis`, the `disk` key is not available and will generate an error if present.
 
 > **notes**
 > Currently we do not support downsizing the persistent disk of a service.

--- a/src/development/faq.md
+++ b/src/development/faq.md
@@ -31,20 +31,6 @@ on a distributed file system (which is transparent for you). When you back-up
 your environment they will be backed up as well. When you create a new staging
 environment... these will be cloned with the rest of your data.
 
-
-
-## How do I change timezone settings?
-
-We do not allow changing the system timezone of your application, though you can change the timezone in your services.
-
-* PHP runtime - You can change the timezone by providing a [custom php.ini](https://docs.platform.sh/user_guide/reference/toolstacks/php/configure-php.html#custom-php-ini).
-* Node.js runtime - You can change the timezone by starting the server with `env TZ='<timezone>' node server.js`.
-* Python runtime - You can change the timezone by starting the server with `env TZ='<timezone>' python server.py`.
-* MySQL - You can change the per-connection timezone by running SQL `SET time_zone = <timezone>;`.
-* PostgreSQL - You can change the timezone of current session by running SQL `SET TIME ZONE <timezone>;`.
-
-You may also refer to the list of [supported timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-
 ## What happens if I push a local branch to my project?
 
 If you push a local branch that you created with Git, you create what we call an `inactive environment`, ie. an environment that is not deployed.


### PR DESCRIPTION
They seem to be missing.  Let's make them not missing.

Note: the FAQ currently says that setting the system timezone for app containers is impossible, which is not true according to the code.  This PR corrects that.