### PR TITLE
Change LE renewal schedule recommendation to twice a month.

### DIFF
--- a/src/configuration/routes/https.md
+++ b/src/configuration/routes/https.md
@@ -137,23 +137,23 @@ It is possible to set a variable from a cron task, which in turn will cause the 
 
 You will first need to install the CLI in your application container.  See the section on [API tokens](/gettingstarted/cli/api-tokens.md) for instructions on how to do so.
 
-Once the CLI is installed and an API token configured you can add a cron task to run once a month to trigger a redeploy.  For example:
+Once the CLI is installed and an API token configured you can add a cron task to run twice a month to trigger a redeploy.  For example:
 
 ```yaml
 crons:
     renewcert:
-        # Force a redeploy at 10 am (UTC) on the 3rd of every month.
-        spec: '0 10 3 * *'
+        # Force a redeploy at 10 am (UTC) on the 1st and 15th of every month.
+        spec: '0 10 1,15 * *'
         cmd: |
             if [ "$PLATFORM_BRANCH" = master ]; then
                 platform redeploy --yes --no-wait
             fi
 ```
 
-The above cron task will run on the 3rd of the month at 10 am (UTC), and, if the current environment is the master branch, it will run `platform redeploy` on the current project and environment.  The `--yes` flag will skip any user-interaction.  The `--no-wait` flag will cause the command to complete immediately rather than waiting for the redeploy to complete.  We recommend adjusting the cron schedule to whenever is off-peak time for your site, and to a random day within the month.
+The above cron task will run on the 1st and 15th of the month at 10 am (UTC), and, if the current environment is the master branch, it will run `platform redeploy` on the current project and environment.  The `--yes` flag will skip any user-interaction.  The `--no-wait` flag will cause the command to complete immediately rather than waiting for the redeploy to complete.  We recommend adjusting the cron schedule to whenever is off-peak time for your site, and to random days within the month.
 
 > **warning**
 >
 > It is very important to include the `--no-wait` flag.  If you do not, the cron process will block waiting on the deployment to finish, but the deployment will be blocked by the running cron task.  That will take your site offline until you log in and manually terminate the running cron task.  You want the `--no-wait` flag.  We're not joking.
 
-The certificate will not renew unless it has less than one month remaining, so forcing a deploy more than once a month is pointless.  As the redeploy does cause a momentary pause in service we recommend running during non-peak hours for your site.
+The certificate will not renew unless it has less than one month remaining; trying twice a month is sufficient to ensure a certificate is never less than 2 weeks from expiring.  As the redeploy does cause a momentary pause in service we recommend running during non-peak hours for your site.

--- a/src/golive/steps.md
+++ b/src/golive/steps.md
@@ -108,8 +108,8 @@ crons:
                 platform snapshot:create --yes --no-wait
             fi
     renewcert:
-        # Force a redeploy at 9 am (UTC) on the 14th of every month.
-        spec: '0 9 14 * *'
+        # Force a redeploy at 8 am (UTC) on the 14th and 28th of every month.
+        spec: '0 8 14,28 * *'
         cmd: |
             if [ "$PLATFORM_BRANCH" = master ]; then
                 platform redeploy --yes --no-wait


### PR DESCRIPTION
This eliminates a small window on the 31st of the month where the cert may be expired.