### PR TITLE
make env:PLATFORMSH_CLI_TOKEN clearer

### DIFF
--- a/src/gettingstarted/cli/api-tokens.md
+++ b/src/gettingstarted/cli/api-tokens.md
@@ -16,7 +16,7 @@ You may be asked to reverify your password, then enter a unique application name
 
 After creating the token it will be displayed once at the top of the page in a green banner.  You may also view it later by clicking the "view" link next to the token name.  You will be asked to reverify your password as well when viewing the token.
 
-Now set that token to an environment variable named `PLATFORMSH_CLI_TOKEN` on your system where the CLI will run.  Consult the documentation for your CI system to see how to do that.
+Now set that token to an environment variable named `env:PLATFORMSH_CLI_TOKEN` on your system where the CLI will run.  Consult the documentation for your CI system to see how to do that.
 
 > **note**
 >


### PR DESCRIPTION
Is there any use-case where it wouldn't be `env:PLATFORMSH_CLI_TOKEN` ?