### PR TITLE
Add documentation for Tideways APM for PHP

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -74,6 +74,7 @@
   * [New Relic](administration/integrations/new-relic.md)
   * [GitHub](administration/integrations/github.md)
   * [HipChat](administration/integrations/hipchat.md)
+  * [Tideways](administration/integrations/tideways.md)
   * [Web hooks](administration/integrations/webhooks.md)
 * [Web interface](administration/web.md)
   * [Project configuration](administration/web/configure-project.md)

--- a/src/administration/integrations/tideways.md
+++ b/src/administration/integrations/tideways.md
@@ -1,0 +1,39 @@
+# Tideways
+
+Platform.sh supports [Tideways APM](https://tideways.io/) for PHP.  This functionality is only available on PHP 7.0 and later.
+
+## Get Started
+
+### 1. Get your license key
+
+Sign up at [https://tideways.io](https://app.tideways.io/register/) and get your license key.
+
+### 2. Add your license key
+
+Add your Tideways license key as a project level variable:
+
+```bash
+platform project:variable:set --no-visible-build php:tideways.api_key <your-license-key>
+```
+
+### 3. Enable the Tideways extension
+
+Enable the Tideways extension in your `.platform.app.yaml` as follows:
+
+```bash
+runtime:
+    extensions:
+        - tideways
+```
+
+Enabling the extension will also activate the Tideways background process.
+
+Push the changes to your Platform.sh environment to enable New Relic as follows:
+
+```bash
+git add .platform.app.yaml
+git commit -m "Enable Tideways."
+git push
+```
+
+Tideways should now be enabled.  Give it a few hours to a day to get a decent set of data before checking your Tideways dashboard.

--- a/src/administration/integrations/tideways.md
+++ b/src/administration/integrations/tideways.md
@@ -37,3 +37,7 @@ git push
 ```
 
 Tideways should now be enabled.  Give it a few hours to a day to get a decent set of data before checking your Tideways dashboard.
+
+## Email integration
+
+Once Tideways is enabled, an additional environment variable will be available.  The `PLATFORM_SMTP_HOST` variable will contain the hostname of the Tideways SMTP server should it be needed.

--- a/src/languages/php.md
+++ b/src/languages/php.md
@@ -106,6 +106,7 @@ This is the complete list of extensions that can be enabled:
 | mysql        | *   | *   | *   |     |     |
 | mysqli       | *   | *   | *   | *   | *   |
 | mysqlnd      | *   | *   | *   |     |     |
+| newrelic     |     |     | *   | *   | *   |
 | oauth        |     |     |     | *   | *   |
 | odbc         | *   | *   | *   | *   | *   |
 | opcache      |     | *   | *   | *   | *   |
@@ -131,6 +132,7 @@ This is the complete list of extensions that can be enabled:
 | spplus       | *   | *   |     |     |     |
 | sqlite3      | *   | *   | *   | *   | *   |
 | ssh2         | *   | *   | *   |     |     |
+| tideways     |     |     |     | *   | *   |
 | tidy         | *   | *   | *   | *   | *   |
 | uuid         |     |     |     |     | *   |
 | xcache       | *   | *   |     |     |     |


### PR DESCRIPTION
Also mention the newrelic PHP extension in the list, since it's not there yet.

Note: Technically Tideways isn't on 7.0 yet.  We should add that before merging this.