### PR TITLE
[Redis] Remove Confusion with Relationship name

### DIFF
--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -77,7 +77,7 @@ runtime:
         - redis
 
 relationships:
-    myredis: "rediscache:redis"
+    fooredis: "rediscache:redis"
 ```
 
 You can then use the service in a configuration file of your application with something like:
@@ -87,16 +87,16 @@ You can then use the service in a configuration file of your application with so
 if (getenv('PLATFORM_RELATIONSHIPS')) {
     $relationships = json_decode(base64_decode(getenv('PLATFORM_RELATIONSHIPS')), true);
 
-    if (!empty($relationships['myredis'][0])) {
-        $container->setParameter('redis_host', $relationships['myredis'][0]['host']);
-        $container->setParameter('redis_port', $relationships['myredis'][0]['port']);
+    if (!empty($relationships['fooredis'][0])) {
+        $container->setParameter('redis_host', $relationships['fooredis'][0]['host']);
+        $container->setParameter('redis_port', $relationships['fooredis'][0]['port']);
     }
 }
 ```
 
 ## Using redis-cli to access your Redis service
 
-Assuming your Redis relationship is named `myredis`.
+Assuming your Redis relationship is named `fooredis`.
 
 ```yaml
 # .platform/services.yaml
@@ -107,23 +107,23 @@ rediscache:
 ```yaml
 # .platform.app.yaml
 relationships:
-    myredis: "rediscache:redis"
+    fooredis: "rediscache:redis"
 ```
 
-The host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `myredis.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
+The host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `fooredis.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
 
 ```bash
-redis-cli -h myredis.internal -p 6379
+redis-cli -h fooredis.internal -p 6379
 ```
 
 ### Using Redis as handler for native PHP sessions
 
-In the same configuration, with your Redis relationship named `myredis`:
+In the same configuration, with your Redis relationship named `fooredis`:
 
 ```yaml
 # .platform.app.yaml
 variables:
     php:
         session.save_handler: redis
-        session.save_path: "tcp://myredis.internal:6379"
+        session.save_path: "tcp://fooredis.internal:6379"
 ```

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -94,7 +94,21 @@ if (getenv('PLATFORM_RELATIONSHIPS')) {
 
 ## Using redis-cli to access your Redis service
 
-Assuming your Redis relationship is named `rediscache`, the host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `rediscache.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
+Assuming your Redis relationship is named `myredis`.
+
+```yaml
+# .platform/services.yaml
+rediscache:
+    type: redis:3.2
+```
+
+```yaml
+# .platform.app.yaml
+relationships:
+    myredis: "rediscache:redis"
+```
+
+The host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `myredis.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
 
 ```bash
 redis-cli -h rediscache.internal -p 6379

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -111,5 +111,17 @@ relationships:
 The host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `myredis.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
 
 ```bash
-redis-cli -h rediscache.internal -p 6379
+redis-cli -h myredis.internal -p 6379
+```
+
+### Using Redis as handler for native PHP sessions
+
+In the same configuration, with your Redis relationship named `myredis`:
+
+```yaml
+# .platform.app.yaml
+variables:
+    php:
+        session.save_handler: redis
+        session.save_path: "tcp://myredis.internal:6379"
 ```

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -69,7 +69,7 @@ rediscache:
     type: redis:3.2
 ```
 
-If you are using PHP, configure the relationship and enable the [PHP redis extension](/languages/php.md#php-extensions) in your `.platform.app.yaml`.
+If you are using PHP, configure a relationship and enable the [PHP redis extension](/languages/php.md#php-extensions) in your `.platform.app.yaml`.
 
 ```yaml
 runtime:
@@ -77,7 +77,7 @@ runtime:
         - redis
 
 relationships:
-    redis: "rediscache:redis"
+    myredis: "rediscache:redis"
 ```
 
 You can then use the service in a configuration file of your application with something like:
@@ -87,8 +87,10 @@ You can then use the service in a configuration file of your application with so
 if (getenv('PLATFORM_RELATIONSHIPS')) {
     $relationships = json_decode(base64_decode(getenv('PLATFORM_RELATIONSHIPS')), true);
 
-    $container->setParameter('redis_host', $relationships['redis'][0]['host']);
-    $container->setParameter('redis_port', $relationships['redis'][0]['port']);
+    if (!empty($relationships['myredis'][0])) {
+        $container->setParameter('redis_host', $relationships['myredis'][0]['host']);
+        $container->setParameter('redis_port', $relationships['myredis'][0]['port']);
+    }
 }
 ```
 

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -77,7 +77,7 @@ runtime:
         - redis
 
 relationships:
-    fooredis: "rediscache:redis"
+    applicationcache: "rediscache:redis"
 ```
 
 You can then use the service in a configuration file of your application with something like:
@@ -87,16 +87,16 @@ You can then use the service in a configuration file of your application with so
 if (getenv('PLATFORM_RELATIONSHIPS')) {
     $relationships = json_decode(base64_decode(getenv('PLATFORM_RELATIONSHIPS')), true);
 
-    if (!empty($relationships['fooredis'][0])) {
-        $container->setParameter('redis_host', $relationships['fooredis'][0]['host']);
-        $container->setParameter('redis_port', $relationships['fooredis'][0]['port']);
+    if (!empty($relationships['applicationcache'][0])) {
+        $container->setParameter('redis_host', $relationships['applicationcache'][0]['host']);
+        $container->setParameter('redis_port', $relationships['applicationcache'][0]['port']);
     }
 }
 ```
 
 ## Using redis-cli to access your Redis service
 
-Assuming your Redis relationship is named `fooredis`.
+With a Redis relationship named `applicationcache`.
 
 ```yaml
 # .platform/services.yaml
@@ -107,23 +107,35 @@ rediscache:
 ```yaml
 # .platform.app.yaml
 relationships:
-    fooredis: "rediscache:redis"
+    applicationcache: "rediscache:redis"
 ```
 
-The host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `fooredis.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
+The host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `applicationcache.internal` and `6379`. Open an [SSH session](/development/ssh.md) and access the Redis server using the `redis-cli` tool as follows:
 
 ```bash
-redis-cli -h fooredis.internal -p 6379
+redis-cli -h applicationcache.internal -p 6379
 ```
 
 ### Using Redis as handler for native PHP sessions
 
-In the same configuration, with your Redis relationship named `fooredis`:
+Using the same configuration but with your Redis relationship named `sessionstorage`:
+
+```yaml
+# .platform/services.yaml
+rediscache:
+    type: redis:3.2
+```
+
+```yaml
+# .platform.app.yaml
+relationships:
+    sessionstorage: "rediscache:redis"
+```
 
 ```yaml
 # .platform.app.yaml
 variables:
     php:
         session.save_handler: redis
-        session.save_path: "tcp://fooredis.internal:6379"
+        session.save_path: "tcp://sessionstorage.internal:6379"
 ```


### PR DESCRIPTION
The documentation is unclear to me, it is confusing when it comes to the relationship name.

The `Assuming your Redis relationship is named 'rediscache'` is weird as in the previous configuration `rediscache` is just the name of the service.

Letting `redis` as the name is also a bit confusing to me. Then I have added the configuration again to make it clear.

Let me know

Best,