### PR TITLE
Disable the passthru since there's no application to passthru to. 

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -48,6 +48,9 @@ web:
             # list multiple fallbacks here if desired.
             index:
                 - "index.html"
+            # Since there is no backend application, return a 404 for a missing
+            # file rather than passing through to a non-existent application.
+            passthru: false
             # Set a 5 minute cache lifetime on all static files.
             expires: 300s
             # Disable all scripts, since we don't have any anyway.


### PR DESCRIPTION
This seems like good general practice for a static site.

(Damien mentioned it in passing in Slack when debugging a customer, so since this file is our documentation for static sites, we should probably include it.)