### PR TITLE
Troubleshoot reorg

### DIFF
--- a/src/development/troubleshoot.md
+++ b/src/development/troubleshoot.md
@@ -32,74 +32,6 @@ These errors indicate your application (or application runner, like PHP-FPM) is 
 * A PHP process is crashing because of a segmentation fault (see below).
 * A PHP process is killed by the kernel out-of-memory killer (see below).
 
-## PHP-specific error messages
-
-### server reached max_children
-
-You may see a line like the following in the `/var/log/app.log` file:
-
-```
-WARNING: [pool web] server reached max_children setting (2), consider raising it
-```
-
-That indicates that the server is receiving more concurrent requests than it has PHP processes allocated, which means some requests will have to wait until another finishes.  In this example there are 2 PHP processes that can run concurrently.
-
-Platform.sh sets the number of workers based on the available memory of your container and the estimated average memory size of each process.  There are two ways to increase the number of workers:
-
-* Adjust the [worker sizing hints](/languages/php/fpm.md) for your project.
-* Upgrade your subscription on Platform.sh to get more computing resources. To do so, log into your [account](https://accounts.platform.sh) and edit the project.
-
-
-### Execution timeout
-
-If your PHP application is not able to handle the amount of traffic or it is slow, you should see log lines from `/var/log/app.log` like any of the below:
-
-```
-WARNING: [pool web] child 120, script '/app/public/index.php' (request: "GET /index.php") execution timed out (358.009855 sec), terminating
-```
-
-That means your PHP process is running longer than allowed.  You can adjust the `max_execution_time` value in `php.ini`, but there is still a 5 minute hard cap on any web request that cannot be adjusted.
-
-The most common cause of a timeout is either an infinite loop (which is a bug that you should fix) or the work itself requires a long time to complete. For the latter case, you should consider putting the task into a background job.
-
-The following command will identify the 20 slowest requests in the last hour, which can provide an indication of what code paths to investigate.
-
-```bash
-grep $(date +%Y-%m-%dT%H --date='-1 hours') /var/log/php.access.log | sort -k 4 -r -n | head -20
-```
-
-If you see that the processing time of certain requests is slow (e.g. taking more than 1000ms), you may wish to consider using a profiler like [Blackfire](/administration/integrations/blackfire.md) to debug the performance issue.
-
-Otherwise, you may check if the following options are applicable:
-
-* Find the most visited pages and see if they can be cached and/or put behind a CDN.  You may refer to [how caching works](/configuration/routes/cache.md).
-* Upgrade your subscription on Platform.sh to get more computing resources. To do so, log into your [account](https://accounts.platform.sh) and edit the project subscription.
-
-### PHP process crashed
-
-If your PHP process crashed with a segmentation fault, you should see log lines in `/var/log/app.log` like below:
-
-```
-WARNING: [pool web] child 112 exited on signal 11 (SIGSEGV) after 7.405936 seconds from start
-```
-
-This is complicated, either a PHP extension is hitting a segmentation fault or your PHP application code is crashing. You should review recent changes in your application and try to find the cause of it, probably with the help of XDebug.
-
-### PHP process is killed
-
-If your PHP process is killed by the kernel, you should see log lines in `/var/log/app.log` like this:
-
-```
-WARNING: [pool web] child 429 exited on signal 9 (SIGKILL) after 50.938617 seconds from start
-```
-
-That means the memory usage of your container exceeds the limit allowed on your plan so the kernel kills the offending process. You should try the following:
-
-* Check if the memory usage of your application is expected and try to optimize it.
-* Use [sizing hints](/languages/php/fpm.md) to reduce the amount of PHP workers which reduces the memory footprint.
-* Upgrade your subscription on Platform.sh to get more computing resources. To do so, log into your [account](https://accounts.platform.sh) and edit the project.
-
-
 ## Low disk space
 
 If you suspect you are running low on disk space in your application container, the easiest way to check it is to log in using `platform ssh` and run the `df` command.  `df` has numerous options to tweak its output, but for just checking the available writeable space the most direct option is:
@@ -195,6 +127,73 @@ If you see a bare "File not found" error when accessing your Drupal site with a 
 
 Make sure your repository contains an *index.php* file in the [web location root](/configuration/app-containers.md#locations), or that your [Drush](/frameworks/drupal7/drush.md) make files are properly named.
 
+
+## PHP-specific error messages
+
+### server reached max_children
+
+You may see a line like the following in the `/var/log/app.log` file:
+
+```
+WARNING: [pool web] server reached max_children setting (2), consider raising it
+```
+
+That indicates that the server is receiving more concurrent requests than it has PHP processes allocated, which means some requests will have to wait until another finishes.  In this example there are 2 PHP processes that can run concurrently.
+
+Platform.sh sets the number of workers based on the available memory of your container and the estimated average memory size of each process.  There are two ways to increase the number of workers:
+
+* Adjust the [worker sizing hints](/languages/php/fpm.md) for your project.
+* Upgrade your subscription on Platform.sh to get more computing resources. To do so, log into your [account](https://accounts.platform.sh) and edit the project.
+
+
+### Execution timeout
+
+If your PHP application is not able to handle the amount of traffic or it is slow, you should see log lines from `/var/log/app.log` like any of the below:
+
+```
+WARNING: [pool web] child 120, script '/app/public/index.php' (request: "GET /index.php") execution timed out (358.009855 sec), terminating
+```
+
+That means your PHP process is running longer than allowed.  You can adjust the `max_execution_time` value in `php.ini`, but there is still a 5 minute hard cap on any web request that cannot be adjusted.
+
+The most common cause of a timeout is either an infinite loop (which is a bug that you should fix) or the work itself requires a long time to complete. For the latter case, you should consider putting the task into a background job.
+
+The following command will identify the 20 slowest requests in the last hour, which can provide an indication of what code paths to investigate.
+
+```bash
+grep $(date +%Y-%m-%dT%H --date='-1 hours') /var/log/php.access.log | sort -k 4 -r -n | head -20
+```
+
+If you see that the processing time of certain requests is slow (e.g. taking more than 1000ms), you may wish to consider using a profiler like [Blackfire](/administration/integrations/blackfire.md) to debug the performance issue.
+
+Otherwise, you may check if the following options are applicable:
+
+* Find the most visited pages and see if they can be cached and/or put behind a CDN.  You may refer to [how caching works](/configuration/routes/cache.md).
+* Upgrade your subscription on Platform.sh to get more computing resources. To do so, log into your [account](https://accounts.platform.sh) and edit the project subscription.
+
+### PHP process crashed
+
+If your PHP process crashed with a segmentation fault, you should see log lines in `/var/log/app.log` like below:
+
+```
+WARNING: [pool web] child 112 exited on signal 11 (SIGSEGV) after 7.405936 seconds from start
+```
+
+This is complicated, either a PHP extension is hitting a segmentation fault or your PHP application code is crashing. You should review recent changes in your application and try to find the cause of it, probably with the help of XDebug.
+
+### PHP process is killed
+
+If your PHP process is killed by the kernel, you should see log lines in `/var/log/app.log` like this:
+
+```
+WARNING: [pool web] child 429 exited on signal 9 (SIGKILL) after 50.938617 seconds from start
+```
+
+That means the memory usage of your container exceeds the limit allowed on your plan so the kernel kills the offending process. You should try the following:
+
+* Check if the memory usage of your application is expected and try to optimize it.
+* Use [sizing hints](/languages/php/fpm.md) to reduce the amount of PHP workers which reduces the memory footprint.
+* Upgrade your subscription on Platform.sh to get more computing resources. To do so, log into your [account](https://accounts.platform.sh) and edit the project.
 
 ## Stuck build or deployment
 

--- a/src/development/troubleshoot.md
+++ b/src/development/troubleshoot.md
@@ -34,7 +34,7 @@ These errors indicate your application (or application runner, like PHP-FPM) is 
 
 ## PHP-specific error messages
 
-### server reached max_children (PHP)
+### server reached max_children
 
 You may see a line like the following in the `/var/log/app.log` file:
 


### PR DESCRIPTION
One of the section titles is broken with the TOC plugin, and I decided it makes sense to put the PHP specific stuff together toward the bottom.  No other changes than the title and moving stuff around.