### PR TITLE
clarify usage of --prune-branches

### DIFF
--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -49,12 +49,14 @@ platform integration:add --type=github --project=abcde12345 --token=xxx --reposi
 
 Optional parameters:
 * `--fetch-branches`: Track and deploy branches (true by default)
-* `--prune-branches`: Delete branches that do not exist in the remote GitHub repository (true by default, requires --fetch-branches set to true to enable)
+* `--prune-branches`: Delete branches that do not exist in the remote GitHub repository (true by default)
 * `--build-pull-requests`: Track and deploy pull-requests (true by default)
 * `--build-pull-requests-post-merge`: `false` to have Platform.sh build the branch specified in a PR. `true` to build the result of merging the PR.  (`false` by default)
 * `--pull-requests-clone-parent-data`: Set to `false` to disable cloning of parent environment data when creating a PR environment, so each PR environment starts with no data. (`true` by default)
 
-The CLI will create the necessary webhook for you when there's correct permission set in the given token. 
+The CLI will create the necessary webhook for you when there's correct permission set in the given token.
+
+Note that the `--prune-branches` option depends on `--fetch-branches` being enabled.  If `--fetch-branches` is disabled, `--prune-branches` will automatically be set to false, even if specifically set to true.
 
 ### 3. Add the webhook
 

--- a/src/administration/integrations/github.md
+++ b/src/administration/integrations/github.md
@@ -49,7 +49,7 @@ platform integration:add --type=github --project=abcde12345 --token=xxx --reposi
 
 Optional parameters:
 * `--fetch-branches`: Track and deploy branches (true by default)
-* `--prune-branches`: Delete branches that do not exist in the remote GitHub repository (true by default)
+* `--prune-branches`: Delete branches that do not exist in the remote GitHub repository (true by default, requires --fetch-branches set to true to enable)
 * `--build-pull-requests`: Track and deploy pull-requests (true by default)
 * `--build-pull-requests-post-merge`: `false` to have Platform.sh build the branch specified in a PR. `true` to build the result of merging the PR.  (`false` by default)
 * `--pull-requests-clone-parent-data`: Set to `false` to disable cloning of parent environment data when creating a PR environment, so each PR environment starts with no data. (`true` by default)

--- a/src/administration/integrations/gitlab.md
+++ b/src/administration/integrations/gitlab.md
@@ -43,7 +43,10 @@ Optional parameters:
 * `--build-merge-requests`: Track and deploy merge-requests (true by default)
 * `--merge-requests-clone-parent-data` : should merge requests clone the data from the parent environment (true by default)
 * `--fetch-branches`: Track and deploy branches (true by default)
-* `--prune-branches`: Delete branches that do not exist in the remote GitLab repository (true by default, requires --fetch-branches set to true to enable)
+* `--prune-branches`: Delete branches that do not exist in the remote GitLab repository (true by default)
+
+
+Note that the `--prune-branches` option depends on `--fetch-branches` being enabled.  If `--fetch-branches` is disabled, `--prune-branches` will automatically be set to false, even if specifically set to true.
 
 ### 3. Add the webhook
 

--- a/src/administration/integrations/gitlab.md
+++ b/src/administration/integrations/gitlab.md
@@ -43,7 +43,7 @@ Optional parameters:
 * `--build-merge-requests`: Track and deploy merge-requests (true by default)
 * `--merge-requests-clone-parent-data` : should merge requests clone the data from the parent environment (true by default)
 * `--fetch-branches`: Track and deploy branches (true by default)
-* `--prune-branches`: Delete branches that do not exist in the remote GitLab repository (true by default)
+* `--prune-branches`: Delete branches that do not exist in the remote GitLab repository (true by default, requires --fetch-branches set to true to enable)
 
 ### 3. Add the webhook
 


### PR DESCRIPTION
prune requires fetch

```
sandbox/ $ platform integration:update  qe33ucjhqbtl2 --prune-branches true
Integration qe33ucjhqbtl2 (github) updated
Checking webhook configuration on the repository: alustenberg/psh_sandbox
  Valid configuration found
....
| fetch_branches                  | true 
| prune_branches                  | true
...

sandbox/ $ platform integration:update  qe33ucjhqbtl2 --fetch-branches false
Integration qe33ucjhqbtl2 (github) updated
Checking webhook configuration on the repository: alustenberg/psh_sandbox
  Valid configuration found
...
| fetch_branches                  | false
| prune_branches                  | false 
```