### PR TITLE
Fix link to Symfony example to point to the right repository.

### DIFF
--- a/src/frameworks/symfony.md
+++ b/src/frameworks/symfony.md
@@ -12,4 +12,4 @@ Composer is a tool for dependency management in PHP. It allows you to declare th
 
 The ideal `.platform.app.yaml` file will vary from project project, and you are free to customize yours as needed.  A recommended baseline Symfony configuration is listed below, and can also be found in our [Symfony template project](https://github.com/platformsh/platformsh-example-symfony).
 
-{% codesnippet "https://raw.githubusercontent.com/platformsh/platformsh-example-symfony/3.0/.platform.app.yaml", language="yaml" %}{% endcodesnippet %}
+{% codesnippet "https://raw.githubusercontent.com/platformsh/platformsh-example-symfony3/master/.platform.app.yaml", language="yaml" %}{% endcodesnippet %}


### PR DESCRIPTION
The old link was pointing to the long-deprecated repository that I just marked private to avoid people using it.  Oops.