### PR TITLE
Add leading slash back into Dropbox mount names

### DIFF
--- a/src/tutorials/dropbox.md
+++ b/src/tutorials/dropbox.md
@@ -28,10 +28,10 @@ Because Dropbox files are mirrored on your writable disk mount, your application
 disk: 2048
 # the needed mounts for the Dropbox daemon
 mounts:
-    Dropbox:
+    '/Dropbox':
         source: local
         source_path: dropbox
-    '.dropbox':
+    '/.dropbox':
         source: local
         source_path: 'dropbox-meta'
 ```


### PR DESCRIPTION
Fixes reversion of https://github.com/platformsh/platformsh-docs/pull/543/commits/d35c7efe2936ea81d1b6eadd79977f911a7f8f8e.