### PR TITLE
Note SimpleSAML cookie whitelisting

### DIFF
--- a/src/frameworks/drupal8/simplesaml.md
+++ b/src/frameworks/drupal8/simplesaml.md
@@ -14,6 +14,21 @@ composer require simplesamlphp/simplesamlphp drupal/simplesamlphp_auth
 
 Once that's run, commit both `composer.json` and `composer.lock` to your repository.
 
+## Include SimpleSAML cookies in the cache key
+
+The SimpleSAML client uses additional cookies besides the Drupal session cookie that need to be whitelisted for the cache.  To do so, modify your `routes.yaml` file for the route that points to your Drupal site and add two additional cookies to the `cache.cookies` line.  It should end up looking approximately like this:
+
+```yaml
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+      enabled: true
+      cookies: ['/^SS?ESS/', '/^Drupal.visitor/', 'SimpleSAMLSessionID', 'SimpleSAMLAuthToken']
+```
+
+Commit this change to the Git repository.
+
 ## Expose the SimpleSAML endpoint
 
 The SimpleSAML library's `www` directory needs to be publicly accessible.  That can be done by mapping it directly to a path in the Application configuration.  Add the following block to the `web.locations` section of `.platform.app.yaml`:

--- a/src/frameworks/drupal8/simplesaml.md
+++ b/src/frameworks/drupal8/simplesaml.md
@@ -6,7 +6,7 @@ The following configuration assumes you are building Drupal 8 using Composer.  I
 
 ## Download the library and Drupal module
 
-The easiest way to download SimpleSAMLphp is via Composer.  The following lines will add both the Drupal module and the PHP library to your `composer.json` file.
+The easiest way to download SimpleSAMLphp is via Composer.  The following command will add both the Drupal module and the PHP library to your `composer.json` file.
 
 ```bash
 composer require simplesamlphp/simplesamlphp drupal/simplesamlphp_auth


### PR DESCRIPTION
Resolves #965 

@Berdir Is this section needed under Drupal 7 as well, or does the SAML library there not need it?  I'm not aware of any bugs or issues with the current D7 docs but that doesn't prove anything conclusively. :smile: 