### PR TITLE
Revert "runtime updates"

### DIFF
--- a/src/changelog/2017.md
+++ b/src/changelog/2017.md
@@ -1,12 +1,5 @@
 # December 2017
 
-## Runtimes versions updates
-
-*  Ruby 2.5 support
-*  Golang 1.9 support
-*  NodeJS 8.9 support
-*  Python 3.7 support
-
 ## New project subdomains
 
 The routes generated for subdomains and literal domains in development environments will now use `.` instead of translating them to `---`, for projects created after this date.

--- a/src/languages/go.md
+++ b/src/languages/go.md
@@ -6,12 +6,11 @@ Platform.sh supports building and deploying applications written in Go.  They ar
 ## Supported versions
 
 * 1.8
-* 1.9
 
 To specify a Go container, use the `type` property in your `.platform.app.yaml`.
 
 ```yaml
-type: 'golang:1.9'
+type: 'golang:1.8'
 ```
 
 ## GOPATH

--- a/src/languages/python.md
+++ b/src/languages/python.md
@@ -8,7 +8,6 @@ WSGI-based (Gunicorn / uWSGI) application server, Tornado, Twisted, or Python 3.
 * 2.7
 * 3.5
 * 3.6
-* 3.7
 
 ## WSGI-based configuration
 
@@ -20,7 +19,7 @@ as listed below, a complete example is included at the end of this section.
 
    ```yaml
    # .platform.app.yaml
-   type: "python:3.7"
+   type: "python:3.6"
    ```
 
 2. Build your application with the build hook.
@@ -95,7 +94,7 @@ Here is the complete `.platform.app.yaml` file:
 
 ```yaml
 name: app
-type: python:3.7
+type: python:2.7
 
 web:
   commands:

--- a/src/languages/ruby.md
+++ b/src/languages/ruby.md
@@ -23,7 +23,7 @@ as listed below, a complete example is included at the end of this section.
 
    ```yaml
    # .platform.app.yaml
-   type: "ruby:2.4"
+   type: "ruby:2.5"
    ```
 
 2. Build your application with the build hook.


### PR DESCRIPTION
Reverts platformsh/platformsh-docs#722

Python 3.7 is *not* released yet.  