### PR TITLE
Fix cookie example so it doesn't break Drupal

### DIFF
--- a/src/configuration/routes/cache.md
+++ b/src/configuration/routes/cache.md
@@ -152,10 +152,10 @@ A cookie value may also be a regular expression.  An entry that begins and ends 
 ```yaml
 cache:
   enabled: true
-  cookies: ['/^SESS/']
+  cookies: ['/^SS?ESS/']
 ```
 
-Will cause all cookies beginning with `SESS` to be part of the cache key, as a single value.  Other cookies will be ignored for caching.  If your site uses a session cookie as well as 3rd party cookies, say from an analytics service, this is the recommended approach.
+Will cause all cookies beginning with `SESS` or `SSESS` to be part of the cache key, as a single value.  Other cookies will be ignored for caching.  If your site uses a session cookie as well as 3rd party cookies, say from an analytics service, this is the recommended approach.
 
 ### `default_ttl`
 


### PR DESCRIPTION
Even though it doesn't say it's a Drupal example, it looks like one, so people will want to copy and paste it into a Drupal configuration anyway. The current example breaks Drupal sites on https.