### PR TITLE
Add note about variable

### DIFF
--- a/src/configuration/app/build.md
+++ b/src/configuration/app/build.md
@@ -93,7 +93,7 @@ Hooks are executed using the dash shell, not the bash shell used by normal SSH l
 
 ### Build hook
 
-The `build` hook is run after the build flavor (if any).  The file system is fully writable, but no services are available (such as a database) nor any persistent file mounts, as the application has not yet been deployed.
+The `build` hook is run after the build flavor (if any).  The file system is fully writable, but no services are available (such as a database) nor any persistent file mounts, as the application has not yet been deployed. The `PLATFORM_RELATIONSHIPS` variable is not available in this phase.
 
 ### Deploy hook
 

--- a/src/configuration/app/build.md
+++ b/src/configuration/app/build.md
@@ -93,7 +93,7 @@ Hooks are executed using the dash shell, not the bash shell used by normal SSH l
 
 ### Build hook
 
-The `build` hook is run after the build flavor (if any).  The file system is fully writable, but no services are available (such as a database) nor any persistent file mounts, as the application has not yet been deployed. Environment variables that exist only at runtime such as `PLATFORM_BRANCH`, `PLATFORM_DOCUMENT_ROOT` etc. are not available during this phase. The full list of build time and runtime variables is available at [link](/development/variables.md#platformsh-provided-variables).
+The `build` hook is run after the build flavor (if any).  The file system is fully writable, but no services are available (such as a database) nor any persistent file mounts, as the application has not yet been deployed. Environment variables that exist only at runtime such as `PLATFORM_BRANCH`, `PLATFORM_DOCUMENT_ROOT` etc. are not available during this phase. The full list of build time and runtime variables is available on the [variables page](/development/variables.md#platformsh-provided-variables).
 
 ### Deploy hook
 

--- a/src/configuration/app/build.md
+++ b/src/configuration/app/build.md
@@ -93,7 +93,7 @@ Hooks are executed using the dash shell, not the bash shell used by normal SSH l
 
 ### Build hook
 
-The `build` hook is run after the build flavor (if any).  The file system is fully writable, but no services are available (such as a database) nor any persistent file mounts, as the application has not yet been deployed. The `PLATFORM_RELATIONSHIPS` variable is not available in this phase.
+The `build` hook is run after the build flavor (if any).  The file system is fully writable, but no services are available (such as a database) nor any persistent file mounts, as the application has not yet been deployed. Environment variables that exist only at runtime such as `PLATFORM_BRANCH`, `PLATFORM_DOCUMENT_ROOT` etc. are not available during this phase. The full list of build time and runtime variables is available at [link](/development/variables.md#platformsh-provided-variables).
 
 ### Deploy hook
 


### PR DESCRIPTION
A user suggested that it would be helpful if there was a note saying that `PLATFORM_RELATIONSHIPS` will not be available in the build phase. 