### PR TITLE
Remove mention of password login for the CLI

### DIFF
--- a/src/development/cli.md
+++ b/src/development/cli.md
@@ -24,14 +24,9 @@ The [Platform.sh CLI](https://github.com/platformsh/platformsh-cli) will authent
 platform
 ```
 
-The credentials you enter are the same as your [Platform.sh account](https://accounts.platform.sh/user).
+You will be asked to log in via a browser.
 
-> **note**
-> If you have created your account using the OAuth Login (via Bitbucket, GitHub or Google) then in order to use the Platform CLI you
-> will need to create a password, which you can do using the ['Request new password' tool](https://accounts.platform.sh/user/password)
-
-Enter your details. A list of your projects appears, along with some
-tips for getting started.
+When you are logged in, a list of your projects appears, along with some tips for getting started.
 
 **Your command-line tools are now ready to use with Platform.sh.**
 


### PR DESCRIPTION
Browser login has been available for a long time, and password login will be removed in future. See https://github.com/platformsh/platformsh-cli/pull/850