### PR TITLE
Change order in go live GS guide as well

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -43,8 +43,8 @@
   * [Going live](gettingstarted/going-live.md)
     * [First steps](gettingstarted/going-live/first-steps.md)
     * [Upgrade plan](gettingstarted/going-live/upgrade-plan.md)
-    * [Set your domain](gettingstarted/going-live/set-domain.md)
     * [Configure DNS](gettingstarted/going-live/configure-dns.md)
+    * [Set your domain](gettingstarted/going-live/set-domain.md)
     * [Troubleshooting](gettingstarted/going-live/troubleshooting.md)
 
 ## Configuration


### PR DESCRIPTION
I used the current order to put this guide together, so it should be switched as well.