### PR TITLE
Update the php extensions

### DIFF
--- a/src/languages/php/extensions.md
+++ b/src/languages/php/extensions.md
@@ -58,84 +58,109 @@ You can disable those by adding them to the `disabled_extensions` list.
 
 This is the complete list of extensions that can be enabled:
 
-| Extension    | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 |
-|--------------|-----|-----|-----|-----|-----|-----|
-| amqp         |     |     |     | *   | *   | *   |
-| apc          | *   |     |     |     |     |     |
-| apcu         |     | *   | *   | *   | *   | *   |
-| apcu_bc      |     |     |     | *   | *   | *   |
-| applepay     |     |     |     | *   | *   | *   |
-| blackfire    | *   | *   | *   | *   | *   | *   |
-| bcmath       |     |     |     | *   | *   | *   |
-| bz2          |     |     |     | *   | *   | *   |
-| curl         | *   | *   | *   | *   | *   | *   |
-| enchant      | *   | *   | *   | *   | *   | *   |
-| event        |     |     |     |     | *   | *   |
-| gd           | *   | *   | *   | *   | *   | *   |
-| gearman      | *   | *   | *   |     |     |     |
-| geoip        | *   | *   | *   | *   |     |     |
-| gmp          | *   | *   | *   | *   | *   | *   |
-| http         | *   | *   |     |     |     |     |
-| igbinary     |     |     |     | *   | *   | *   |
-| imagick      | *   | *   | *   | *   | *   | *   |
-| imap         | *   | *   | *   | *   | *   | *   |
-| interbase    | *   | *   | *   | *   | *   | *   |
-| intl         | *   | *   | *   | *   | *   | *   |
-| ioncube      |     |     |     | *   | *   |     |
-| json         |     |     | *   | *   | *   | *   |
-| ldap         | *   | *   | *   | *   | *   | *   |
-| mailparse    |     |     |     | *   | *   | *   |
-| mcrypt       | *   | *   | *   | *   | *   |     |
-| memcache     | *   | *   | *   |     |     |     |
-| memcached    | *   | *   | *   | *   | *   | *   |
-| mongo        | *   | *   | *   |     |     |     |
-| mongodb      |     |     |     | *   | *   | *   |
-| msgpack      |     |     | *   | *   | *   | *   |
-| mssql        | *   | *   | *   |     |     |     |
-| mysql        | *   | *   | *   |     |     |     |
-| mysqli       | *   | *   | *   | *   | *   | *   |
-| mysqlnd      | *   | *   | *   |     |     |     |
-| newrelic     |     |     | *   | *   | *   | *   |
-| oauth        |     |     |     | *   | *   | *   |
-| odbc         | *   | *   | *   | *   | *   | *   |
-| opcache      |     | *   | *   | *   | *   | *   |
-| openssl      |     |     |     |     |     |     |
-| pdo          | *   | *   | *   | *   | *   | *   |
-| pdo_dblib    | *   | *   | *   | *   | *   | *   |
-| pdo_firebird | *   | *   | *   | *   | *   | *   |
-| pdo_mysql    | *   | *   | *   | *   | *   | *   |
-| pdo_odbc     | *   | *   | *   | *   | *   | *   |
-| pdo_pgsql    | *   | *   | *   | *   | *   | *   |
-| pdo_sqlite   | *   | *   | *   | *   | *   | *   |
-| pdo_sqlsrv   | *   | *   | *   | *   |     |     |
-| pecl-http    |     |     | *   |     |     |     |
-| pgsql        | *   | *   | *   | *   | *   | *   |
-| pinba        | *   | *   | *   |     |     |     |
-| propro       |     |     | *   |     |     |     |
-| pspell       | *   | *   | *   | *   | *   | *   |
-| pthreads     |     |     |     |     | *   | *   |
-| raphf        |     |     | *   |     |     |     |
-| readline     | *   | *   | *   | *   | *   | *   |
-| recode       | *   | *   | *   | *   | *   | *   |
-| redis        | *   | *   | *   | *   | *   | *   |
-| snmp         | *   | *   | *   | *   | *   | *   |
-| sockets      |     |     | *   | *   |     |     |
-| sodium       |     |     |     |     |     | *   |
-| spplus       | *   | *   |     |     |     |     |
-| sqlite3      | *   | *   | *   | *   | *   | *   |
-| sqlsrv       | *   | *   | *   | *   |     |     |
-| ssh2         | *   | *   | *   |     | *   | *   |
-| tideways     |     |     |     | *   | *   | *   |
-| tidy         | *   | *   | *   | *   | *   | *   |
-| uuid         |     |     |     |     | *   | *   |
-| xcache       | *   | *   |     |     |     |     |
-| xdebug       | *   | *   | *   | *   | *   | *   |
-| xhprof       | *   | *   | *   |     |     |     |
-| xmlrpc       | *   | *   | *   | *   | *   | *   |
-| xml          | *   | *   | *   | *   | *   | *   |
-| yaml         |     |     |     |     | *   | *   |
-| zbarcode     |     |     |     | *   | *   | *   |
-| zendopcache  | *   |     |     |     |     |     |
+| Extension     | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 |
+|---------------|-----|-----|-----|-----|-----|-----|
+| amqp          |     |     |     | *   | *   | *   |
+| apc           | *   | *   |     |     |     |     |
+| apcu          | *   |     | *   | *   | *   | *   |
+| apcu_bc       |     |     |     | *   | *   | *   |
+| applepay      |     |     |     | *   | *   |     |
+| bcmath        |     |     |     | *   | *   | *   |
+| blackfire     | *   | *   | *   | *   |     |     |
+| bz2           |     |     |     | *   | *   | *   |
+| calendar      |     |     |     | *   | *   | *   |
+| ctype         |     |     |     | *   | *   | *   |
+| curl          | *   | *   | *   | *   | *   | *   |
+| dba           |     |     |     | *   | *   | *   |
+| dom           |     |     |     | *   | *   | *   |
+| enchant       | *   | *   | *   | *   | *   | *   |
+| event         |     |     |     |     | *   | *   |
+| exif          |     |     |     | *   | *   | *   |
+| fileinfo      |     |     |     | *   | *   | *   |
+| ftp           |     |     |     | *   | *   | *   |
+| gd            | *   | *   | *   | *   | *   | *   |
+| gearman       | *   | *   | *   |     |     |     |
+| geoip         | *   | *   | *   | *   | *   | *   |
+| gettext       |     |     |     | *   | *   | *   |
+| gmp           | *   | *   | *   | *   | *   | *   |
+| http          | *   | *   |     |     |     |     |
+| iconv         |     |     |     | *   | *   | *   |
+| igbinary      |     |     |     | *   | *   | *   |
+| imagick       | *   | *   | *   | *   | *   | *   |
+| imap          | *   | *   | *   | *   | *   | *   |
+| interbase     | *   | *   | *   | *   | *   | *   |
+| intl          | *   | *   | *   | *   | *   | *   |
+| ioncube       |     |     |     | *   | *   |     |
+| json          |     |     | *   | *   | *   | *   |
+| ldap          | *   | *   | *   | *   | *   | *   |
+| mailparse     |     |     |     | *   | *   | *   |
+| mbstring      |     |     |     | *   | *   | *   |
+| mcrypt        | *   | *   | *   | *   | *   |     |
+| memcache      | *   | *   | *   |     |     |     |
+| memcached     | *   | *   | *   | *   | *   | *   |
+| mongo         | *   | *   | *   |     |     |     |
+| mongodb       |     |     |     | *   | *   | *   |
+| msgpack       |     |     | *   | *   | *   | *   |
+| mssql         | *   | *   | *   |     |     |     |
+| mysql         | *   | *   | *   |     |     |     |
+| mysqli        | *   | *   | *   | *   | *   | *   |
+| mysqlnd       | *   | *   | *   | *   | *   | *   |
+| newrelic      |     |     | *   | *   |     |     |
+| oauth         |     |     |     | *   | *   | *   |
+| odbc          | *   | *   | *   | *   | *   | *   |
+| opcache       |     | *   | *   | *   | *   | *   |
+| openssl       |     |     |     |     |     |     |
+| pdo           | *   | *   | *   | *   | *   | *   |
+| pdo_dblib     | *   | *   | *   | *   | *   | *   |
+| pdo_firebird  | *   | *   | *   | *   | *   | *   |
+| pdo_mysql     | *   | *   | *   | *   | *   | *   |
+| pdo_odbc      | *   | *   | *   | *   | *   | *   |
+| pdo_pgsql     | *   | *   | *   | *   | *   | *   |
+| pdo_sqlite    | *   | *   | *   | *   | *   | *   |
+| pdo_sqlsrv    |     |     |     | *   | *   | *   |
+| pecl-http     |     |     | *   |     |     |     |
+| pgsql         | *   | *   | *   | *   | *   | *   |
+| phar          |     |     |     | *   | *   | *   |
+| pinba         | *   | *   | *   |     |     |     |
+| posix         |     |     |     | *   | *   | *   |
+| propro        |     |     | *   |     |     |     |
+| pspell        | *   | *   | *   | *   | *   | *   |
+| pthreads      |     |     |     |     | *   | *   |
+| raphf         |     |     | *   |     |     |     |
+| readline      | *   | *   | *   | *   | *   | *   |
+| recode        | *   | *   | *   | *   | *   | *   |
+| redis         | *   | *   | *   | *   | *   | *   |
+| shmop         |     |     |     | *   | *   | *   |
+| simplexml     |     |     |     | *   | *   | *   |
+| snmp          | *   | *   | *   | *   | *   | *   |
+| soap          |     |     |     | *   | *   | *   |
+| sockets       |     |     |     | *   | *   | *   |
+| sodium        |     |     |     |     |     | *   |
+| sourceguardian|     |     |     | *   | *   |     |
+| spplus        | *   | *   |     |     |     |     |
+| sqlite3       | *   | *   | *   | *   | *   | *   |
+| sqlsrv        |     |     |     | *   | *   | *   |
+| ssh2          | *   | *   | *   | *   | *   | *   |
+| sysvmsg       |     |     |     | *   | *   | *   |
+| sysvsem       |     |     |     | *   | *   | *   |
+| sysvshm       |     |     |     | *   | *   | *   |
+| tideways      |     |     |     | *   | *   | *   |
+| tidy          | *   | *   | *   | *   | *   | *   |
+| tokenizer     |     |     |     | *   | *   | *   |
+| uuid          |     |     |     |     | *   | *   |
+| wddx          |     |     |     | *   | *   | *   |
+| xcache        | *   | *   |     |     |     |     |
+| xdebug        | *   | *   | *   | *   | *   | *   |
+| xhprof        | *   | *   | *   |     |     |     |
+| xml           |     |     |     | *   | *   | *   |
+| xmlreader     |     |     |     | *   | *   | *   |
+| xmlrpc        | *   | *   | *   | *   | *   | *   |
+| xmlwriter     |     |     |     | *   | *   | *   |
+| xsl           | *   | *   | *   | *   | *   | *   |
+| yaml          |     |     |     |     | *   | *   |
+| zbarcode      |     |     |     | *   | *   | *   |
+| zendopcache   | *   |     |     |     |     |     |
+| zip           |     |     |     | *   | *   | *   |
 
 > **note**
 > You can check out the output of `ls /etc/php5/mods-available` to


### PR DESCRIPTION
Update of the list of supported extensions. By supported is intended:
- Can be added in the `.platform.app.yaml`
- Can be loaded from the PHP application (tested via `extension_loaded()` PHP assert)

I did not made distinction between built-in extensions and the others.