### PR TITLE
Clarify parameters for the integration hook

### DIFF
--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -34,6 +34,18 @@ Open a terminal window (you need to have the Platform.sh CLI installed). Enable 
 ```bash
 platform integration:add --type=github --project=PROJECT_ID --token=GITHUB-USER-TOKEN --repository=USER/REPOSITORY
 ```
+where
+* `PROJECT_ID` is the project ID for your Platform.sh project
+* `GITHUB-USER-TOKEN` is the token you generated in step 1
+* `USER` is your github user name
+* `REPOSITORY` is the name of the repository in github (not the git address)
+
+Note that if your repository belongs to an organization, use ``--repository=ORGANIZATION/REPOSITORY``.
+
+e.g.
+```bash
+platform integration:add --type=github --project=abcde12345 --token=xxx --repository=platformsh/platformsh-docs
+```
 
 Optional parameters:
 * `--fetch-branches`: Track and deploy branches (true by default)
@@ -41,16 +53,15 @@ Optional parameters:
 * `--build-pull-requests-post-merge`: `false` to have Platform.sh build the branch specified in a PR. `true` to build the result of merging the PR.  (`false` by default)
 * `--pull-requests-clone-parent-data`: Set to `false` to disable cloning of parent environment data when creating a PR environment, so each PR environment starts with no data. (`true` by default)
 
-Note that if your repository belongs to an organization, use ``--repository=ORGANIZATION/REPOSITORY``.
+The CLI will create the necessary webhook for you when there's correct permission set in the given token. 
 
 ### 3. Add the webhook
 
-The CLI will create the necessary webhook for you when there's correct permission set in the given token. If you see the message `Failed to read or write webhooks`, you will need to add a webhook manually:
+If you see the message `Failed to read or write webhooks`, you will need to add a webhook manually:
 
 1. Copy the hook URL shown in the message.
 2. Go to your GitHub repository and click Settings, select the Webhooks and Services tab, and click Add webhook.
 3. Paste the hook URL, choose application/json for the content type, choose "Send me everything" for the events you want to receive, and click Add webhook.
-
 
 You can now start pushing code, creating new branches or opening pull requests directly on your GitHub repository.
 


### PR DESCRIPTION
Some customers have had issues with the hook because they made errors with the repository name. This clarifies parameters to help avoid that.