### PR TITLE
Added NodeJS 8.2 to Node documentation page.

### DIFF
--- a/src/languages/nodejs.md
+++ b/src/languages/nodejs.md
@@ -13,6 +13,7 @@ Javascript and PHP applications.
 * 6.9
 * 6.10
 * 6.11
+* 8.2
 
 See https://github.com/platformsh/platformsh-example-nodejs/tree/mongodb for a
 full example with MongoDB support.


### PR DESCRIPTION
Following a mini conversation in Slack, it appears NodeJS 8.2 is available but not documents. This fixes that.