### PR TITLE
GitBook isn't translating .md to .html in links with anchors

### DIFF
--- a/src/configuration/app/timezone.md
+++ b/src/configuration/app/timezone.md
@@ -14,7 +14,7 @@ This entry is only meaningful on cron specs that specify a particular time of da
 
 The application runtime timezone can also be set, although the mechanism varies a bit by the runtime.
 
-* PHP runtime - You can change the timezone by providing a [custom php.ini](https://docs.platform.sh/languages/php.md#custom-phpini).
+* PHP runtime - You can change the timezone by providing a [custom php.ini](https://docs.platform.sh/languages/php.html#custom-phpini).
 * Node.js runtime - You can change the timezone by starting the server with `env TZ='<timezone>' node server.js`.
 * Python runtime - You can change the timezone by starting the server with `env TZ='<timezone>' python server.py`.
 


### PR DESCRIPTION
Because it sucks.  As does the W3C link checker for not catching this.