### PR TITLE
SECOPS-714 fix broken troubleshooting link on pen test page

### DIFF
--- a/src/security/pen-test.md
+++ b/src/security/pen-test.md
@@ -22,5 +22,5 @@ Platform.sh understands the need for application owners to ensure the integrity,
 
 * Please limit scans to a maximum of 20 Mbps and 50 requests per second in order to prevent triggering denial of service bans.
 
-
-If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please see the Security and Compliance [Troubleshooting](/security/troubleshooting.md) section for common resolutions.
+## Troubleshooting
+If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please ensure your container is [updated](/security/updates.md) and retest. If the problem remains, please [contact support](/overview/getting-help.md).

--- a/src/security/pen-test.md
+++ b/src/security/pen-test.md
@@ -23,4 +23,5 @@ Platform.sh understands the need for application owners to ensure the integrity,
 * Please limit scans to a maximum of 20 Mbps and 50 requests per second in order to prevent triggering denial of service bans.
 
 ## Troubleshooting
+
 If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please ensure your container is [updated](/security/updates.md) and retest. If the problem remains, please [contact support](/overview/getting-help.md).


### PR DESCRIPTION
SECOPS-714 fix broken troubleshooting section at the bottom of the pen test page. I'm the culprit. I reworked the troubleshooting page a while ago and missed updating this section.