### PR TITLE
Misleading --fetch-branches value in GitHub integration documentation

### DIFF
--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -40,7 +40,7 @@ Note that only `project owner` or `project admin` can manage the integrations.
 Open a terminal window (you need to have the Platform.sh CLI installed). Enable the GitHub integration as follows:
 
 ```bash
-platform integration:add --type=github --project=PROJECT_ID --token=GITHUB-USER-TOKEN --repository=USER/REPOSITORY --build-pull-requests=true --fetch-branches=false
+platform integration:add --type=github --project=PROJECT_ID --token=GITHUB-USER-TOKEN --repository=USER/REPOSITORY --build-pull-requests=true --fetch-branches=true
 ```
 
 Optional parameters:


### PR DESCRIPTION
In order to avoid confusion for developers we should update the documentation and set `--fetch-branches` to it's default value so copying the full line doesn't lead to unexpected behavior.