### PR TITLE
Gitlab integration - Clarified the --base-url option

### DIFF
--- a/src/administration/integrations/gitlab.md
+++ b/src/administration/integrations/gitlab.md
@@ -36,6 +36,9 @@ Open a terminal window (you need to have the Platform.sh CLI installed). Enable 
 platform integration:add --type=gitlab --token=THE-TOKEN-YOU-WROTE-DOWN --base-url=https://THE-URL-OF-YOUR-GITLAB/ --gitlab-project=MY-NAMESPACE/MY-PROJECTNAME
 ```
 
+Please note that the `--base-url` option is used as the base to call the Gitlab API; you should point it to `https://gitlab.com/` if your project is hosted on Gitlab, or the URL for your own Gitlab instance otherwise.
+Do **not** append your namespace and project name!
+
 Optional parameters:
 * `--fetch-branches`: Track and deploy branches (true by default)
 * `--build-merge-requests`: Track and deploy merge-requests (true by default)


### PR DESCRIPTION
Some users reported that it was confusing, so I thought that adding this little warning could not hurt.
Please let me know what you think!