### PR TITLE
Add warning to Postgres and Mongo pages about downgrades not being supported

### DIFF
--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -11,6 +11,10 @@ For more information on using MongoDB, see [MongoDB's own documentation](https:/
 * 3.4
 * 3.6
 
+> **note**
+>
+> Downgrades of MongoDB are not supported. MongoDB will update its own datafiles to a new version automatically but cannot downgrade them. If you want to experiment with a later version without committing to it use a non-master environment.
+
 ## Relationship
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md#platformsh-provided-variables):

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -12,7 +12,7 @@ See the [MariaDB documentation](https://mariadb.org/learn/) or [MySQL documentat
 
 > **note**
 >
-> Downgrades of MariaDB are not supported. MariaDB will update its own datafiles to a new version automatically but cannot downgrade them. If you want to experiment with a later version of MariaDB without committing to it use a non-master environment.
+> Downgrades of MariaDB are not supported. MariaDB will update its own datafiles to a new version automatically but cannot downgrade them. If you want to experiment with a later version without committing to it use a non-master environment.
 
 ### Deprecated versions
 

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -9,6 +9,10 @@ See the [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/static/in
 * 9.3
 * 9.6
 
+> **note**
+>
+> Downgrades of PostgreSQL are not supported. PostgreSQL will update its own datafiles to a new version automatically but cannot downgrade them. If you want to experiment with a later version without committing to it use a non-master environment.
+
 ## Relationship
 
 The format exposed in the ``$PLATFORM_RELATIONSHIPS`` [environment variable](/development/variables.md#platformsh-provided-variables):


### PR DESCRIPTION
Per customer suggestion.  We already do it for MySQL; we ought to do it everywhere.