### PR TITLE
Document WordPress usage

### DIFF
--- a/src/frameworks/drupal8/redis.md
+++ b/src/frameworks/drupal8/redis.md
@@ -10,10 +10,10 @@ First you need to create a Redis service.  In your `.platform/services.yaml` fil
 
 ```yaml
 rediscache:
-    type: redis:3.0
+    type: redis:3.2
 ```
 
-That will create a service named `rediscache`, of type `redis`, specifically version `3.0`.
+That will create a service named `rediscache`, of type `redis`, specifically version `3.2`.
 
 ### Expose the Redis service to your application
 

--- a/src/frameworks/wordpress.md
+++ b/src/frameworks/wordpress.md
@@ -1,0 +1,11 @@
+# WordPress
+
+The recommended way to deploy WordPress on Platform.sh is using Composer.  The most popular and supported way to do so is with the [John Block](https://github.com/johnpbloch/wordpress) script.
+
+Platform.sh strongly recommends starting new WordPress projects from our [WordPress Template](https://github.com/platformsh/platformsh-example-wordpress), which is built using Composer and includes the WP-CLI by default.  It also includes modifications to the configuration files necessary to connect to a database on Platform.sh automatically.
+
+## Plugin compatibility
+
+Platform.sh does not blacklist any WordPress plugins.  However, some plugins are known to require write access to their own file system as part of their setup process.  That is not possible on Platform.sh.  The file system where code lives is read-only for security reasons and cannot be written to from the application, only during the [build hook](configuration/app/build.md).
+
+In some cases that can be worked around by copying a file as part of the build hook process.  In other cases the plugin is simply incompatible with Platform.sh.  If you find a plugin that tries to write to its own directory we recommend filing an issue with that plugin, as such behavior should be viewed as a security bug.

--- a/src/frameworks/wordpress/redis.md
+++ b/src/frameworks/wordpress/redis.md
@@ -1,0 +1,99 @@
+# Using Redis with WordPress
+
+There are a number of Redis libraries for WordPress, only some of which are compatible with Platform.sh.  We have tested and recommend [devgeniem/wp-redis-object-cache-dropin](https://packagist.org/packages/devgeniem/wp-redis-object-cache-dropin), which requires extremely little configuration.
+
+## Requirements
+
+### Add a Redis service
+
+First you need to create a Redis service.  In your `.platform/services.yaml` file, add the following:
+
+```yaml
+rediscache:
+    type: redis:3.2
+```
+
+That will create a service named `rediscache`, of type `redis`, specifically version `3.2`.
+
+### Expose the Redis service to your application
+
+In your `.platform.app.yaml` file, we now need to open a connection to the new Redis service.  Under the `relationships` section, add the following:
+
+```yaml
+relationships:
+    redis: "rediscache:redis"
+```
+
+The key (left side) is the name that will be exposed to the application in the `PLATFORM_RELATIONSHIPS` [variable](/development/variables.md).  The right hand side is the name of the service we specified above (`rediscache`) and the endpoint (`redis`).  If you named the service something different above, change `rediscache` to that.
+
+### Add the Redis PHP extension
+
+You will need to enable the PHP Redis extension.  In your `.platform.app.yaml` file, add the following right after the `type` block:
+
+```yaml
+# Additional extensions
+runtime:
+    extensions:
+        - redis
+```
+
+### Add the Redis library
+
+If using Composer to build WordPress, you can install the WP-Redis library with the following Composer command:
+
+```bash
+composer require devgeniem/wp-redis-object-cache-dropin
+```
+
+Then commit the resulting changes to your `composer.json` and `composer.lock` files.
+
+## Configuration
+
+To enable the WP-Redis cache the `object-cache.php` file needs to be copied from the downloaded package to the `wp-content` directory.  Add the following line to the bottom of your `build` hook:
+
+```bash
+cp -r vendor/devgeniem/wp-redis-object-cache-dropin/object-cache.php wp/wp-content/object-cache.php
+```
+
+It should now look something like:
+
+```yaml
+hooks:
+    build: |
+      mkdir -p wp/wp-content/themes
+      mkdir -p wp/wp-content/plugins
+      mkdir -p wp/wp-content/languages
+      cp -r plugins/* wp/wp-content/plugins/
+      cp -r themes/* wp/wp-content/themes/
+      cp -r languages/* wp/wp-content/languages/
+      cp -r vendor/devgeniem/wp-redis-object-cache-dropin/object-cache.php wp/wp-content/object-cache.php
+```
+
+Next, place the following code in the `wp-config.php` file, somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
+
+```php
+if (!empty($_ENV['PLATFORM_RELATIONSHIPS']) && extension_loaded('redis')) {
+    $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), true);
+
+    $relationship_name = 'redis';
+
+    if (!empty($relationships[$relationship_name][0])) {
+        $redis = $relationships[$relationship_name][0];
+        define('WP_REDIS_CLIENT', 'pecl');
+        define('WP_REDIS_HOST', $redis['host']);
+        define('WP_REDIS_PORT', $redis['port']);
+    }
+}
+```
+
+That will define 3 constants that the WP-Redis extension will look for in order to connect to the Redis server.  If you used a different name for the relationship above, change `$relationship_name` accordingly.  This code will have no impact when run on a local development environment.
+
+That's it.  There is no Plugin to enable through the WordPress administrative interface.  Commit the above changes and push.
+
+### Verifying Redis is running
+
+Run this command in a SSH session in your environment `redis-cli -h redis.internal info`. You should run it before you push all this new code to your repository.
+
+This should give you a baseline of activity on your Redis installation. There should be very little memory allocated to the Redis cache.
+
+After you push this code, you should run the command and notice that allocated memory will start jumping.


### PR DESCRIPTION
And Redis while we're at it.

Note: The warning about plugins that need write access is a bit stern, but there's really no way around it that I know of, at least not generically.  Modules that need to write to themselves are just wrong and need to stop.