### PR TITLE
Add PHP 7.3 extension list.

### DIFF
--- a/src/languages/php/extensions.md
+++ b/src/languages/php/extensions.md
@@ -60,7 +60,7 @@ This is the complete list of extensions that can be enabled:
 
 | Extension     | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 |
 |---------------|-----|-----|-----|-----|-----|-----|-----|
-| amqp          |     |     |     | *   | *   | *   | *   |
+| amqp          |     |     |     | *   | *   | *   |     |
 | apc           | *   | *   |     |     |     |     |     |
 | apcu          | *   |     | *   | *   | *   | *   | *   |
 | apcu_bc       |     |     |     | *   | *   | *   | *   |
@@ -90,17 +90,17 @@ This is the complete list of extensions that can be enabled:
 | imap          | *   | *   | *   | *   | *   | *   | *   |
 | interbase     | *   | *   | *   | *   | *   | *   | *   |
 | intl          | *   | *   | *   | *   | *   | *   | *   |
-| ioncube       |     |     |     | *   | *   |     |     |
+| ioncube       |     |     |     | *   | *   | *   |     |
 | json          |     |     | *   | *   | *   | *   | *   |
 | ldap          | *   | *   | *   | *   | *   | *   | *   |
-| mailparse     |     |     |     | *   | *   | *   | *   |
+| mailparse     |     |     |     | *   | *   | *   |     |
 | mbstring      |     |     |     | *   | *   | *   | *   |
 | mcrypt        | *   | *   | *   | *   | *   |     |     |
 | memcache      | *   | *   | *   |     |     |     |     |
 | memcached     | *   | *   | *   | *   | *   | *   |     |
 | mongo         | *   | *   | *   |     |     |     |     |
 | mongodb       |     |     |     | *   | *   | *   | *   |
-| msgpack       |     |     | *   | *   | *   | *   | *   |
+| msgpack       |     |     | *   | *   | *   | *   |     |
 | mssql         | *   | *   | *   |     |     |     |     |
 | mysql         | *   | *   | *   |     |     |     |     |
 | mysqli        | *   | *   | *   | *   | *   | *   | *   |
@@ -117,7 +117,7 @@ This is the complete list of extensions that can be enabled:
 | pdo_odbc      | *   | *   | *   | *   | *   | *   | *   |
 | pdo_pgsql     | *   | *   | *   | *   | *   | *   | *   |
 | pdo_sqlite    | *   | *   | *   | *   | *   | *   | *   |
-| pdo_sqlsrv    |     |     |     | *   | *   | *   | *   |
+| pdo_sqlsrv    |     |     |     | *   | *   | *   |     |
 | http          |     |     | *   |     |     |     |     |
 | pgsql         | *   | *   | *   | *   | *   | *   | *   |
 | phar          |     |     |     | *   | *   | *   | *   |
@@ -125,7 +125,7 @@ This is the complete list of extensions that can be enabled:
 | posix         |     |     |     | *   | *   | *   | *   |
 | propro        |     |     | *   |     |     |     |     |
 | pspell        | *   | *   | *   | *   | *   | *   | *   |
-| pthreads      |     |     |     |     | *   | *   | *   |
+| pthreads      |     |     |     |     | *   | *   |     |
 | raphf         |     |     | *   |     |     |     |     |
 | readline      | *   | *   | *   | *   | *   | *   | *   |
 | recode        | *   | *   | *   | *   | *   | *   | *   |
@@ -139,18 +139,18 @@ This is the complete list of extensions that can be enabled:
 | sourceguardian|     |     |     | *   | *   |     |     |
 | spplus        | *   | *   |     |     |     |     |     |
 | sqlite3       | *   | *   | *   | *   | *   | *   | *   |
-| sqlsrv        |     |     |     | *   | *   | *   | *   |
+| sqlsrv        |     |     |     | *   | *   | *   |     |
 | ssh2          | *   | *   | *   | *   | *   | *   | *   |
 | sysvmsg       |     |     |     | *   | *   | *   | *   |
 | sysvsem       |     |     |     | *   | *   | *   | *   |
 | sysvshm       |     |     |     | *   | *   | *   | *   |
-| tideways      |     |     |     | *   | *   | *   | *   |
+| tideways      |     |     |     | *   | *   | *   |     |
 | tidy          | *   | *   | *   | *   | *   | *   | *   |
 | tokenizer     |     |     |     | *   | *   | *   | *   |
 | uuid          |     |     |     |     | *   | *   | *   |
 | wddx          |     |     |     | *   | *   | *   | *   |
 | xcache        | *   | *   |     |     |     |     |     |
-| xdebug        | *   | *   | *   | *   | *   | *   | *   |
+| xdebug        | *   | *   | *   | *   | *   | *   |     |
 | xhprof        | *   | *   | *   |     |     |     |     |
 | xml           |     |     |     | *   | *   | *   | *   |
 | xmlreader     |     |     |     | *   | *   | *   | *   |

--- a/src/languages/php/extensions.md
+++ b/src/languages/php/extensions.md
@@ -58,109 +58,109 @@ You can disable those by adding them to the `disabled_extensions` list.
 
 This is the complete list of extensions that can be enabled:
 
-| Extension     | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 |
-|---------------|-----|-----|-----|-----|-----|-----|
-| amqp          |     |     |     | *   | *   | *   |
-| apc           | *   | *   |     |     |     |     |
-| apcu          | *   |     | *   | *   | *   | *   |
-| apcu_bc       |     |     |     | *   | *   | *   |
-| applepay      |     |     |     | *   | *   |     |
-| bcmath        |     |     |     | *   | *   | *   |
-| blackfire     | *   | *   | *   | *   | *   | *   |
-| bz2           |     |     |     | *   | *   | *   |
-| calendar      |     |     |     | *   | *   | *   |
-| ctype         |     |     |     | *   | *   | *   |
-| curl          | *   | *   | *   | *   | *   | *   |
-| dba           |     |     |     | *   | *   | *   |
-| dom           |     |     |     | *   | *   | *   |
-| enchant       | *   | *   | *   | *   | *   | *   |
-| event         |     |     |     |     | *   | *   |
-| exif          |     |     |     | *   | *   | *   |
-| fileinfo      |     |     |     | *   | *   | *   |
-| ftp           |     |     |     | *   | *   | *   |
-| gd            | *   | *   | *   | *   | *   | *   |
-| gearman       | *   | *   | *   |     |     |     |
-| geoip         | *   | *   | *   | *   | *   | *   |
-| gettext       |     |     |     | *   | *   | *   |
-| gmp           | *   | *   | *   | *   | *   | *   |
-| http          | *   | *   |     |     |     |     |
-| iconv         |     |     |     | *   | *   | *   |
-| igbinary      |     |     |     | *   | *   | *   |
-| imagick       | *   | *   | *   | *   | *   | *   |
-| imap          | *   | *   | *   | *   | *   | *   |
-| interbase     | *   | *   | *   | *   | *   | *   |
-| intl          | *   | *   | *   | *   | *   | *   |
-| ioncube       |     |     |     | *   | *   |     |
-| json          |     |     | *   | *   | *   | *   |
-| ldap          | *   | *   | *   | *   | *   | *   |
-| mailparse     |     |     |     | *   | *   | *   |
-| mbstring      |     |     |     | *   | *   | *   |
-| mcrypt        | *   | *   | *   | *   | *   |     |
-| memcache      | *   | *   | *   |     |     |     |
-| memcached     | *   | *   | *   | *   | *   | *   |
-| mongo         | *   | *   | *   |     |     |     |
-| mongodb       |     |     |     | *   | *   | *   |
-| msgpack       |     |     | *   | *   | *   | *   |
-| mssql         | *   | *   | *   |     |     |     |
-| mysql         | *   | *   | *   |     |     |     |
-| mysqli        | *   | *   | *   | *   | *   | *   |
-| mysqlnd       | *   | *   | *   | *   | *   | *   |
-| newrelic      |     |     | *   | *   |     |     |
-| oauth         |     |     |     | *   | *   | *   |
-| odbc          | *   | *   | *   | *   | *   | *   |
-| opcache       |     | *   | *   | *   | *   | *   |
-| openssl       |     |     |     |     |     |     |
-| pdo           | *   | *   | *   | *   | *   | *   |
-| pdo_dblib     | *   | *   | *   | *   | *   | *   |
-| pdo_firebird  | *   | *   | *   | *   | *   | *   |
-| pdo_mysql     | *   | *   | *   | *   | *   | *   |
-| pdo_odbc      | *   | *   | *   | *   | *   | *   |
-| pdo_pgsql     | *   | *   | *   | *   | *   | *   |
-| pdo_sqlite    | *   | *   | *   | *   | *   | *   |
-| pdo_sqlsrv    |     |     |     | *   | *   | *   |
-| http          |     |     | *   |     |     |     |
-| pgsql         | *   | *   | *   | *   | *   | *   |
-| phar          |     |     |     | *   | *   | *   |
-| pinba         | *   | *   | *   |     |     |     |
-| posix         |     |     |     | *   | *   | *   |
-| propro        |     |     | *   |     |     |     |
-| pspell        | *   | *   | *   | *   | *   | *   |
-| pthreads      |     |     |     |     | *   | *   |
-| raphf         |     |     | *   |     |     |     |
-| readline      | *   | *   | *   | *   | *   | *   |
-| recode        | *   | *   | *   | *   | *   | *   |
-| redis         | *   | *   | *   | *   | *   | *   |
-| shmop         |     |     |     | *   | *   | *   |
-| simplexml     |     |     |     | *   | *   | *   |
-| snmp          | *   | *   | *   | *   | *   | *   |
-| soap          |     |     |     | *   | *   | *   |
-| sockets       |     |     |     | *   | *   | *   |
-| sodium        |     |     |     |     |     | *   |
-| sourceguardian|     |     |     | *   | *   |     |
-| spplus        | *   | *   |     |     |     |     |
-| sqlite3       | *   | *   | *   | *   | *   | *   |
-| sqlsrv        |     |     |     | *   | *   | *   |
-| ssh2          | *   | *   | *   | *   | *   | *   |
-| sysvmsg       |     |     |     | *   | *   | *   |
-| sysvsem       |     |     |     | *   | *   | *   |
-| sysvshm       |     |     |     | *   | *   | *   |
-| tideways      |     |     |     | *   | *   | *   |
-| tidy          | *   | *   | *   | *   | *   | *   |
-| tokenizer     |     |     |     | *   | *   | *   |
-| uuid          |     |     |     |     | *   | *   |
-| wddx          |     |     |     | *   | *   | *   |
-| xcache        | *   | *   |     |     |     |     |
-| xdebug        | *   | *   | *   | *   | *   | *   |
-| xhprof        | *   | *   | *   |     |     |     |
-| xml           |     |     |     | *   | *   | *   |
-| xmlreader     |     |     |     | *   | *   | *   |
-| xmlrpc        | *   | *   | *   | *   | *   | *   |
-| xmlwriter     |     |     |     | *   | *   | *   |
-| xsl           | *   | *   | *   | *   | *   | *   |
-| yaml          |     |     |     |     | *   | *   |
-| zbarcode      |     |     |     | *   | *   | *   |
-| zendopcache   | *   |     |     |     |     |     |
-| zip           |     |     |     | *   | *   | *   |
+| Extension     | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 |
+|---------------|-----|-----|-----|-----|-----|-----|-----|
+| amqp          |     |     |     | *   | *   | *   | *   |
+| apc           | *   | *   |     |     |     |     |     |
+| apcu          | *   |     | *   | *   | *   | *   | *   |
+| apcu_bc       |     |     |     | *   | *   | *   | *   |
+| applepay      |     |     |     | *   | *   |     |     |
+| bcmath        |     |     |     | *   | *   | *   | *   |
+| blackfire     | *   | *   | *   | *   | *   | *   | *   |
+| bz2           |     |     |     | *   | *   | *   | *   |
+| calendar      |     |     |     | *   | *   | *   | *   |
+| ctype         |     |     |     | *   | *   | *   | *   |
+| curl          | *   | *   | *   | *   | *   | *   | *   |
+| dba           |     |     |     | *   | *   | *   | *   |
+| dom           |     |     |     | *   | *   | *   | *   |
+| enchant       | *   | *   | *   | *   | *   | *   | *   |
+| event         |     |     |     |     | *   | *   | *   |
+| exif          |     |     |     | *   | *   | *   | *   |
+| fileinfo      |     |     |     | *   | *   | *   | *   |
+| ftp           |     |     |     | *   | *   | *   | *   |
+| gd            | *   | *   | *   | *   | *   | *   | *   |
+| gearman       | *   | *   | *   |     |     |     |     |
+| geoip         | *   | *   | *   | *   | *   | *   | *   |
+| gettext       |     |     |     | *   | *   | *   | *   |
+| gmp           | *   | *   | *   | *   | *   | *   | *   |
+| http          | *   | *   |     |     |     |     |     |
+| iconv         |     |     |     | *   | *   | *   | *   |
+| igbinary      |     |     |     | *   | *   | *   | *   |
+| imagick       | *   | *   | *   | *   | *   | *   | *   |
+| imap          | *   | *   | *   | *   | *   | *   | *   |
+| interbase     | *   | *   | *   | *   | *   | *   | *   |
+| intl          | *   | *   | *   | *   | *   | *   | *   |
+| ioncube       |     |     |     | *   | *   |     |     |
+| json          |     |     | *   | *   | *   | *   | *   |
+| ldap          | *   | *   | *   | *   | *   | *   | *   |
+| mailparse     |     |     |     | *   | *   | *   | *   |
+| mbstring      |     |     |     | *   | *   | *   | *   |
+| mcrypt        | *   | *   | *   | *   | *   |     |     |
+| memcache      | *   | *   | *   |     |     |     |     |
+| memcached     | *   | *   | *   | *   | *   | *   |     |
+| mongo         | *   | *   | *   |     |     |     |     |
+| mongodb       |     |     |     | *   | *   | *   | *   |
+| msgpack       |     |     | *   | *   | *   | *   | *   |
+| mssql         | *   | *   | *   |     |     |     |     |
+| mysql         | *   | *   | *   |     |     |     |     |
+| mysqli        | *   | *   | *   | *   | *   | *   | *   |
+| mysqlnd       | *   | *   | *   | *   | *   | *   | *   |
+| newrelic      |     |     | *   | *   |     |     |     |
+| oauth         |     |     |     | *   | *   | *   | *   |
+| odbc          | *   | *   | *   | *   | *   | *   | *   |
+| opcache       |     | *   | *   | *   | *   | *   | *   |
+| openssl       |     |     |     |     |     |     |     |
+| pdo           | *   | *   | *   | *   | *   | *   | *   |
+| pdo_dblib     | *   | *   | *   | *   | *   | *   | *   |
+| pdo_firebird  | *   | *   | *   | *   | *   | *   | *   |
+| pdo_mysql     | *   | *   | *   | *   | *   | *   | *   |
+| pdo_odbc      | *   | *   | *   | *   | *   | *   | *   |
+| pdo_pgsql     | *   | *   | *   | *   | *   | *   | *   |
+| pdo_sqlite    | *   | *   | *   | *   | *   | *   | *   |
+| pdo_sqlsrv    |     |     |     | *   | *   | *   | *   |
+| http          |     |     | *   |     |     |     |     |
+| pgsql         | *   | *   | *   | *   | *   | *   | *   |
+| phar          |     |     |     | *   | *   | *   | *   |
+| pinba         | *   | *   | *   |     |     |     |     |
+| posix         |     |     |     | *   | *   | *   | *   |
+| propro        |     |     | *   |     |     |     |     |
+| pspell        | *   | *   | *   | *   | *   | *   | *   |
+| pthreads      |     |     |     |     | *   | *   | *   |
+| raphf         |     |     | *   |     |     |     |     |
+| readline      | *   | *   | *   | *   | *   | *   | *   |
+| recode        | *   | *   | *   | *   | *   | *   | *   |
+| redis         | *   | *   | *   | *   | *   | *   | *   |
+| shmop         |     |     |     | *   | *   | *   | *   |
+| simplexml     |     |     |     | *   | *   | *   | *   |
+| snmp          | *   | *   | *   | *   | *   | *   | *   |
+| soap          |     |     |     | *   | *   | *   | *   |
+| sockets       |     |     |     | *   | *   | *   | *   |
+| sodium        |     |     |     |     |     | *   | *   |
+| sourceguardian|     |     |     | *   | *   |     |     |
+| spplus        | *   | *   |     |     |     |     |     |
+| sqlite3       | *   | *   | *   | *   | *   | *   | *   |
+| sqlsrv        |     |     |     | *   | *   | *   | *   |
+| ssh2          | *   | *   | *   | *   | *   | *   | *   |
+| sysvmsg       |     |     |     | *   | *   | *   | *   |
+| sysvsem       |     |     |     | *   | *   | *   | *   |
+| sysvshm       |     |     |     | *   | *   | *   | *   |
+| tideways      |     |     |     | *   | *   | *   | *   |
+| tidy          | *   | *   | *   | *   | *   | *   | *   |
+| tokenizer     |     |     |     | *   | *   | *   | *   |
+| uuid          |     |     |     |     | *   | *   | *   |
+| wddx          |     |     |     | *   | *   | *   | *   |
+| xcache        | *   | *   |     |     |     |     |     |
+| xdebug        | *   | *   | *   | *   | *   | *   | *   |
+| xhprof        | *   | *   | *   |     |     |     |     |
+| xml           |     |     |     | *   | *   | *   | *   |
+| xmlreader     |     |     |     | *   | *   | *   | *   |
+| xmlrpc        | *   | *   | *   | *   | *   | *   | *   |
+| xmlwriter     |     |     |     | *   | *   | *   | *   |
+| xsl           | *   | *   | *   | *   | *   | *   | *   |
+| yaml          |     |     |     |     | *   | *   | *   |
+| zbarcode      |     |     |     | *   | *   | *   | *   |
+| zendopcache   | *   |     |     |     |     |     |     |
+| zip           |     |     |     | *   | *   | *   | *   |
 
 > **note**
 > You can check out the output of `ls /etc/php5/mods-available` to


### PR DESCRIPTION
memcached is excluded for now as the extension isn't quite ready yet. As soon as it is that can get added back in.