### PR TITLE
Fix old links to Symfony repositories.

### DIFF
--- a/src/gettingstarted/first-project.md
+++ b/src/gettingstarted/first-project.md
@@ -46,8 +46,8 @@ You can also initialize your project using any of the pre-made templates below. 
   <h4>Frameworks</h4>
   <a href="https://github.com/platformsh/platformsh-example-amphp">AmPHP</a><br />
   <a href="https://github.com/platformsh/platformsh-example-reactphp">React PHP</a><br />
-  <a href="https://github.com/platformsh/platformsh-example-symfony/tree/2.8">Symfony 2.8</a><br />
-  <a href="https://github.com/platformsh/platformsh-example-symfony/tree/3.0">Symfony 3.x</a><br />
+  <a href="https://github.com/platformsh/platformsh-example-symfony3">Symfony 3.x</a><br />
+  <a href="https://github.com/platformsh/template-symfony4">Symfony 4.x</a><br />
 </div>
 
 </section>

--- a/src/languages/php.md
+++ b/src/languages/php.md
@@ -94,5 +94,5 @@ A number of project templates for major PHP applications are available on GitHub
 
 * [Amp/Aerys](https://github.com/platformsh/platformsh-example-amphp)
 * [React PHP](https://github.com/platformsh/platformsh-example-reactphp)
-* [Symfony 2.8](https://github.com/platformsh/platformsh-example-symfony/tree/2.8)
-* [Symfony 3.x](https://github.com/platformsh/platformsh-example-symfony/tree/3.0)
+* [Symfony 3.x](https://github.com/platformsh/platformsh-example-symfony3)
+* [Symfony 4.x](https://github.com/platformsh/template-symfony4)


### PR DESCRIPTION
Find and replace says this is the last of them.

Also, Symfony 2 is no longer supported so let's not even bother linking to that repo.