### PR TITLE
Remove branch-sensitive env vars from Source Ops

### DIFF
--- a/src/configuration/app/source-operations.md
+++ b/src/configuration/app/source-operations.md
@@ -43,7 +43,7 @@ platform source-operation:run update --variable env:FOO=bar --variable env:BAZ=b
 When this operation is triggered:
 
 * A clean Git checkout of the current environment HEAD commit is created; this checkout doesn't have any remotes, has all the tags defined in the project, but only has the current environment branch.
-* Sequentially, for each application that has defined this operation, the operation command is launched in the container image of the application.  The environment will have all of the variables available during the build phase, plus `PLATFORM_BRANCH` and `PLATFORM_ENVIRONMENT`, optionally overridden by the variables specified in the operation payload.
+* Sequentially, for each application that has defined this operation, the operation command is launched in the container image of the application.  The environment will have all of the variables available during the build phase, optionally overridden by the variables specified in the operation payload.
 * At the end of the process, if any commits were created, the new commits are pushed to the repository and the normal build process of the environment is triggered.
 
 Note that these operations run in an isolated container: it is not part of the runtime cluster of the environment, and doesn't require the environment to be running.  Also be aware that if multiple applications in a single project both result in a new commit, that will appear as two distinct commits in the Git history but only a single new build/deploy cycle will occur.


### PR DESCRIPTION
Since they don't work yet.