### PR TITLE
Update references to Python 3

### DIFF
--- a/src/configuration/app/workers.md
+++ b/src/configuration/app/workers.md
@@ -155,7 +155,7 @@ For example, consider this `.platform.app.yaml`:
 ```yaml
 name: app
 
-type: "python:3.6"
+type: "python:3.7"
 
 disk: 2048
 
@@ -223,7 +223,7 @@ workers:
             emails: 'rabbitqueue:rabbitmq'
 ```
 
-There's a lot going on here, but it's all reasonably straightforward.  This configuration will take a single Python 3.6 code base from your repository, download all dependencies in `requirements.txt`, and the install Gunicorn.  That artifact (your code plus the downloaded dependencies) will be deployed as three separate container instances, all running Python 3.6.
+There's a lot going on here, but it's all reasonably straightforward.  This configuration will take a single Python 3.7 code base from your repository, download all dependencies in `requirements.txt`, and the install Gunicorn.  That artifact (your code plus the downloaded dependencies) will be deployed as three separate container instances, all running Python 3.7.
 
 The `web` instance will start a gunicorn process to serve a web application.  
 

--- a/src/languages/python.md
+++ b/src/languages/python.md
@@ -176,7 +176,7 @@ relationships = json.loads(str(base64.b64decode(relationships), 'utf-8'))
 A number of project templates for Python applications are available on GitHub.  Not all of them are proactively maintained but all can be used as a starting point or reference for building your own website or web application.
 
 * [Starter kit Python 2.7 minimal example](https://github.com/platformsh/platformsh-example-python-2.7)
-* [Starter kit Python 3.6 minimal example](https://github.com/platformsh/platformsh-example-python-3.6)
+* [Starter kit Python 3 minimal example](https://github.com/platformsh/platformsh-example-python-3)
 * [Starter kit Python with uwsgi](https://github.com/platformsh/platformsh-example-python-uwsgi)
 * [Starter kit Python and Elastic Search](https://github.com/platformsh/platformsh-example-python-elasticsearch)
 * [Starter kit Django project](https://github.com/platformsh/platformsh-example-django)

--- a/src/overview/structure.md
+++ b/src/overview/structure.md
@@ -47,6 +47,6 @@ There may be zero or more Service containers in a cluster, depending on the `ser
 
 There always must be one Application container in a cluster, but there may be more.
 
-Each Application container corresponds to a `.platform.app.yaml` file in the repository.  If there are 3 `.platform.app.yaml` files, there will be three Application containers.  Application containers hold the code you provide via your Git repository.  Application containers are always built off of one of the Platform.sh-provided language-specific images, such as “PHP 5.6”, “PHP 7.2”, or “Python 3.6”. It is also possible to have multiple Application containers running different languages or versions.
+Each Application container corresponds to a `.platform.app.yaml` file in the repository.  If there are 3 `.platform.app.yaml` files, there will be three Application containers.  Application containers hold the code you provide via your Git repository.  Application containers are always built off of one of the Platform.sh-provided language-specific images, such as “PHP 5.6”, “PHP 7.2”, or “Python 3.7”. It is also possible to have multiple Application containers running different languages or versions.
 
 For typical applications, there is only one `.platform.app.yaml` file, which is generally placed at the repository root.


### PR DESCRIPTION
The latest available Python version is now 3.7, update all the references, including the new GitHub repository name of the example.