### PR TITLE
Clarifying env:PLATFORMSH_CLI_TOKEN when using CLI on app container

### DIFF
--- a/src/gettingstarted/cli/api-tokens.md
+++ b/src/gettingstarted/cli/api-tokens.md
@@ -35,7 +35,8 @@ First, obtain an API token as above.  Set it as the [top-level](https://docs.pla
 ```bash
 platform variable:create -e master --level environment --name env:PLATFORMSH_CLI_TOKEN --sensitive true --value 'your API token'
 ```
-**Note:** It is important to include the `env:` so as to expose `$PLATFORMSH_CLI_TOKEN` on its own as a top level Unix environment variable, rather than as a part of `$PLATFORM_VARIABLES` like normal environment variables.
+> **note**
+> It is important to include the `env:` so as to expose `$PLATFORMSH_CLI_TOKEN` on its own as a top level Unix environment variable, rather than as a part of `$PLATFORM_VARIABLES` like normal environment variables.
 
 Second, add a build hook to your `.platform.app.yaml` file to download the CLI as part of the build process.
 

--- a/src/gettingstarted/cli/api-tokens.md
+++ b/src/gettingstarted/cli/api-tokens.md
@@ -30,13 +30,14 @@ We recommend having a separate automation user for each project to be automated.
 
 A common use case for an API token is to allow the Platform.sh CLI to be run on an app container, often via a cron hook.  An API token is necessary for authentication, but the CLI will be able to auto-detect the current project and environment.
 
-First, obtain an API token as above.  Set it as an environment variable either through the UI or via the CLI, like so:
+First, obtain an API token as above.  Set it as the [top-level](https://docs.platform.sh/development/variables.html#top-level-environment-variables) environment variable `env:PLATFORMSH_CLI_TOKEN` either through the UI or via the CLI, like so:
 
 ```bash
 platform variable:create -e master --level environment --name env:PLATFORMSH_CLI_TOKEN --sensitive true --value 'your API token'
 ```
+**Note:** It is important to include the `env:` so as to expose `$PLATFORMSH_CLI_TOKEN` on its own as a top level Unix environment variable, rather than as a part of `$PLATFORM_VARIABLES` like normal environment variables.
 
-Second, add a build hook to your `.platform.app.yaml` file to download the CLI as part of the build process.  
+Second, add a build hook to your `.platform.app.yaml` file to download the CLI as part of the build process.
 
 ```yaml
 hooks:


### PR DESCRIPTION
The docs here: https://docs.platform.sh/gettingstarted/cli/api-tokens.html

Are unclear that the api token environment variable must be set as `env:PLATFORMSH_CLI_TOKEN`, and not `PLATFORMSH_CLI_TOKEN`, when setting up the Platform CLI on a platform app container. A client made this mistake and I made the same mistake when trying to debug the issue the client was having.