### PR TITLE
Remove alpha tag from Java.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -68,7 +68,7 @@
 * [Python](languages/python.md)
 * [Ruby](languages/ruby.md)
 * [Go](languages/go.md)
-* [Java (alpha)](languages/java.md)
+* [Java](languages/java.md)
 
 ## Development
 


### PR DESCRIPTION
Remove alpha tag from Java.md now that Java is GA