### PR TITLE
Remote examples

### DIFF
--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -47,6 +47,8 @@ You can then use the service in a configuration file of your application with so
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/elasticsearch" -%}
 
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/elasticsearch" -%}
+
 {%- endcodetabs %}
 
 

--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -43,22 +43,12 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-```php
-<?php
-// This assumes a fictional application with an array named $settings.
-if (getenv('PLATFORM_RELATIONSHIPS')) {
-	$relationships = json_decode(base64_decode($relationships), TRUE);
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/elasticsearch" -%}
 
-	// For a relationship named 'elasticsearch' referring to one endpoint.
-	if (!empty($relationships['elasticsearch'])) {
-		foreach ($relationships['elasticsearch'] as $endpoint) {
-			$settings['elasticsearch_host'] = $endpoint['host'];
-			$settings['elasticsearch_port'] = $endpoint['port'];
-			break;
-		}
-	}
-}
-```
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/elasticsearch" -%}
+
+{%- endcodetabs %}
+
 
 > **note**
 >

--- a/src/configuration/services/memcached.md
+++ b/src/configuration/services/memcached.md
@@ -54,25 +54,9 @@ dependencies:
 
 You can then use the service in a configuration file of your application with something like:
 
-{% codetabs name="PHP", type="php" -%}
-<?php
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/memcached" -%}
 
-if (!isset($_ENV['PLATFORM_RELATIONSHIPS'])) {
-    return;
-}
-
-$relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
-$rel = $relationships['cache'][0];
-
-$m = new Memcached();
-$m->addServer($rel['host'], $rel['port']);
-$m->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
-
-$m->set('int', 99);
-$m->set('string', 'a simple string');
-$m->set('array', array(11, 12));
-/* expire 'object' key in 5 minutes */
-$m->set('object', new stdclass, time() + 300);
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/memcached" -%}
 
 {%- language name="Python", type="py" -%}
 import memcache
@@ -99,7 +83,6 @@ if relationships:
     mc.decr("key")
     #print "Counter Value: {}<br />\n".format(mc.get("key"))
 {%- endcodetabs %}
-
 
 ## Accessing Memcached directly
 

--- a/src/configuration/services/memcached.md
+++ b/src/configuration/services/memcached.md
@@ -58,30 +58,8 @@ You can then use the service in a configuration file of your application with so
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/memcached" -%}
 
-{%- language name="Python", type="py" -%}
-import memcache
-import os
-import json
-import base64
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/memcached" -%}
 
-relationships = os.getenv('PLATFORM_RELATIONSHIPS')
-if relationships:
-    relationships = json.loads(base64.b64decode(relationships).decode('utf-8'))
-    memcache_settings = relationships['cache'][0]
-
-    mc = memcache.Client([memcache_settings['host'] + ':' + str(memcache_settings['port'])], debug=0)
-
-    mc.set("an_int", 99)
-    #print "Int Value: {}<br />\n".format(mc.get("an_int"))
-
-    mc.set("a_sring", "a simple string")
-    mc.delete("a_string")
-    #print "String Value: {}<br />\n".format(mc.get("a_string"))
-
-    #mc.set("key", "1")   # note that the key used for incr/decr must be a string.
-    mc.incr("key")
-    mc.decr("key")
-    #print "Counter Value: {}<br />\n".format(mc.get("key"))
 {%- endcodetabs %}
 
 ## Accessing Memcached directly

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -53,54 +53,10 @@ runtime:
 
 You can then use the service in a configuration file of your application with something like:
 
-{% codetabs name="PHP", type="php" -%}
-<?php
-// First run `composer require mongodb/mongodb` to get the userspace
-// library, and autoload it.  Then:
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/mongodb" -%}
 
-if ($relationships = getenv('PLATFORM_RELATIONSHIPS')) {
-    $relationships = json_decode(base64_decode($relationships), TRUE);
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/mongodb" -%}
 
-    // For a relationship named 'database' referring to one endpoint.
-    if (!empty($relationships['database'])) {
-        foreach ($relationships['database'] as $endpoint) {
-            $settings = $endpoint;
-            break;
-        }
-    }
-}
-
-$server = sprintf('%s://%s:%s@%s:%d/%s',
-    $settings['scheme'],
-    $settings['username'],
-    $settings['password'],
-    $settings['host'],
-    $settings['port'],
-    $settings['path'],
-);
-
-$client = new MongoDB\Client($server);
-$collection = $client->main->starwars;
-
-$result = $collection->insertOne( [ 'name' => 'Rey', 'occupation' => 'Jedi' ] );
-
-echo "Inserted with Object ID '{$result->getInsertedId()}'";
-
-{%- language name="JavaScript", type="js" -%}
-var config= require("platformsh").config();
-var db = config.relationships.database[0];
-var url = db["scheme"] + '://' + db["username"] + ':' + db['password']+ "@" + db['ip']+ ":" + db['port']+ '/' + db['path'];
-
-var MongoClient = require('mongodb').MongoClient
-  , assert = require('assert');
-
-// Use connect method to connect to the server
-MongoClient.connect(url, function(err, db) {
-  assert.equal(null, err);
-  console.log("Connected successfully to server");
-
-  db.close();
-});
 {%- endcodetabs %}
 
 ## Exporting data

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -57,6 +57,8 @@ You can then use the service in a configuration file of your application with so
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/mongodb" -%}
 
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/mongodb" -%}
+
 {%- endcodetabs %}
 
 ## Exporting data

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -47,26 +47,10 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-{% codetabs name="PHP", type="php" -%}
-<?php
-// This assumes a fictional application with an array named $settings.
-$relationships = getenv('PLATFORM_RELATIONSHIPS');
-if ($relationships) {
-	$relationships = json_decode(base64_decode($relationships), TRUE);
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/mysql" -%}
 
-	// For a relationship named 'database' referring to one endpoint.
-	if (!empty($relationships['database'])) {
-		foreach ($relationships['database'] as $endpoint) {
-			$settings['database_driver'] = 'pdo_' . $endpoint['scheme'];
-			$settings['database_host'] = $endpoint['host'];
-			$settings['database_name'] = $endpoint['path'];
-			$settings['database_port'] = $endpoint['port'];
-			$settings['database_user'] = $endpoint['username'];
-			$settings['database_password'] = $endpoint['password'];
-			break;
-		}
-	}
-}
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/mysql" -%}
+
 {%- language name="Python", type="py" -%}
 import os
 import json

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -51,25 +51,8 @@ You can then use the service in a configuration file of your application with so
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/mysql" -%}
 
-{%- language name="Python", type="py" -%}
-import os
-import json
-import base64
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/mysql" -%}
 
-relationships = os.getenv('PLATFORM_RELATIONSHIPS')
-if relationships:
-    relationships = json.loads(base64.b64decode(relationships).decode('utf-8'))
-    db_settings = relationships['database'][0]
-    DATABASES = {
-        "default": {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': db_settings['path'],
-            'USER': db_settings['username'],
-            'PASSWORD': db_settings['password'],
-            'HOST': db_settings['host'],
-            'PORT': db_settings['port'],
-        }
-    }
 {%- language name="Go", type="go" -%}
 // Using the Platform.sh Go helper library: https://github.com/platformsh/gohelper
 

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -50,26 +50,10 @@ runtime:
 You can then use the service in a configuration file of your application with something like:
 
 
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/postgresql" -%}
 
-{% codetabs name="PHP", type="php" -%}
-<?php
-// This assumes a fictional application with an array named $settings.
-if (getenv('PLATFORM_RELATIONSHIPS')) {
-	$relationships = json_decode(base64_decode($relationships), TRUE);
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/postgresql" -%}
 
-	// For a relationship named 'database' referring to one endpoint.
-	if (!empty($relationships['database'])) {
-		foreach ($relationships['database'] as $endpoint) {
-			$settings['database_driver'] = 'pdo_' . $endpoint['scheme'];
-			$settings['database_host'] = $endpoint['host'];
-			$settings['database_name'] = $endpoint['path'];
-			$settings['database_port'] = $endpoint['port'];
-			$settings['database_user'] = $endpoint['user'];
-			$settings['database_password'] = $endpoint['password'];
-			break;
-		}
-	}
-}
 {%- language name="Python", type="py" -%}
 relationships = os.getenv('PLATFORM_RELATIONSHIPS')
 if relationships:
@@ -85,25 +69,6 @@ if relationships:
             'PORT': db_settings['port'],
         }
     }
-{%- language name="NodeJS", type="js" -%}
-// Using the Platform.sh JS helper library: https://github.com/platformsh/platformsh-nodejs-helper
-
-var config = require("platformsh").config();
-
-if (config.relationships != null) {
-  var db = config.relationships.first_db[0]
-
-  const connObj = {
-      user: database.username,
-      database: database.path,
-      password: database.password,
-      host: database.host
-  };
-
-  const pg = require('pg');
-
-  pg.connectAsync(connObj)...;
-}
 
 {%- language name="Go", type="go" -%}
 // Using the Platform.sh Go helper library: https://github.com/platformsh/gohelper

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -49,39 +49,12 @@ runtime:
 
 You can then use the service in a configuration file of your application with something like:
 
-
 {% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/postgresql" -%}
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/postgresql" -%}
 
-{%- language name="Python", type="py" -%}
-relationships = os.getenv('PLATFORM_RELATIONSHIPS')
-if relationships:
-    relationships = json.loads(base64.b64decode(relationships).decode('utf-8'))
-    db_settings = relationships['database'][0]
-    DATABASES = {
-        "default": {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': db_settings['path'],
-            'USER': db_settings['username'],
-            'PASSWORD': db_settings['password'],
-            'HOST': db_settings['host'],
-            'PORT': db_settings['port'],
-        }
-    }
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/postgresql" -%}
 
-{%- language name="Go", type="go" -%}
-// Using the Platform.sh Go helper library: https://github.com/platformsh/gohelper
-
-dbString, err := pi.SqlDsn("database")
-if (err != nil) {
-  panic(err)
-}
-
-db, err := sql.Open("postgres", dbString)
-if (err != nil) {
-  panic(err)
-}
 {%- endcodetabs %}
 
 ## Exporting data

--- a/src/configuration/services/rabbitmq.md
+++ b/src/configuration/services/rabbitmq.md
@@ -35,22 +35,10 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-```php
-<?php
-// This assumes a fictional application with an array named $settings.
-if (getenv('PLATFORM_RELATIONSHIPS')) {
-	$relationships = json_decode(base64_decode($relationships), TRUE);
 
-	// For a relationship named 'mq' referring to one endpoint.
-	if (!empty($relationships['mq'])) {
-		foreach ($relationships['mq'] as $endpoint) {
-			$settings['rabbitmq_host'] = $endpoint['host'];
-			$settings['rabbitmq_port'] = $endpoint['port'];
-			break;
-		}
-	}
-}
-```
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/rabbitmq" -%}
+
+{%- endcodetabs %}
 
 (The specific way to inject configuration into your application will vary. Consult your application or framework's documentation.)
 

--- a/src/configuration/services/rabbitmq.md
+++ b/src/configuration/services/rabbitmq.md
@@ -37,8 +37,6 @@ You can then use the service in a configuration file of your application with so
 
 {% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/rabbitmq" -%}
 
-{% codetabs name="Python", type="py", url="https://examples.docs.platform.sh/python/rabbitmq" -%}
-
 {%- endcodetabs %}
 
 (The specific way to inject configuration into your application will vary. Consult your application or framework's documentation.)

--- a/src/configuration/services/rabbitmq.md
+++ b/src/configuration/services/rabbitmq.md
@@ -35,8 +35,9 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-
 {% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/rabbitmq" -%}
+
+{% codetabs name="Python", type="py", url="https://examples.docs.platform.sh/python/rabbitmq" -%}
 
 {%- endcodetabs %}
 

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -83,6 +83,8 @@ You can then use the service in a configuration file of your application with so
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/redis" -%}
 
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/redis" -%}
+
 {%- endcodetabs %}
 
 ## Using redis-cli to access your Redis service

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -79,22 +79,11 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-```php
-<?php
-// This assumes a fictional application with an array named $settings.
-if (getenv('PLATFORM_RELATIONSHIPS')) {
-	$relationships = json_decode(base64_decode($relationships), TRUE);
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/redis" -%}
 
-	// For a relationship named 'applicationcache' referring to one endpoint.
-	if (!empty($relationships['applicationcache'])) {
-		foreach ($relationships['applicationcache'] as $endpoint) {
-			$settings['redis_host'] = $endpoint['host'];
-			$settings['redis_port'] = $endpoint['port'];
-			break;
-		}
-	}
-}
-```
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/redis" -%}
+
+{%- endcodetabs %}
 
 ## Using redis-cli to access your Redis service
 

--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -39,10 +39,11 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-
 {% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/solr" -%}
 
 {%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/solr" -%}
+
+{%- language name="Python", type="py", url="https://examples.docs.platform.sh/python/solr" -%}
 
 {%- endcodetabs %}
 

--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -39,22 +39,12 @@ relationships:
 
 You can then use the service in a configuration file of your application with something like:
 
-```php
-<?php
-// This assumes a fictional application with an array named $settings.
-if (getenv('PLATFORM_RELATIONSHIPS')) {
-	$relationships = json_decode(base64_decode($relationships), TRUE);
 
-	// For a relationship named 'solr' referring to one endpoint.
-	if (!empty($relationships['solr'])) {
-		foreach ($relationships['solr'] as $endpoint) {
-			$settings['solr_host'] = $endpoint['host'];
-			$settings['solr_port'] = $endpoint['port'];
-			break;
-		}
-	}
-}
-```
+{% codetabs name="PHP", type="php", url="https://examples.docs.platform.sh/php/solr" -%}
+
+{%- language name="Node.js", type="js", url="https://examples.docs.platform.sh/nodejs/solr" -%}
+
+{%- endcodetabs %}
 
 ## Configuration
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -413,3 +413,9 @@ section.examples-lists {
 section.examples-lists > div {
   margin-right: 1em;
 }
+
+.codetabs-body {
+  max-height: 30em;
+  overflow-x: scroll;
+  overflow-y: scroll;
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -414,8 +414,7 @@ section.examples-lists > div {
   margin-right: 1em;
 }
 
-.codetabs-body {
+.codetabs-body pre {
   max-height: 30em;
-  overflow-x: scroll;
-  overflow-y: scroll;
+  overflow: scroll;
 }


### PR DESCRIPTION
Switch all services to use the examples site for PHP and Node examples.  A few Python ones are left in place for now until the Python examples branch is merged.  There's also one or two Go examples I left in place.  And I found one service (RabbitMQ) that doesn't have a Node example yet, so it's omitted until it is.  It's trivial enough to add all of those as they come online.