### PR TITLE
fix broken environment link

### DIFF
--- a/src/overview/build-deploy.md
+++ b/src/overview/build-deploy.md
@@ -1,6 +1,6 @@
 # Building and deploying applications
 
-Every time you push to a live branch (a git branch with an active environment attached to it) or activate an [environment](administration/web/environments.md) for a branch, there are two main processes that happen: *Build* and *Deploy*.  
+Every time you push to a live branch (a git branch with an active environment attached to it) or activate an [environment](/administration/web/environments.md) for a branch, there are two main processes that happen: *Build* and *Deploy*.  
 
 1.  The build process looks through the configuration files in your repository and assembles the necessary containers.  
 2. The deploy process makes those containers live, replacing the previous versions, with virtually no interruption in service.


### PR DESCRIPTION
without slash at the beginning it will be appended to overview path which does not work. 

With this it's also  in line with contribution guidelines
> Internal links should be absolute (starting with /) and link to a file ending in .md, not .html. That makes them easier to find when needed to update.

See broken version here: https://docs.platform.sh/overview/build-deploy.html