### PR TITLE
Fix read repository scope name

### DIFF
--- a/src/administration/integrations/gitlab.md
+++ b/src/administration/integrations/gitlab.md
@@ -20,7 +20,7 @@ Give it a description and then ensure the token has the following scopes:
 
  * `api`  - Access your API
  * `read_user` - Read user information
- * `read_registry` - Read Registry
+ * `read_repository` - Read repositories
 
 Copy the token and make a note of it (temporarily).
 


### PR DESCRIPTION
While I set up a new GitLab integration for a customer, I saw that the scope key for git repositories read access was wrong.

Double-checked on our GitLab instance and fixed the key in the documentation.