### PR TITLE
update data retention to include google analytics

### DIFF
--- a/src/administration/data-retention.md
+++ b/src/administration/data-retention.md
@@ -40,4 +40,4 @@ These "tombstone" backups are retained for between _7 days_ and _6 months_.
 
 ## Analytics
 
-Platform.sh uses Google Analytics on various web pages, and therefore Google Analytics will store collected data for a period of time.  We have configured our Google Analytics account to store data for 14 months from the time you last accessed our site, which is the minimum Google allows.
+Platform.sh uses Google Analytics on various web pages, and therefore Google Analytics will store collected data for a period of time.  We have configured our Google Analytics account to store data for _14 months_ from the time you last accessed our site, which is the minimum Google allows.

--- a/src/administration/data-retention.md
+++ b/src/administration/data-retention.md
@@ -38,3 +38,6 @@ When a project is deleted Platform.sh takes a final snapshot of active environme
 
 These "tombstone" backups are retained for between _7 days_ and _6 months_.
 
+## Analytics
+
+Platform.sh uses Google Analytics on various web pages, and therefore Google Analytics will store collected data for a period of time.  We have configured our Google Analytics account to store data for 14 months from the time you last accessed our site, which is the minimum Google allows.


### PR DESCRIPTION
COM-372.  "Google analytics has new GDPR controls and the minimum amount we can keep analytics data is 14 months. We need to articulate this in our privacy policy. Add something like "we are going to keep analytics data for 14 from the time of last use"