### PR TITLE
Clarify pagerduty notification setup

### DIFF
--- a/src/administration/integrations/notifications.md
+++ b/src/administration/integrations/notifications.md
@@ -48,7 +48,7 @@ That will trigger the corresponding bot to post a notification to the `#channeln
 
 ### PagerDuty notifications
 
-A notification can trigger a message to be sent via PagerDuty, if you are using that service.  First, create a new PagerDuty "[integration](https://www.pagerduty.com/integrations/)" using the v2 API.  Copy the routing key it provides.
+A notification can trigger a message to be sent via PagerDuty, if you are using that service.  First, create a new PagerDuty "[integration](https://support.pagerduty.com/docs/services-and-integrations)" that uses the Events API v2.  Copy the "Integration Key" as known as the "routing key" for the integration.
 
 Now register a `health.pagerduty` integration as follows:
 


### PR DESCRIPTION
We use the Events API v2[1] to send notification, let's clarify what is the required "routing key".

[1]: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2