### PR TITLE
Updating snapshot outage time to current standard

### DIFF
--- a/src/administration/snapshot-and-restore.md
+++ b/src/administration/snapshot-and-restore.md
@@ -18,7 +18,7 @@ Using the CLI:
 $ platform snapshot:create
 ```
 
-Please be aware that triggering a snapshot will cause a momentary pause in site availability so that all requests can complete, allowing the snapshot to be taken against a known consistent state.  The total interruption is usually only 1-2 seconds and any requests during that time are held temporarily, not dropped.
+Please be aware that triggering a snapshot will cause a momentary pause in site availability so that all requests can complete, allowing the snapshot to be taken against a known consistent state.  The total interruption is usually only 15 to 30 seconds and any requests during that time are held temporarily, not dropped.
 
 ## Restore
 


### PR DESCRIPTION
Most snapshots those days takes a minimum of 15 seconds and may take up to 30 seconds as opposed to 1 to 2 seconds.