### PR TITLE
Stick gitbook-cli version to 2.3.0 to prevent build failure

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -14,7 +14,7 @@ size: S
 # of it globally.
 dependencies:
   nodejs:
-    gitbook-cli: "*"
+    gitbook-cli: "2.3.1"
 
 # Use a build hook to install the GitBook plugins specified by the book.json file,
 # then build the book. The generated files will be placed in the _book directory

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -14,7 +14,7 @@ size: S
 # of it globally.
 dependencies:
   nodejs:
-    gitbook-cli: "2.3.1"
+    gitbook-cli: "2.3.0"
 
 # Use a build hook to install the GitBook plugins specified by the book.json file,
 # then build the book. The generated files will be placed in the _book directory


### PR DESCRIPTION
The most recent gitbook-cli version 2.3.1 throws the following error during build:
`Error loading version latest: Error: Cannot find module 'extend'`