### PR TITLE
Make memcache Drupal bin env-specific

### DIFF
--- a/src/frameworks/drupal7/memcached.md
+++ b/src/frameworks/drupal7/memcached.md
@@ -82,6 +82,10 @@ if (!empty($_ENV['PLATFORM_RELATIONSHIPS']) && extension_loaded('memcached')) {
       $host = sprintf("%s:%d", $endpoint['host'], $endpoint['port']);
       $conf['memcache_servers'][$host] = 'default';
     }
+
+    // If using a multisite configuration, adapt this line to include a site-unique
+    // value.
+    $conf['memcache_key_prefix'] = $PLATFORM_ENVIRONMENT;
   }
 }
 ```

--- a/src/frameworks/drupal8/memcached.md
+++ b/src/frameworks/drupal8/memcached.md
@@ -90,6 +90,10 @@ if (!empty($_ENV['PLATFORM_RELATIONSHIPS']) && extension_loaded('memcached')) {
   if ($memcache_exists || $memcached_exists) {
     $class_loader->addPsr4('Drupal\\memcache\\', 'modules/contrib/memcache/src');
 
+    // If using a multisite configuration, adapt this line to include a site-unique
+    // value.
+    $settings['memcache']['key_prefix'] = $PLATFORM_ENVIRONMENT;
+
     // Define custom bootstrap container definition to use Memcache for cache.container.
     $settings['bootstrap_container_definition'] = [
       'parameters' => [],


### PR DESCRIPTION
Without this, on PE both staging and production try to use the same memcache bin.  Hilarity ensues.