### PR TITLE
Improve cookies regular expression example

### DIFF
--- a/src/configuration/routes/cache.md
+++ b/src/configuration/routes/cache.md
@@ -152,7 +152,7 @@ A cookie value may also be a regular expression.  An entry that begins and ends 
 ```yaml
 cache:
   enabled: true
-  cookies: ["/^SESS.*/"]
+  cookies: ['/^SESS/']
 ```
 
 Will cause all cookies beginning with `SESS` to be part of the cache key, as a single value.  Other cookies will be ignored for caching.  If your site uses a session cookie as well as 3rd party cookies, say from an analytics service, this is the recommended approach.


### PR DESCRIPTION
- Regular expressions (along with nearly everything else) should be quoted by `'` in YAML.
- The `.*` was unnecessary.