### PR TITLE
Use Config Reader in Drupal documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -146,6 +146,7 @@
   * [Drush](frameworks/drupal8/drush.md)
   * [Redis](frameworks/drupal8/redis.md)
   * [Memcached](frameworks/drupal8/memcached.md)
+  * [Elasticsearch](frameworks/drupal8/elasticsearch.md)
   * [Solr](frameworks/drupal8/solr.md)
   * [SimpleSAML](frameworks/drupal8/simplesaml.md)
   * [FAQ](frameworks/drupal8/faq.md)

--- a/src/frameworks/drupal8.md
+++ b/src/frameworks/drupal8.md
@@ -14,8 +14,14 @@ $ composer require drupal/devel
 
 And then commit just the changes to `composer.json` and `composer.lock` to your repository.  That also means that to get a working copy of your site locally you will need to run `composer install` to download all of the necessary libraries and modules.
 
+We also strongly recommend installing the Platform.sh Config Reader library, which simplifies access to the Platform.sh environment.  The rest of this documentation assumes you have it installed.
+
+```bash
+$ composer require platformsh/config-reader
+```
+
 > **note**
-> When using Composer, your docroot where most of Drupal lives will be called `web`, but the `vendor` directory will be outside of that directory in contrast to how a standard Drupal download .tar.gz file is organized.  The config export directory will also be outside of the web root.  This is normal, expected, and more secure.
+> When using Composer, your docroot where most of Drupal lives will be called `web`, but the `vendor` directory will be outside of that directory in contrast to how a standard Drupal download `.tar.gz` file is organized.  The config export directory will also be outside of the web root.  This is normal, expected, and more secure.
 
 ### File organization
 

--- a/src/frameworks/drupal8/elasticsearch.md
+++ b/src/frameworks/drupal8/elasticsearch.md
@@ -1,0 +1,72 @@
+# Using Elasticsearch with Drupal 8.x
+
+## Requirements
+
+### Add the Drupal modules
+
+You will need to add the [Search API](https://www.drupal.org/project/search_api) and [Elasticsearch Connector](https://www.drupal.org/project/elasticsearch_connector) modules to your project. If you are using composer, the easiest way to add them is to simply run:
+
+```bash
+$ composer require drupal/search_api drupal/elasticsearch_connector
+```
+
+And then commit the changes to `composer.json` and `composer.lock`.
+
+### Add an Elasticsearch service
+
+First you need to create an Elasticsearch service.  In your `.platform/services.yaml` file, add or uncomment the following:
+
+```yaml
+elasticsearch:
+    type: elasticsearch:6.5
+    disk: 2014
+```
+
+The above definition defines a single Elasticsearch 6.5 server.  Because Elasticsearch defines additional indexes dynamically there is no need to define custom endpoints.
+
+### Expose the Elasticsearch service to your application
+
+In your `.platform.app.yaml` file, you now need to open a connection to the new Elasticsearch service.  Under the `relationships` section, add or uncomment the following:
+
+```
+relationships:
+    elasticsearch: 'elasticsearch:elasticsearch'
+```
+
+## Configuration
+
+Because Drupal defines connection information via the Configuration Management system, you will need to first define an Elasticsearch "Cluster" at `admin/config/search/elasticsearch-connector`.  Note the "machine name" the server is given.
+
+Then, paste the following code snippet into your `settings.platformsh.php` file.
+
+> **note**
+>
+> If you do not already have the Platform.sh Config Reader library installed and referenced at the top of the file, you will need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
+>
+> ```php
+> $platformsh = new \Platformsh\ConfigReader\Config();
+> if (!$platformsh->inRuntime()) {
+>   return;
+> }
+> ```
+
+- Edit the value of `$relationship_name` if you are using a different relationship.
+
+- Edit the value of `$es_server_name` to match the machine name of your cluster in Drupal.
+
+```php
+// Update these values to the relationship name (from .platform.app.yaml)
+// and the machine name of the server from your Drupal configuration.
+$relationship_name = 'elasticsearch';
+$es_cluster_name = 'YOUR_CLUSTER_HERE';
+if ($platformsh->hasRelationship($relationship_name)) {
+  $platformsh->registerFormatter('drupal-elastic', function($creds) {
+    return sprintf('http://%s:%s', $creds['host'], $creds['port']);
+  });
+
+  // Set the connector configuration to the appropriate value, as defined by the formatter above.
+  $config['elasticsearch_connector.cluster.' . $es_cluster_name]['url'] = $platformsh->formattedCredentials($relationship_name, 'drupal-elastic');
+}
+```
+
+Commit that code and push.  The specified cluster will now always point to the Elasticsearch service.  Then configure Search API as normal.

--- a/src/frameworks/drupal8/redis.md
+++ b/src/frameworks/drupal8/redis.md
@@ -10,7 +10,7 @@ First you need to create a Redis service.  In your `.platform/services.yaml` fil
 
 ```yaml
 rediscache:
-    type: redis:3.2
+    type: redis:5.0
 ```
 
 That will create a service named `rediscache`, of type `redis`, specifically version `3.2`.

--- a/src/frameworks/drupal8/redis.md
+++ b/src/frameworks/drupal8/redis.md
@@ -57,74 +57,85 @@ Place the following at the end of `settings.platformsh.php`. Note the inline com
 
 The example below is intended as a "most common case".  (Note: This example assumes Drupal 8.2 or later.)
 
+> **note**
+>
+> If you do not already have the Platform.sh Config Reader library installed and referenced at the top of the file, you will need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
+>
+> ```php
+> $platformsh = new \Platformsh\ConfigReader\Config();
+> if (!$platformsh->inRuntime()) {
+>   return;
+> }
+> ```
+
 ```php
 // Set redis configuration.
-if (!empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
-  $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
+if ($platformsh->hasRelationship('redis') && !drupal_installation_attempted() && extension_loaded('redis')) {
+  $redis = $platformsh->credentials('redis');
 
-  if (!empty($relationships['redis'][0]) && !drupal_installation_attempted() && extension_loaded('redis')) {
-    $redis = $relationships['redis'][0];
+  // Set Redis as the default backend for any cache bin not otherwise specified.
+  $settings['cache']['default'] = 'cache.backend.redis';
+  $settings['redis.connection']['host'] = $redis['host'];
+  $settings['redis.connection']['port'] = $redis['port'];
 
-    // Set Redis as the default backend for any cache bin not otherwise specified.
-    $settings['cache']['default'] = 'cache.backend.redis';
-    $settings['redis.connection']['host'] = $redis['host'];
-    $settings['redis.connection']['port'] = $redis['port'];
+  // Apply changes to the container configuration to better leverage Redis.
+  // This includes using Redis for the lock and flood control systems, as well
+  // as the cache tag checksum. Alternatively, copy the contents of that file
+  // to your project-specific services.yml file, modify as appropriate, and
+  // remove this line.
+  $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
 
-    // Apply changes to the container configuration to better leverage Redis.
-    // This includes using Redis for the lock and flood control systems, as well
-    // as the cache tag checksum. Alternatively, copy the contents of that file
-    // to your project-specific services.yml file, modify as appropriate, and
-    // remove this line.
-    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+  // Allow the services to work before the Redis module itself is enabled.
+  $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
 
-    // Allow the services to work before the Redis module itself is enabled.
-    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+  // Manually add the classloader path, this is required for the container cache bin definition below
+  // and allows to use it without the redis module being enabled.
+  $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
 
-    // Manually add the classloader path, this is required for the container cache bin definition below
-    // and allows to use it without the redis module being enabled.
-    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
-
-    // Use redis for container cache.
-    // The container cache is used to load the container definition itself, and
-    // thus any configuration stored in the container itself is not available
-    // yet. These lines force the container cache to use Redis rather than the
-    // default SQL cache.
-    $settings['bootstrap_container_definition'] = [
-      'parameters' => [],
-      'services' => [
-        'redis.factory' => [
-          'class' => 'Drupal\redis\ClientFactory',
-        ],
-        'cache.backend.redis' => [
-          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
-          'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
-        ],
-        'cache.container' => [
-          'class' => '\Drupal\redis\Cache\PhpRedis',
-          'factory' => ['@cache.backend.redis', 'get'],
-          'arguments' => ['container'],
-        ],
-        'cache_tags_provider.container' => [
-          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
-          'arguments' => ['@redis.factory'],
-        ],
-        'serialization.phpserialize' => [
-          'class' => 'Drupal\Component\Serialization\PhpSerialize',
-        ],
+  // Use redis for container cache.
+  // The container cache is used to load the container definition itself, and
+  // thus any configuration stored in the container itself is not available
+  // yet. These lines force the container cache to use Redis rather than the
+  // default SQL cache.
+  $settings['bootstrap_container_definition'] = [
+    'parameters' => [],
+    'services' => [
+      'redis.factory' => [
+        'class' => 'Drupal\redis\ClientFactory',
       ],
-    ];
-  }
+      'cache.backend.redis' => [
+        'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+        'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
+      ],
+      'cache.container' => [
+        'class' => '\Drupal\redis\Cache\PhpRedis',
+        'factory' => ['@cache.backend.redis', 'get'],
+        'arguments' => ['container'],
+      ],
+      'cache_tags_provider.container' => [
+        'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
+        'arguments' => ['@redis.factory'],
+      ],
+      'serialization.phpserialize' => [
+        'class' => 'Drupal\Component\Serialization\PhpSerialize',
+      ],
+    ],
+  ];
 }
 ```
 
-The `example.services.yml` file noted above will also use Redis for the lock and flood
-control systems.
+The `example.services.yml` file noted above will also use Redis for the lock and flood control systems.
 
 The redis module is able to use Redis as a queue backend, however, that should not be done on an ephemeral Redis instance as that could result in lost items when the Redis service instance is restarted or fills up.  If you wish to use Redis for the queue we recommend using a separate persistent Redis instance.  See the [Redis documentation page](/configuration/services/redis.md) for more information.
 
 ### Verifying Redis is running
+
 Run this command in a SSH session in your environment `redis-cli -h redis.internal info`. You should run it before you push all this new code to your repository.
 
 This should give you a baseline of activity on your Redis installation. There should be very little memory allocated to the Redis cache.
 
 After you push this code, you should run the command and notice that allocated memory will start jumping.
+
+### Clear SQL cache tables
+
+Once you've confirmed that your site is using Redis for caching, you can and should purge any remaining cache data in the MySQL database as it is now just taking up space.  `TRUNCATE` any table that begins with `cache` *except* for `cache_form`.  Despite its name `cache_form` is not part of the cache system proper and thus should not be moved out of SQL.

--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -85,27 +85,27 @@ The configuration can be managed from `settings.platformsh.php` by adding the fo
 $relationship_name = 'solr';
 
 if ($platformsh->hasRelationship($relationship_name)) {
-    // Edit this value to use the the machine name of the Solr server in Drupal
-    // if you are using a different server than the default one automatically
-    // created by the module Search API Solr, which is named 'default_solr_server'.
-    $solr_server_name = 'default_solr_server';
+  // Edit this value to use the the machine name of the Solr server in Drupal
+  // if you are using a different server than the default one automatically
+  // created by the module Search API Solr, which is named 'default_solr_server'.
+  $solr_server_name = 'default_solr_server';
 
-    $platformsh->registerFormatter('drupal-solr', function($solr) {
-      // Gets the name of the Solr core from the Platform.sh relationship. Uses
-      // 'collection1' if empty to conform with the default Solr service single
-      // core configuration for versions lower than 6.x.
-      $core = substr($solr['path'], 5) ? : 'collection1';
+  $platformsh->registerFormatter('drupal-solr', function($solr) {
+    // Gets the name of the Solr core from the Platform.sh relationship. Uses
+    // 'collection1' if empty to conform with the default Solr service single
+    // core configuration for versions lower than 6.x.
+    $core = substr($solr['path'], 5) ? : 'collection1';
 
-      return [
-        'core' => $core,
-        'path' => '/solr',
-        'host' => $solr['host'],
-        'port' => $solr['port'],
-      ];
-    });
+    return [
+      'core' => $core,
+      'path' => '/solr',
+      'host' => $solr['host'],
+      'port' => $solr['port'],
+    ];
+  });
 
-    // Set the connector configuration to the appropriate value, as defined by the formatter above.
-    $config['search_api.server.' . $solr_server_name]['backend_config']['connector_config'] = $platformsh->formattedCredentials($relationship_name, 'drupal-solr');
+  // Set the connector configuration to the appropriate value, as defined by the formatter above.
+  $config['search_api.server.' . $solr_server_name]['backend_config']['connector_config'] = $platformsh->formattedCredentials($relationship_name, 'drupal-solr');
 }
 ```
 

--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -82,22 +82,15 @@ The configuration can be managed from `settings.platformsh.php` by adding the fo
 - Edit the value of `$solr_server_name` if you want to configure a Solr server in Drupal other than the default server automatically created by Search API Solr module.
 
 ```php
+// Update these values to the relationship name (from .platform.app.yaml)
+// and the machine name of the server from your Drupal configuration.
 $relationship_name = 'solr';
-
+$solr_server_name = 'default_solr_server';
 if ($platformsh->hasRelationship($relationship_name)) {
-  // Edit this value to use the the machine name of the Solr server in Drupal
-  // if you are using a different server than the default one automatically
-  // created by the module Search API Solr, which is named 'default_solr_server'.
-  $solr_server_name = 'default_solr_server';
-
   $platformsh->registerFormatter('drupal-solr', function($solr) {
-    // Gets the name of the Solr core from the Platform.sh relationship. Uses
-    // 'collection1' if empty to conform with the default Solr service single
-    // core configuration for versions lower than 6.x.
-    $core = substr($solr['path'], 5) ? : 'collection1';
-
+    // Default the solr core name to `collection1` for pre-Solr-6.x instances.
     return [
-      'core' => $core,
+      'core' => substr($solr['path'], 5) ? : 'collection1',
       'path' => '/solr',
       'host' => $solr['host'],
       'port' => $solr['port'],

--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -45,6 +45,7 @@ solrsearch:
             main:
                 core: maincore
 ```
+
 The above definition defines a single Solr 6.6 server.  That server has 1 core defined: `maincore` - the configuration for which is in the `.platform/solr-conf/6.x` directory.
 
 It then defines one endpoint: `main` is connected to the `maincore`.
@@ -101,6 +102,9 @@ if ($platformsh->hasRelationship($relationship_name)) {
   $config['search_api.server.' . $solr_server_name]['backend_config']['connector_config'] = $platformsh->formattedCredentials($relationship_name, 'drupal-solr');
 }
 ```
+
+Commit that code and push.  The specified cluster will now always point to the Solr service on the specified core.  Then configure Search API as normal.
+
 
 > **note**
 > At this time, bugs in Drupal 8 configuration system prevent new Solr servers from being added via configuration. The default server is automatically created by Search API Solr module if you enable its Solr Search Defaults sub-module, so this configuration will work fine for it. For multiple Solr servers or a different one other than the default you must add the new server(s) at the Search API administration page `/admin/config/search/search-api/add-server`. The newly created server(s) will use its configuration from code. See this [issue](https://www.drupal.org/node/2744057) for more information.

--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -90,8 +90,6 @@ if ($platformsh->hasRelationship($relationship_name)) {
     // created by the module Search API Solr, which is named 'default_solr_server'.
     $solr_server_name = 'default_solr_server';
 
-    $solr = $platformsh->crendentials($relationship_name);
-
     $platformsh->registerFormatter('drupal-solr', function($solr) {
       // Gets the name of the Solr core from the Platform.sh relationship. Uses
       // 'collection1' if empty to conform with the default Solr service single


### PR DESCRIPTION
I have tested all three services in this PR and they all seem to work.  The resulting copy-pasta code is much nicer, I feel, and shows we got the formatter stuff right. :smile: 

This also adds Drupal-Elasticsearch instructions for the first time.  Woo!