### PR TITLE
Remove 301redirect as it no longer exists.

### DIFF
--- a/src/golive/steps/dns.md
+++ b/src/golive/steps/dns.md
@@ -49,7 +49,6 @@ If you are willing to make the `www.` version of your site the canonical version
 If your preferred registrar/DNS provider doesn't support either custom records or the apex domain forwarding options above, the following free services both allow blind redirects and allow you to use a CNAME record to Platform.sh for `www.example.com` and an `A` record to their service at `example.com`, which will in turn send a redirect.
 
 * [WWWizer](http://wwwizer.com/)
-* [301Redirect](https://www.301redirect.it/)
 
 ### (Alternate) Using A records
 


### PR DESCRIPTION
301redirect shut down December 2018.