### PR TITLE
Go 1.12 support.

### DIFF
--- a/src/changelog/2019.md
+++ b/src/changelog/2019.md
@@ -1,5 +1,9 @@
 # March 2019
 
+## Go 1.12
+
+We now support [Go 1.12](/languages/go.md).
+
 ## Elasticsearch 6.5
 
 We now support [Elasticsearch 6.5](/configuration/services/elasticsearch.md).

--- a/src/languages/go.md
+++ b/src/languages/go.md
@@ -5,11 +5,12 @@ Platform.sh supports building and deploying applications written in Go using Go 
 ## Supported versions
 
 * 1.11
+* 1.12
 
 To specify a Go container, use the `type` property in your `.platform.app.yaml`.
 
 ```yaml
-type: 'golang:1.11'
+type: 'golang:1.12'
 ```
 
 ## Deprecated versions
@@ -62,7 +63,7 @@ The following basic `.platform.app.yaml` file is sufficient to run most Go appli
 ```yaml
 name: app
 
-type: golang:1.11
+type: golang:1.12
 
 hooks:
     build: |


### PR DESCRIPTION
Easy peasy.