### PR TITLE
Added a leading forward slash

### DIFF
--- a/src/tutorials/dropbox.md
+++ b/src/tutorials/dropbox.md
@@ -41,7 +41,7 @@ If your `.platform.app.yaml` file still uses the old syntax for mounts, this is 
 ```yaml
 mounts:
     'Dropbox': 'shared:files/dropbox'
-    '.dropbox': 'shared:files/dropbox-meta'
+    '/.dropbox': 'shared:files/dropbox-meta'
 ```
 
 **Make sure you've `git push`ed these configuration changes to Platform.sh if you haven't already.**


### PR DESCRIPTION
This is required to create the writable mount in order to properly run the Dropbox installer.