### PR TITLE
Link Magento 1 example project to correct page

### DIFF
--- a/src/languages/php.md
+++ b/src/languages/php.md
@@ -305,7 +305,7 @@ A number of project templates for major PHP applications are available on GitHub
 * [Drupal 8 (Multisite variant)](https://github.com/platformsh/platformsh-example-drupal8-multisite)
 * [Laravel](https://github.com/platformsh/platformsh-example-laravel)
 * [Moodle](https://github.com/platformsh/platformsh-example-moodle)
-* [Magento 1](https://github.com/platformsh/platformsh-example-laravel)
+* [Magento 1](https://github.com/platformsh/platformsh-example-magento1)
 * [Magento 2](https://github.com/platformsh/platformsh-example-magento)
 * [Sculpin](https://github.com/platformsh/platformsh-example-sculpin)
 * [TYPO3](https://github.com/platformsh/platformsh-example-typo3)


### PR DESCRIPTION
The Magento 1 link currently redirects to the Laravel example project, but should redirect to the Magento 1 example project.