### PR TITLE
Adjective typo

### DIFF
--- a/src/configuration/app/size.md
+++ b/src/configuration/app/size.md
@@ -8,7 +8,7 @@ Every application container as well as every service in `.platform/services.yaml
 
 Legal values for the `size` key are `AUTO` (the default), `S`, `M`, `L`, `XL`.
 
-Note that in a development environment this value is ignored and always set to `S`.  It will only take effect in a production deployment (a master branch with an associated domain).  If the total resources requested by all apps and services is smaller than what the plan size allows then a production deployment will fail with an error.
+Note that in a development environment this value is ignored and always set to `S`.  It will only take effect in a production deployment (a master branch with an associated domain).  If the total resources requested by all apps and services is larger than what the plan size allows then a production deployment will fail with an error.
 
 # How do I make a background processing container smaller to save resources?
 


### PR DESCRIPTION
Usage should be larger than limit to trigger an error