### PR TITLE
Remove passthrough key.

### DIFF
--- a/src/gettingstarted/local/lando.md
+++ b/src/gettingstarted/local/lando.md
@@ -33,8 +33,6 @@ tooling:
     description: Run Platform CLI commands
     cmd:
       - /var/www/.platformsh/bin/platform
-    options:
-      passthrough: true
 
 config:
   # Lando defaults to Apache. Switch to nginx to match Platform.sh.


### PR DESCRIPTION
The passthrough as written here does not do anything and worst case can break in latest lando builds.

Remove:

```
    options:
      passthrough: true
```