### PR TITLE
add elasticsearch 6.5 plugins

### DIFF
--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -83,26 +83,33 @@ If there is a publicly available plugin you need that is not listed here, please
 
 This is the complete list of official Elasticsearch plugins that can be enabled:
 
-| Plugin              | Description                                                                       | 2.4 | 5.2 | 5.4 |
-|---------------------|-----------------------------------------------------------------------------------|-----|-----|-----|
-| analysis-icu        | Support ICU Unicode text analysis                                                 | *   | *   | *   |
-| analysis-kuromoji   | Japanese language support                                                         | *   | *   | *   |
-| analysis-smartcn    | Smart Chinese Analysis Plugins                                                    | *   | *   | *   |
-| analysis-stempel    | Stempel Polish Analysis Plugin                                                    | *   | *   | *   |
-| analysis-phonetic   | Phonetic analysis                                                                 | *   | *   | *   |
-| analysis-ukrainian  | Ukrainian language support                                                        |     | *   | *   |
-| cloud-aws           | AWS Cloud plugin, allows storing indices on AWS S3                                | *   |     |     |
-| delete-by-query     | Support for deleting documents matching a given query                             | *   |     |     |
-| discovery-multicast | Ability to form a cluster using TCP/IP multicast messages                         | *   |     |     |
-| ingest-attachment   | Extract file attachments in common formats (such as PPT, XLS, and PDF)            |     | *   | *   |
-| ingest-user-agent   | Extracts details from the user agent string a browser sends with its web requests |     | *   | *   |
-| lang-javascript     | Javascript language plugin, allows the use of Javascript in Elasticsearch scripts |     | *   | *   |
-| lang-python         | Python language plugin, allows the use of Python in Elasticsearch scripts         | *   | *   | *   |
-| mapper-attachments  | Mapper attachments plugin for indexing common file types                          | *   | *   | *   |
-| mapper-murmur3      | Murmur3 mapper plugin for computing hashes at index-time                          | *   | *   | *   |
-| mapper-size         | Size mapper plugin, enables the `_size` meta field                                | *   | *   | *   |
-| repository-s3       | Support for using S3 as a repository for Snapshot/Restore                         |     | *   | *   |
+| Plugin                | Description                                                                               | 2.4 | 5.2 | 5.4 | 6.5 |
+|-----------------------|-------------------------------------------------------------------------------------------|-----|-----|-----|-----|
+| analysis-icu          | Support ICU Unicode text analysis                                                         | *   | *   | *   | *   |
+| analysis-nori         | Integrates Lucene nori analysis module into Elasticsearch                                 |     |     |     | *   |
+| analysis-kuromoji     | Japanese language support                                                                 | *   | *   | *   | *   |
+| analysis-smartcn      | Smart Chinese Analysis Plugins                                                            | *   | *   | *   | *   |
+| analysis-stempel      | Stempel Polish Analysis Plugin                                                            | *   | *   | *   | *   |
+| analysis-phonetic     | Phonetic analysis                                                                         | *   | *   | *   | *   |
+| analysis-ukrainian    | Ukrainian language support                                                                |     | *   | *   | *   |
+| cloud-aws             | AWS Cloud plugin, allows storing indices on AWS S3                                        | *   |     |     |     |
+| delete-by-query       | Support for deleting documents matching a given query                                     | *   |     |     |     |
+| discovery-multicast   | Ability to form a cluster using TCP/IP multicast messages                                 | *   |     |     |     |
+| ingest-attachment     | Extract file attachments in common formats (such as PPT, XLS, and PDF)                    |     | *   | *   | *   |
+| ingest-user-agent     | Extracts details from the user agent string a browser sends with its web requests         |     | *   | *   | *   |
+| lang-javascript       | Javascript language plugin, allows the use of Javascript in Elasticsearch scripts         |     | *   | *   |     |
+| lang-python           | Python language plugin, allows the use of Python in Elasticsearch scripts                 | *   | *   | *   |     |
+| mapper-annotated-text | Adds support for text fields with markup used to inject annotation tokens into the index  |     |     |     | *   |
+| mapper-attachments    | Mapper attachments plugin for indexing common file types                                  | *   | *   | *   |     |
+| mapper-murmur3        | Murmur3 mapper plugin for computing hashes at index-time                                  | *   | *   | *   | *   |
+| mapper-size           | Size mapper plugin, enables the `_size` meta field                                        | *   | *   | *   | *   |
+| repository-s3         | Support for using S3 as a repository for Snapshot/Restore                                 |     | *   | *   | *   |
 
+analysis-nori
+The Korean (nori) Analysis plugin Integrates Lucene nori analysis module into Elasticsearch
+
+mapper-annotated-text
+The Mapper Annotated_text plugin Adds support for text fields with markup used to inject annotation tokens into the index.
 
 ## Upgrading
 

--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -105,12 +105,6 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 | mapper-size           | Size mapper plugin, enables the `_size` meta field                                        | *   | *   | *   | *   |
 | repository-s3         | Support for using S3 as a repository for Snapshot/Restore                                 |     | *   | *   | *   |
 
-analysis-nori
-The Korean (nori) Analysis plugin Integrates Lucene nori analysis module into Elasticsearch
-
-mapper-annotated-text
-The Mapper Annotated_text plugin Adds support for text fields with markup used to inject annotation tokens into the index.
-
 ## Upgrading
 
 The Elasticsearch data format sometimes changes between versions in incompatible ways.  Elasticsearch does not include a data upgrade mechanism as it is expected that all indexes can be regenerated from stable data if needed.  To upgrade (or downgrade) Elasticsearch you will need to use a new service from scratch.


### PR DESCRIPTION
Documents available plug-ins for Elasticsearch 6.5.

https://lab.plat.farm/images/elasticsearch/tree/6.5/files/usr/share/elasticsearch/plugins-available