### PR TITLE
 No longer need to add the github webhook manually

### DIFF
--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -47,9 +47,12 @@ Note that if your repository belongs to an organization, use ``--repository=ORGA
 
 ### 3. Add the webhook
 
-If you don't see the CLI outputs `Webhook created successfully`, you need to add the webhook manually. Copy the Payload URL that is returned by the previous command and continue the below. 
+The CLI will create the necessary webhook for you when there's correct permission set in the given token. If you see the message `Failed to read or write webhooks`, you will need to add a webhook manually:
 
-Go to your GitHub repository and click `Settings`. Select the *Webhooks and Services* tab and click `Add webhook`. Paste the Payload URL, choose  "application/json" for the content type, choose "Send me everything"  for the events you want to receive and click `Add webhook`.
+1. Copy the hook URL shown in the message.
+2. Go to your GitHub repository and click Settings, select the Webhooks and Services tab, and click Add webhook.
+3. Paste the hook URL, choose application/json for the content type, choose "Send me everything" for the events you want to receive, and click Add webhook.
+
 
 You can now start pushing code, creating new branches or opening pull requests directly on your GitHub repository.
 

--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -47,7 +47,7 @@ Note that if your repository belongs to an organization, use ``--repository=ORGA
 
 ### 3. Add the webhook
 
-Copy the Payload URL that is returned by the previous command.
+If you don't see the CLI outputs `Webhook created successfully`, you need to add the webhook manually. Copy the Payload URL that is returned by the previous command and continue the below. 
 
 Go to your GitHub repository and click `Settings`. Select the *Webhooks and Services* tab and click `Add webhook`. Paste the Payload URL, choose  "application/json" for the content type, choose "Send me everything"  for the events you want to receive and click `Add webhook`.
 


### PR DESCRIPTION
The latest CLI will create the webhook when we have enough permission to do so.