### PR TITLE
Add post_deploy hook

### DIFF
--- a/src/changelog/2018.md
+++ b/src/changelog/2018.md
@@ -1,0 +1,5 @@
+# February 2018
+
+## `post_deploy` hook added
+
+Projects can now run commands on deploy but [without blocking new requests](configuration/app/build.md#post_deploy_hook).

--- a/src/configuration/app/build.md
+++ b/src/configuration/app/build.md
@@ -87,7 +87,7 @@ The `build` hook is run after the build flavor (if any).  The file system is ful
 
 The `deploy` hook is run after the application container has been started, but before it has started accepting requests.  You can access other services at this stage (MySQL, Solr, Redis, etc.). The disk where the application lives is read-only at this point.  Note that the deploy hook will only run on a [`web`](/configuration/app/web.md) instance, not on a [`worker`](/configuration/app/worker.md) instance.
 
-Be aware: The deploy hook blocks the site accepting new requests.  If your deploy hook is only a few seconds then incoming requests in that time are paused and will continue when the hook completes, effectively appearing as the site just took a few extra seconds to respond.  If it takes too long, however, requests cannot be held and will appear as dropped connections.  Only run tasks in your deploy hook that have to be run exclusively, such as database schema updates.  A post-deploy task that can safely run concurrently with new incoming requests should be run as a `post_deploy` hook instead.
+Be aware: The deploy hook blocks the site accepting new requests.  If your deploy hook is only a few seconds then incoming requests in that time are paused and will continue when the hook completes, effectively appearing as the site just took a few extra seconds to respond.  If it takes too long, however, requests cannot be held and will appear as dropped connections.  Only run tasks in your deploy hook that have to be run exclusively, such as database schema updates or some types of cache clear.  A post-deploy task that can safely run concurrently with new incoming requests should be run as a `post_deploy` hook instead.
 
 After a Git push, you can see the results of the `deploy` hook in the `/var/log/deploy.log` file when logged in to the environment via SSH. It contains the log of the execution of the deployment hook. For example:
 
@@ -105,7 +105,7 @@ Finished performing updates.
 
 The `post_deploy` hook functions exactly the same as the `deploy` hook, but after the container is accepting connections.  That is, it will run concurrently with normal incoming traffic.  That makes it well suited to any updates that do not require exclusive database access.
 
-What is "safe" to run in a `post_deploy` hook vs. in a `deploy` hook will vary by the application.  Often times cache clears, content imports, and other such tasks are good candidates for a `post_deploy` hook.
+What is "safe" to run in a `post_deploy` hook vs. in a `deploy` hook will vary by the application.  Often times content imports, some types of cache warmups, and other such tasks are good candidates for a `post_deploy` hook.
 
 The `post_deploy` hook logs to its own file, `/var/log/post_deploy.log`.
 

--- a/src/development/logs.md
+++ b/src/development/logs.md
@@ -22,7 +22,7 @@ The cron log contains the output of all recent cron executions.  If there is no 
 
 ## `deploy.log`
 
-The deploy log contains the output of the most recent run of the deploy hook for the container.  If there is no deploy hook then this file will be absent.
+The deploy log contains the output of the most recent run of the `deploy` hook for the container.  If there is no `deploy` hook then this file will be absent.
 
 ## `nginx/error.log`
 
@@ -35,3 +35,7 @@ nginx-level errors that occur once nginx has fully started will be recorded here
 ## `php.access.log`
 
 On a PHP container, the php.access.log contains a record of all requests to the PHP service.
+
+## `post_deploy.log`
+
+The post_deploy log contains the output of the most recent run of the `post_deploy` hook for the container.  If there is no `post_deploy` hook then this file will be absent.


### PR DESCRIPTION
I reorganized the hooks section a bit to account for it.

Eventually we'll break the build and deploy docs apart, but not until they're broken apart in the config file, too.