### PR TITLE
Add Memcache instructions for Drupal 7.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -115,6 +115,7 @@
   * [Customizing settings.php](frameworks/drupal7/customizing-settings-php.md)
   * [Drush](frameworks/drupal7/drush.md)
   * [Redis](frameworks/drupal7/redis.md)
+  * [Memcached](frameworks/drupal7/memcached.md)
   * [Apache Solr Search](frameworks/drupal7/apachesolr-module.md)
   * [Search API](frameworks/drupal7/search-api-module.md)
   * [SimpleSAML](frameworks/drupal7/simplesaml.md)

--- a/src/frameworks/drupal7/memcached.md
+++ b/src/frameworks/drupal7/memcached.md
@@ -1,0 +1,87 @@
+# Using Memcached with Drupal 7.x
+
+Platform.sh recommends using Redis for caching with Drupal 7 over Memcached, as Redis offers better performance when dealing with larger values as Drupal tends to produce.  However, Memcached is also available if desired and is fully supported.
+
+## Requirements
+
+### Add a Memcached service
+
+First you need to create a  Memcached service.  In your `.platform/services.yaml` file, add or uncomment the following:
+
+```yaml
+cacheservice:
+    type: memcached:1.4
+```
+
+That will create a service named `cacheservice`, of type `memcached`, specifically version `1.4`.
+
+### Expose the Memcached service to your application
+
+In your `.platform.app.yaml` file, we now need to open a connection to the new Memcached service.  Under the `relationships` section, add the following:
+
+```yaml
+relationships:
+    cache: 'cacheservice:memcached'
+```
+
+The key (left side) is the name that will be exposed to the application in the `PLATFORM_RELATIONSHIPS` [variable](/development/variables.md).  The right hand side is the name of the service we specified above (`cacheservice`) and the endpoint (`memcached`).  If you named the service something different above, change `cacheservice` to that.
+
+### Add the Memcached PHP extension
+
+You will need to enable the PHP Memcached extension.  In your `.platform.app.yaml` file, add the following right after the `type` block:
+
+```yaml
+# Additional extensions
+runtime:
+    extensions:
+        - memcached
+```
+
+### Add the Drupal module
+
+You will need to add the [Memcache](https://www.drupal.org/project/memcache) module to your project.  If you are using a Drush Make file, add the following line to your `project.make` file:
+
+```ini
+projects[memcache][version] = 1.6
+```
+
+Then commit the 
+
+> **note**
+>
+> You must commit and deploy your code before continuing, then enable the module. The memcache 
+> module must be enabled before it is configured in the `settings.platformsh.php` file.
+
+## Configuration
+
+The Drupal Memcache module must be configured via `settings.platformsh.php`.
+
+Place the following at the end of `settings.platformsh.php`. Note the inline comments, as you may wish to customize it further.  Also review the `README.txt` file that comes with the memcache module, as it has a more information on possible configuration options. For instance, you may want to consider using memcache for locking as well and configuring cache stampede protection.
+
+The example below is intended as a "most common case".
+
+```php
+if (!empty($_ENV['PLATFORM_RELATIONSHIPS']) && extension_loaded('memcached')) {
+  $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), true);
+
+  // If you named your memcached relationship something other than "cache", set that here.
+  $realtionship_name = 'cache';
+
+  if (!empty($relationships[$realtionship_name])) {
+    // These lines tells Drupal to use memcached as a backend.
+    // Comment out just these lines if you need to disable it for some reason and
+    // fall back to the default database cache.
+    $conf['cache_backends'][] = 'sites/all/modules/contrib/memcache/memcache.inc';
+    $conf['cache_default_class'] = 'MemCacheDrupal';
+    $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+
+    // While we're at it, use Memcache for locking, too.
+    $conf['lock_inc'] = 'sites/all/modules/contrib//memcache/memcache-lock.inc';
+
+    foreach ($relationships[$realtionship_name] as $endpoint) {
+      $host = sprintf("%s:%d", $endpoint['host'], $endpoint['port']);
+      $conf['memcache_servers'][$host] = 'default';
+    }
+  }
+}
+```


### PR DESCRIPTION
Basically copy-paste from the Drupal 8 instructions, but with different glue code.