### PR TITLE
Fix typo when requiring Drush via Composer.

### DIFF
--- a/src/frameworks/drupal8/drush.md
+++ b/src/frameworks/drupal8/drush.md
@@ -44,7 +44,7 @@ And see a list of available commands.
 
 Run this command in the project's repository root folder:
 ```bash
-$ composer require drupal/drush
+$ composer require drush/drush
 ```
 Then, commit and push.
 


### PR DESCRIPTION
This fixes a typo in the docs where you would be requiring a 4 year old Drush version from the Drupal package repo, instead of the fresh one from the Drush namespace.