### PR TITLE
Remove NodeJS 4 from supported versions

### DIFF
--- a/src/languages/nodejs.md
+++ b/src/languages/nodejs.md
@@ -4,9 +4,10 @@ Node.js is a popular JavaScript runtime built on Chrome's V8 JavaScript engine. 
 
 ## Supported versions
 
-* 4.8
 * 6.11
 * 8.9
+
+If you need other versions, take a look at our [options for installing them with NVM](/languages/nodejs/nvm.html).
 
 ## Deprecated versions
 
@@ -14,6 +15,7 @@ The following versions are available but are not receiving security updates from
 
 * 0.12
 * 4.7
+* 4.8
 * 6.9
 * 6.10
 * 8.2


### PR DESCRIPTION
Node 4 is EOL. See https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742.