### PR TITLE
kill all the links

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Platform.sh User Documentation
 
-This repository holds the public user documentation for [Platform.sh](https://platform.sh/).
+This repository holds the public user documentation for Platform.sh.
 
 Our documentation site ([docs.platform.sh](https://docs.platform.sh/)) is itself hosted on Platform.sh, and built using our powerful build-and-deploy system.
 

--- a/src/administration/integrations.md
+++ b/src/administration/integrations.md
@@ -1,6 +1,6 @@
 # Integrations
 
-Platform.sh can easily be integrated with external services. 
+Platform.sh can easily be integrated with external services.
 
 We support native integrations with multiple services, first and foremost Git hosting services such as GitHub, GitLab, or Bitbucket.  You can continue to use those tools for your development workflow, and have Platform.sh environments created automatically for your pull requests and branches.
 

--- a/src/administration/web/environments.md
+++ b/src/administration/web/environments.md
@@ -1,6 +1,6 @@
 # Platform.sh Environments
 
-[Platform.sh](https://platform.sh) helps a coder with the development workflow by making it easy to manage multiple environments, including the Master environment which runs the production website. It's precisely like a "development" or a "staging" server, except they are created on the fly, and they are absolutely identical copies of their parent environments.
+Platform.sh helps a coder with the development workflow by making it easy to manage multiple environments, including the Master environment which runs the production website. It's precisely like a "development" or a "staging" server, except they are created on the fly, and they are absolutely identical copies of their parent environments.
 
 An environment is tied to a Git branch, plus all the services that are serving that branch. You can see that as a **complete working website**. With Bitbucket and GitHub integrations you can even get a "development server" for each and every pull request.
 

--- a/src/development/faq.md
+++ b/src/development/faq.md
@@ -16,7 +16,7 @@ This will delete your project and stop invoicing for this project. If you have m
 
 ## Do you support MySQL?
 
-[Platform.sh](https://platform.sh) uses MariaDB to manage and store your databases. It's a fork of MySQL which is more stable and has more interesting features.
+Platform.sh uses MariaDB to manage and store your databases. It's a fork of MySQL which is more stable and has more interesting features.
 
 ## Does branching an environment duplicate services?
 

--- a/src/development/ssh.md
+++ b/src/development/ssh.md
@@ -1,6 +1,6 @@
 # Using SSH keys
 
-One of the ways [Platform.sh](https://platform.sh/) keeps things secure is by using SSH behind the scenes. Users can interact with their environment through a command shell, or push changes to the environment's Git repository, and both of these features rely on SSH.
+One of the ways Platform.sh keeps things secure is by using SSH behind the scenes. Users can interact with their environment through a command shell, or push changes to the environment's Git repository, and both of these features rely on SSH.
 
 When you create a new project, the wizard will propose that you add your ssh key.
 

--- a/src/gettingstarted/tools.md
+++ b/src/gettingstarted/tools.md
@@ -2,7 +2,7 @@
 
 ## Git
 
-Git is the open source version control system that is utilized by [Platform.sh](https://platform.sh/).
+Git is the open source version control system that is utilized by Platform.sh.
 
 Any change you make to your Platform.sh project will need to be committed via Git. You can see all the Git commit messages of an environment in the activity feed of the web interface.
 

--- a/src/security/protective-block.md
+++ b/src/security/protective-block.md
@@ -6,11 +6,11 @@ The protective block is meant for high impact, low complexity attacks.
 
 ## The Platform.sh security block
 
-Outdated software often contains known vulnerabilities that can be exploited from the Internet. Sites that can be exploited are protected by [Platform.sh](https://platform.sh). The system partially blocks access to these sites.
+Outdated software often contains known vulnerabilities that can be exploited from the Internet. Sites that can be exploited are protected by Platform.sh. The system partially blocks access to these sites.
 
 ## How the protective block works
 
-https://platform.sh maintains a database of signatures of known security vulnerabilities in open-source software that are commonly deployed on our infrastructure. The security check only analyze known vulnerabilities in open-source projects like Drupal, Symfony or WordPress. It cannot examine customizations written by [Platform.sh](https://platform.sh) customers.
+Platform.sh maintains a database of signatures of known security vulnerabilities in open-source software that are commonly deployed on our infrastructure. The security check only analyze known vulnerabilities in open-source projects like Drupal, Symfony or WordPress. It cannot examine customizations written by Platform.sh customers.
 
 We analyze the code of your application:
 
@@ -29,7 +29,7 @@ Unblocking is automated upon resolution of the security risk. The block is remov
 
 ## Opting out of the protective block
 
-The protective block is there to protect you against known vulnerabilities in the software you deploy on [Platform.sh](https://platform.sh).
+The protective block is there to protect you against known vulnerabilities in the software you deploy on Platform.sh.
 
 If nonetheless you want to opt out of the protective block, you simply need to specify it in your `.platform.app.yaml` like this:
 


### PR DESCRIPTION
[Platform.sh](https://platform.sh/) links removed as per Contributing Guidelines: 

> 'The name of the company is always written as "Platform.sh", not simply "Platform". It should not be linked anywhere.'