### PR TITLE
Add some CLI howto tips

### DIFF
--- a/src/gettingstarted/cli.md
+++ b/src/gettingstarted/cli.md
@@ -77,13 +77,13 @@ Options:
 
 ### CLI features
 
-Additional settings to control the operation of the `platform` CLI can be managed in the configuration file (See `.platform/local/project.yaml`) or environment variables. See the [`platformsh-cli` `README` for details](https://github.com/platformsh/platformsh-cli/blob/master/README.md#usage). 
+Additional settings to control the operation of the Platform.sh CLI can be managed in the configuration file (`.platform/local/project.yaml`) or environment variables. See the [`README` for the CLI for details](https://github.com/platformsh/platformsh-cli/blob/master/README.md#usage). 
 
 #### Auto-selecting your project
 
-When your shells working directory is inside a local checkout of your project repository, the `platform` CLI tool will autodetect your project ID and environment, so you don't need to list them as parameters each time.
+When your shell's working directory is inside a local checkout of your project repository, the CLI will autodetect your project ID and environment, so you don't need to list them as parameters each time.
 
-Eg, in your home directory you need to provide the project ID as an argument each time:
+In your home directory, for example, you need to provide the project ID as an argument each time:
 
 ```bash
 ~ $ platform project:info --project=acdefghijkl --environment=staging
@@ -94,7 +94,7 @@ You can instead get the same result with just:
 myproject $ project:info
 ```
 
-You can also set a preferred project ID with the environment variables `PLATFORM_PROJECT`, `PLATFORM_BRANCH` and `PLATFORM_APPLICATION_NAME`..
+You can also set a preferred project ID with the environment variables `PLATFORM_PROJECT`, `PLATFORM_BRANCH` and `PLATFORM_APPLICATION_NAME`.
 
 ```bash
 export PLATFORM_PROJECT=acdefghijkl;
@@ -102,9 +102,9 @@ export PLATFORM_BRANCH=staging;
 project:info
 ```
 
-### Autocomplete on the commandline
+### Autocomplete on the command line
 
-__When installed properly__\* the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
+Once installed\* the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
 ``` bash
 $ platform proj<TAB>
 platform project
@@ -120,7 +120,8 @@ $ platform project:get 2d2dqlhibhdkqj2 --<TAB><TAB>
     --depth          --help           --identity-file  --project        --verbose        --yes  
 ```
 
-* Your system must include the `bash-completion` package or equivalent. This is not available by default on OSX, but can be installed via `brew`. Check your home directory and ensure that the file `~/.platformsh/autocompletion.sh` is being included by your shell. `platform self:install` will attempt a reinstall of this utility if it's needed.
+> **note**
+> Your system must include the `bash-completion` package or equivalent. This is not available by default on OSX, but can be installed via `brew`. Check your home directory and ensure that the file `~/.platformsh/autocompletion.sh` is being included by your shell. `platform self:install` will attempt a reinstall of this utility if it's needed.
 
 
 ## Installing the CLI on Windows 10

--- a/src/gettingstarted/cli.md
+++ b/src/gettingstarted/cli.md
@@ -104,7 +104,7 @@ project:info
 
 ### Autocomplete on the command line
 
-Once installed\* the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
+Once installed, the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
 ``` bash
 $ platform proj<TAB>
 platform project

--- a/src/gettingstarted/cli.md
+++ b/src/gettingstarted/cli.md
@@ -75,6 +75,52 @@ Options:
  --shell (-s)          Launch the shell
 ```
 
+### CLI features
+
+#### Auto-selecting your project
+
+When your working directory is inside a local checkout of your project repository, the platform CLI tool will autodetect your project ID and environment, so you don't need to list them as parameters each time. (See `.platform/local/project.yaml`)
+
+Eg, in your home directory:
+
+```bash
+~ $ platform project:info --project=acdefghijkl --environment=staging
+```
+You can instead get the same result with just:
+```bash
+~ $ cd myproject
+myproject $ project:info
+```
+
+You can also set a preferred project ID with the environment variables `PLATFORM_PROJECT`, `PLATFORM_BRANCH` and `PLATFORM_APPLICATION_NAME`
+
+```bash
+export PLATFORM_PROJECT=acdefghijkl;
+export PLATFORM_BRANCH=staging;
+project:info
+```
+
+### Autocomplete on the commandline
+
+__When installed properly___ the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
+``` bash
+$ platform proj<TAB>
+platform project
+$ platform project<TAB>
+    project:clear-build-cache  project:delete             project:info               project:metadata           projects
+    project:create             project:get                project:list               project:set-remote
+$ platform project:get <TAB><TAB>
+    27vsk5hw7jdca  2dqlhibhdkqj2  3uwms2vi353f6  xmn7qzd2pqhma  yh3p3drn4gglu  
+$ platform project:get 2d<TAB>
+platform project:get 2d2dqlhibhdkqj2
+$ platform project:get 2d2dqlhibhdkqj2 --<TAB><TAB>
+    --build          --environment    --host           --no             --quiet          --version        
+    --depth          --help           --identity-file  --project        --verbose        --yes  
+```
+
+* Your system must include the `bash-completion` package or equivalent. This is not available by default on OSX, but can be installed via `brew`. Check your home directory and ensure that the file `~/.platformsh/autocompletion.sh` is being included by your shell. `platform self:install` will attempt a reinstall of this utility if it's needed.
+
+
 ## Installing the CLI on Windows 10
 
 There are multiple ways to install the CLI on Windows 10. Platform.sh recommends using Bash for Windows (Windows Subsystem for Linux).

--- a/src/gettingstarted/cli.md
+++ b/src/gettingstarted/cli.md
@@ -77,11 +77,13 @@ Options:
 
 ### CLI features
 
+Additional settings to control the operation of the `platform` CLI can be managed in the configuration file (See `.platform/local/project.yaml`) or environment variables. See the [`platformsh-cli` `README` for details](https://github.com/platformsh/platformsh-cli/blob/master/README.md#usage). 
+
 #### Auto-selecting your project
 
-When your working directory is inside a local checkout of your project repository, the platform CLI tool will autodetect your project ID and environment, so you don't need to list them as parameters each time. (See `.platform/local/project.yaml`)
+When your shells working directory is inside a local checkout of your project repository, the `platform` CLI tool will autodetect your project ID and environment, so you don't need to list them as parameters each time.
 
-Eg, in your home directory:
+Eg, in your home directory you need to provide the project ID as an argument each time:
 
 ```bash
 ~ $ platform project:info --project=acdefghijkl --environment=staging
@@ -92,7 +94,7 @@ You can instead get the same result with just:
 myproject $ project:info
 ```
 
-You can also set a preferred project ID with the environment variables `PLATFORM_PROJECT`, `PLATFORM_BRANCH` and `PLATFORM_APPLICATION_NAME`
+You can also set a preferred project ID with the environment variables `PLATFORM_PROJECT`, `PLATFORM_BRANCH` and `PLATFORM_APPLICATION_NAME`..
 
 ```bash
 export PLATFORM_PROJECT=acdefghijkl;
@@ -102,7 +104,7 @@ project:info
 
 ### Autocomplete on the commandline
 
-__When installed properly___ the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
+__When installed properly__\* the `platform` CLI tool provides tab autocompletion for commands, options, and even some values (your projects, valid regions). eg:
 ``` bash
 $ platform proj<TAB>
 platform project


### PR DESCRIPTION
Following recent discussions in #cli , some doc additions I went looking for but did not find.

A couple of useful tips about using the CLI I wish I'd known earlier:
- autocomplete on the CLI
- autodetecting or presetting the project id