### PR TITLE
Security overview page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -117,14 +117,14 @@
 ## Security and compliance
 
 * [Overview](security/index.md)
-* [GDPR](security/gdpr.md)
+* [Backup and restore](security/backups.md)
+* [Compliance guidance](security/compliance-guidance.md)
 * [Data collection](security/data-collection.md)
 * [Data retention](security/data-retention.md)
 * [Data deletion](security/data-deletion.md)
-* [Backup and restore](security/backups.md)
 * [Encryption](security/encryption.md)
+* [GDPR](security/gdpr.md)
 * [Protective block](security/protective-block.md)
-* [Compliance guidance](security/compliance-guidance.md)
 * [Security scans](security/pen-test.md)
 * [Troubleshooting](security/troubleshooting.md)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -116,6 +116,7 @@
 
 ## Security and compliance
 
+* [Overview](security/index.md)
 * [GDPR](security/gdpr.md)
 * [Data collection](security/data-collection.md)
 * [Data retention](security/data-retention.md)

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -4,13 +4,13 @@ Platform.sh takes the security of our infrastructure and your applications very 
 This section contains information on how we manage security and compliance at Platform.sh, and
 the things we do to ensure your applications are protected.
 
-* [Backup and restore](security/backups.md)
-* [Compliance guidance](security/compliance-guidance.md)
-* [Data collection](security/data-collection.md)
-* [Data retention](security/data-retention.md)
-* [Data deletion](security/data-deletion.md)
-* [Encryption](security/encryption.md)
-* [GDPR](security/gdpr.md)
-* [Protective block](security/protective-block.md)
-* [Security scans](security/pen-test.md)
-* [Troubleshooting](security/troubleshooting.md)
+* [Backup and restore](backups.md)
+* [Compliance guidance](compliance-guidance.md)
+* [Data collection](data-collection.md)
+* [Data retention](data-retention.md)
+* [Data deletion](data-deletion.md)
+* [Encryption](sencryption.md)
+* [GDPR](gdpr.md)
+* [Protective block](protective-block.md)
+* [Security scans](pen-test.md)
+* [Troubleshooting](troubleshooting.md)

--- a/src/security/index.md
+++ b/src/security/index.md
@@ -1,0 +1,16 @@
+# Overview of Security at Platform.sh
+
+Platform.sh takes the security of our infrastructure and your applications very seriously. 
+This section contains information on how we manage security and compliance at Platform.sh, and
+the things we do to ensure your applications are protected.
+
+* [Backup and restore](security/backups.md)
+* [Compliance guidance](security/compliance-guidance.md)
+* [Data collection](security/data-collection.md)
+* [Data retention](security/data-retention.md)
+* [Data deletion](security/data-deletion.md)
+* [Encryption](security/encryption.md)
+* [GDPR](security/gdpr.md)
+* [Protective block](security/protective-block.md)
+* [Security scans](security/pen-test.md)
+* [Troubleshooting](security/troubleshooting.md)


### PR DESCRIPTION
Adds a top-level Security Overview page to allow easier linking for Sales et al.