### PR TITLE
Remove 'we' to comply with language standards.

### DIFF
--- a/src/golive/example.md
+++ b/src/golive/example.md
@@ -50,7 +50,7 @@ An incoming request for `mysite.com` will result in the following:
 
 1. Your browser asks the DNS network for `mysite.com`'s DNS A record (the IP address of this host).  It responds with "it's an alias for `www.master-def456-abc123.us.platform.sh`" (the CNAME) which itself resolves to the A record with IP address "1.2.3.4"  (Or whatever the actual address is). By default DNS requests by browsers are recursive, so there is no performance penalty for using CNAMEs.
 3. Your browser sends a request to `1.2.3.4` for domain `mysite.com`.
-4. Your router responds with an HTTP 301 redirect to `www.mysite.com` (because that's that's what `routes.yaml` specified).
+4. Your router responds with an HTTP 301 redirect to `www.mysite.com` (because that's what `routes.yaml` specified).
 5. Your browser looks up `www.mysite.com` and, as above, gets an alias for `www.master-def456-abc123.us.platform.sh`, which is IP 1.2.3.4.
 6. Your browser sends a request to `1.2.3.4` for domain `www.mysite.com`.  Your router passes the request through to your application which in turn responds with whatever it's supposed to do.
 

--- a/src/golive/example.md
+++ b/src/golive/example.md
@@ -50,7 +50,7 @@ An incoming request for `mysite.com` will result in the following:
 
 1. Your browser asks the DNS network for `mysite.com`'s DNS A record (the IP address of this host).  It responds with "it's an alias for `www.master-def456-abc123.us.platform.sh`" (the CNAME) which itself resolves to the A record with IP address "1.2.3.4"  (Or whatever the actual address is). By default DNS requests by browsers are recursive, so there is no performance penalty for using CNAMEs.
 3. Your browser sends a request to `1.2.3.4` for domain `mysite.com`.
-4. Your router responds with an HTTP 301 redirect to `www.mysite.com` (because in our `routes.yaml` we defined such a redirect).
+4. Your router responds with an HTTP 301 redirect to `www.mysite.com` (because that's that's what `routes.yaml` specified).
 5. Your browser looks up `www.mysite.com` and, as above, gets an alias for `www.master-def456-abc123.us.platform.sh`, which is IP 1.2.3.4.
 6. Your browser sends a request to `1.2.3.4` for domain `www.mysite.com`.  Your router passes the request through to your application which in turn responds with whatever it's supposed to do.
 


### PR DESCRIPTION
Trivial fix.