### PR TITLE
Fix broken links

### DIFF
--- a/src/administration/web.md
+++ b/src/administration/web.md
@@ -1,6 +1,6 @@
 # Web Interface
 
-[Platform.sh](https://platform.sh/) provides a responsive Web Interface which allows you to interact with your projects and manage your environments. Everything you can do with this interface you can also achieve with the  [CLI (Command Line Interface)](/overview/cli.md) and vice versa.
+[Platform.sh](https://platform.sh/) provides a responsive Web Interface which allows you to interact with your projects and manage your environments. Everything you can do with this interface you can also achieve with the  [CLI (Command Line Interface)](/gettingstarted/cli.md) and vice versa.
 
 ![Web Interface](/images/platform-ui.png)
 

--- a/src/administration/web/configure-environment.md
+++ b/src/administration/web/configure-environment.md
@@ -85,7 +85,7 @@ User-agent: *
 Disallow: /
 ```
 
-That tells search engines to ignore sites on non-production environments entirely, even if they are publicly visible.  To disable that feature for a non-production environment, use the [Platform.sh CLI](/overview/cli.md) command below:
+That tells search engines to ignore sites on non-production environments entirely, even if they are publicly visible.  To disable that feature for a non-production environment, use the [Platform.sh CLI](/gettingstarted/cli.md) command below:
 
 ```
 platform environment:info restrict_robots false
@@ -99,4 +99,4 @@ platform environment:info -e ENVNAME restrict_robots false
 
 where `ENVNAME` is the name of the environment.
 
-On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`](/configuration/app-container.md#locations).
+On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`](/configuration/app/web.md#locations).

--- a/src/configuration/routes/redirects.md
+++ b/src/configuration/routes/redirects.md
@@ -20,7 +20,7 @@ https://{default}/:
 
 ## Partial redirects
 
-In the [`.platform/routes.yaml`](routes-yaml.html) file you can also add partial redirect rules
+In the [`.platform/routes.yaml`](/configuration/routes.md) file you can also add partial redirect rules
 to existing routes:
 
 ```yaml

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -95,7 +95,7 @@ Once a service is running and exposed as a relationship, its appropriate credent
 
 Be aware that the keys in the `PLATFORM_RELATIONSHIPS` structure are fixed but the values they hold may change on any deployment or restart.  Never hard-code connection credentials for a service into your application.  You should re-check the environment variable every time your script or application starts.
 
-To connect to a remote service from your local computer, the easiest way is to use the [Platform CLI](/overview/cli.md) to open an SSH tunnel.
+To connect to a remote service from your local computer, the easiest way is to use the [Platform CLI](/gettingstarted/cli.md) to open an SSH tunnel.
 
 ```bash
 platform tunnel:open

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -69,7 +69,7 @@ rediscache:
     type: redis:3.2
 ```
 
-If you are using PHP, configure the relationship and enable the [PHP redis extension](/languages/php.md#php-extensions.md) in your `.platform.app.yaml`.
+If you are using PHP, configure the relationship and enable the [PHP redis extension](/languages/php.md#php-extensions) in your `.platform.app.yaml`.
 
 ```yaml
 runtime:

--- a/src/development/variables.md
+++ b/src/development/variables.md
@@ -33,7 +33,7 @@ Naturally in practice you'll want to use only one or the other, or allow the var
 
 ### Platform.sh Environment variables
 
-Environment-level variables can also be set [through the web interface](administration/web/configure-environment.html#settings), or using the CLI. Environment variables are bound to a specific environment or branch.  An environment will also inherit variables from its parent environment, unless it has a variable defined with the same name.  That allows you to define your development variables only once, and use them on all the child environments.  For instance, to set the environment variable "foo" to the value "bar" on the currently checked out environment/branch, run:
+Environment-level variables can also be set [through the web interface](/administration/web/configure-environment.md#settings), or using the CLI. Environment variables are bound to a specific environment or branch.  An environment will also inherit variables from its parent environment, unless it has a variable defined with the same name.  That allows you to define your development variables only once, and use them on all the child environments.  For instance, to set the environment variable "foo" to the value "bar" on the currently checked out environment/branch, run:
 
 ```bash
 $ platform variable:set foo bar

--- a/src/gettingstarted/cli.md
+++ b/src/gettingstarted/cli.md
@@ -6,7 +6,7 @@ The CLI is the official tool to use and manage your Platform.sh projects directl
 
 The source code of the CLI is hosted on [GitHub](https://github.com/platformsh/platformsh-cli).
 
-Find detailed information on [setting up a local development environment](/development/local.md).
+Find detailed information on [setting up a local development environment](/gettingstarted/local.md).
 
 ## How do I get it?
 

--- a/src/gettingstarted/local.md
+++ b/src/gettingstarted/local.md
@@ -2,7 +2,7 @@
 
 While Platform.sh is great as a tool for hosting an application during both development and production, it's naturally not the ideal place to edit code.  You can't, in fact, as the file system is read-only (as it should be).  The proper place to edit your code is on your computer.
 
-You must have an [SSH key](/overview/tools.md#ssh) already configured on your account, and have both [Git](/overview/tools.md#git) and the [Platform.sh CLI](/overview/cli.md) installed before continuing.
+You must have an [SSH key](/gettingstarted/tools.md#ssh) already configured on your account, and have both [Git](/gettingstarted/tools.md#git) and the [Platform.sh CLI](/gettingstarted/cli.md) installed before continuing.
 
 ## Download the code
 

--- a/src/tutorials/dropbox.md
+++ b/src/tutorials/dropbox.md
@@ -36,7 +36,7 @@ mounts:
 
 ## Starting the daemon
 
-You'll eventually be building this step in to [`web.commands.start`](/configuration/app-containers.html#commands), but first you'll need to start it manually so that you can login to Dropbox from your application's container.  `ssh` into your application's container, either by grabbing the URL from the "access site" link in your project's admin UI or by running `platform ssh` if you've installed the [Platform CLI](https://docs.platform.sh/overview/cli.html) (recommended).
+You'll eventually be building this step in to [`web.commands.start`](/configuration/app-containers.html#commands), but first you'll need to start it manually so that you can login to Dropbox from your application's container.  `ssh` into your application's container, either by grabbing the URL from the "access site" link in your project's admin UI or by running `platform ssh` if you've installed the [Platform CLI](/gettingstarted/cli.md) (recommended).
 
 You should see a `~/.dropbox-dist` directory as a result of your build hook.  Run this - `~/.dropbox-dist/dropboxd` and you'll be presented with some text in `stdout` that asks you to visit a tokenized Dropbox URL that will authenticate your new Dropbox client against your account and store the results in the `~/.dropbox` directory.
 

--- a/src/tutorials/exporting.md
+++ b/src/tutorials/exporting.md
@@ -28,7 +28,7 @@ rsync -az `platform ssh --pipe`:/app/web/uploads ./uploads/
 > **notes**
 > If you're running `rsync` on MacOS, you should add `--iconv=utf-8,utf-8-mac` to your `rsync` call.
 
-See the [`rsync` documentation](http://linuxcommand.org/man_pages/rsync1.html) for more details on how to adjust the download process.
+See the [`rsync` documentation](https://download.samba.org/pub/rsync/rsync.html) for more details on how to adjust the download process.
 
 ## Download data from services
 

--- a/src/tutorials/migrating.md
+++ b/src/tutorials/migrating.md
@@ -48,4 +48,4 @@ rsync -az ./web/uploads `platform ssh --pipe`:/app/web/uploads
 > **notes**
 > If you're running `rsync` on MacOS, you should add `--iconv=utf-8-mac,utf-8` to your `rsync` call.
 
-See the [`rsync` documentation](http://linuxcommand.org/man_pages/rsync1.html) for more details on how to adjust the upload process.
+See the [`rsync` documentation](https://download.samba.org/pub/rsync/rsync.html) for more details on how to adjust the upload process.


### PR DESCRIPTION
As reported by @OskarStark in #663 

I also took this chance to go through the W3C link checker and fix up everything it found.  There were one or two false-positives for external links (Redis docs for some reason) and it really hates the way GitBook generates anchors, but they all work, so I'm fine with them.