### PR TITLE
Use relationship/service naming conventions for snippets.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -926,9 +926,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "pshregistry-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pshregistry-parser/-/pshregistry-parser-1.0.3.tgz",
-      "integrity": "sha512-QSeKLZGQioxwFbx6lYTDcchwla4vTq58qaL8f9QlTzYg0ifV2VWx0CFeZY97sLDMZxK6Yl84UVbJohwBxa8L/g=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pshregistry-parser/-/pshregistry-parser-1.0.4.tgz",
+      "integrity": "sha512-rol129xe+1v5LgQYmoMnA4fKF5WiskpQkG8SCrbJzwySul8dZKt3I/kdMUX9Hfu8qlXgK+JptwmAAh357J4L+A=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "platformsh-user-widget": "1.0.49",
-    "pshregistry-parser": "1.0.3",
+    "pshregistry-parser": "1.0.4",
     "eslint": "5.16.0"
   },
   "devDependencies": {},

--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -59,7 +59,7 @@ You can then use the service in a configuration file of your application with so
 The Elasticsearch 2.4 and later services offer a number of plugins.  To enable them, list them under the `configuration.plugins` key in your `services.yaml` file, like so:
 
 ```yaml
-mysearch:
+search:
     type: "elasticsearch:7.2"
     disk: 1024
     configuration:

--- a/src/configuration/services/headless-chrome.md
+++ b/src/configuration/services/headless-chrome.md
@@ -59,7 +59,7 @@ Using the [Node.js Config Reader](https://github.com/platformsh/config-reader-no
 const platformsh = require('platformsh-config');
 
 let config = platformsh.config();
-const credentials = config.credentials('headless');
+const credentials = config.credentials('chromeheadlessbrowser');
 ```
 
 and use them to define the `browserURL` parameter of `puppeteer.connect()` within an `async` function:
@@ -68,7 +68,7 @@ and use them to define the `browserURL` parameter of `puppeteer.connect()` withi
 exports.takeScreenshot = async function (url) {
     try {
         // Connect to chrome-headless using pre-formatted puppeteer credentials
-        const formattedURL = config.formattedCredentials('headless', 'puppeteer');
+        const formattedURL = config.formattedCredentials('chromeheadlessbrowser', 'puppeteer');
         const browser = await puppeteer.connect({browserURL: formattedURL});
 
         ...

--- a/src/configuration/services/influxdb.md
+++ b/src/configuration/services/influxdb.md
@@ -35,8 +35,8 @@ if (getenv('PLATFORM_RELATIONSHIPS')) {
 	$relationships = json_decode(base64_decode($relationships), TRUE);
 
 	// For a relationship named 'timedb' referring to one endpoint.
-	if (!empty($relationships['timedb'])) {
-		foreach ($relationships['timedb'] as $endpoint) {
+	if (!empty($relationships['database'])) {
+		foreach ($relationships['database'] as $endpoint) {
 			$settings['influxdb_host'] = $endpoint['host'];
 			$settings['influxdb_port'] = $endpoint['port'];
 			break;

--- a/src/configuration/services/mongodb.md
+++ b/src/configuration/services/mongodb.md
@@ -69,7 +69,7 @@ platform tunnel:open
 That will open an SSH tunnel to all services on your current environment, and produce output something like the following:
 
 ```text
-SSH tunnel opened on port 30000 to relationship: mongodb
+SSH tunnel opened on port 30000 to relationship: database
 SSH tunnel opened on port 30001 to relationship: redis
 ```
 

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -55,13 +55,9 @@ Note that the minimum disk size for `mysql`/`oracle-mysql` is 256MB.
 
 Despite these service type differences, MariaDB and Oracle MySQL both use the `mysql` endpoint in their configuration.
 
-For MariaDB, the endpoint does not change whether you used the `mysql` service type:
+For MariaDB, the endpoint does not change whether you used the `mysql` or `mariadb` service type:
 
 {% codesnippet "/registry/images/examples/full/mysql.app.yaml", language="yaml" %}{% endcodesnippet %}
-
-or the `mariadb` service type:
-
-{% codesnippet "/registry/images/examples/full/mariadb.app.yaml", language="yaml" %}{% endcodesnippet %}
 
 The same goes for using the `oracle-mysql` service type as well.
 
@@ -97,8 +93,8 @@ If you are using version `10.0` or later of this service it is possible to defin
 Consider the following illustrative example:
 
 ```yaml
-mysqldb:
-    type: mysql:10.0
+db:
+    type: mysql:10.2
     disk: 2048
     configuration:
         schemas:
@@ -156,7 +152,7 @@ For version 10.2 and later, a select few MariaDB configuration properties from t
 At this time, only the `max_allowed_packet` size is available, and defaults to `16` (in MB).  Legal values are from `1` to `100`.
 
 ```yaml
-mysqldb:
+db:
     type: mysql:10.2
     disk: 2048
     configuration:

--- a/src/configuration/services/network-storage.md
+++ b/src/configuration/services/network-storage.md
@@ -119,7 +119,7 @@ name: 'app'
 type: 'php:7.2'
 
 relationships:
-    database: 'mysqldb:mysql'
+    database: 'db:mysql'
 
 hooks:
   # ...

--- a/src/configuration/services/postgresql.md
+++ b/src/configuration/services/postgresql.md
@@ -103,8 +103,8 @@ platform sql --relationship database -e master < my_database_snapshot.sql
 Platform.sh supports a number of PostgreSQL extensions.  To enable them, list them under the `configuration.extensions` key in your `services.yaml` file, like so:
 
 ```yaml
-postgresql:
-    type: "postgresql:11"
+db:
+    type: postgresql:11
     disk: 1025
     configuration:
         extensions:

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -98,7 +98,7 @@ Consult the documentation for your connection library and Redis itself for furth
 On the Ephemeral `redis` service it is also possible to select the key eviction policy.  That will control how Redis behaves when it runs out of memory for cached items and needs to clear old items to make room.
 
 ```yaml
-rediscache:
+cache:
     type: redis:5.0
     configuration:
       maxmemory_policy: allkeys-lru
@@ -137,7 +137,7 @@ Using the same configuration but with your Redis relationship named `sessionstor
 
 ```yaml
 # .platform/services.yaml
-rediscache:
+cache:
     type: redis:5.0
 ```
 

--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -64,7 +64,7 @@ runtime:
         - redis
 
 relationships:
-    applicationcache: "rediscache:redis"
+    rediscache: "cache:redis"
 ```
 
 You can then use the service in a configuration file of your application with something like:

--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -55,7 +55,7 @@ For Solr 4, Platform.sh supports only a single core per server called `collectio
 If you want to provide your own Solr configuration, you can add a `core_config` key in your ``.platform/services.yaml``:
 
 ```yaml
-mysearch:
+search:
     type: solr:4.10
     disk: 1024
     configuration:
@@ -65,7 +65,7 @@ mysearch:
 The `directory` parameter points to a directory in the Git repository, in or below the `.platform/` folder. This directory needs to contain everything that Solr needs to start a core. At the minimum, `solrconfig.xml` and `schema.xml`.  For example, place them in `.platform/solr/conf/` such that the `schema.xml` file is located at `.platform/solr/conf/schema.xml`.   You can then reference that path like this -
 
 ```yaml
-mysearch:
+search:
     type: solr:4.10
     disk: 1024
     configuration:
@@ -77,7 +77,7 @@ mysearch:
 For Solr 6 and later Platform.sh supports multiple cores via different endpoints.  Cores and endpoints are defined separately, with endpoints referencing cores.  Each core may have its own configuration or share a configuration.  It is best illustrated with an example.
 
 ```yaml
-solrsearch:
+search:
     type: solr:8.0
     disk: 1024
     configuration:
@@ -101,8 +101,8 @@ Each endpoint is then available in the relationships definition in `.platform.ap
 
 ```yaml
 relationships:
-    solr1: 'solrsearch:main'
-    solr2: 'solrsearch:extra'
+    solrsearch1: 'search:main'
+    solrsearch2: 'search:extra'
 ```
 
 That is, the application's environment would include a `solr1` relationship that connects to the `main` endpoint, which is the `mainindex` core, and a `solr2` relationship that connects to the `extra` endpoint, which is the `extraindex` core.
@@ -135,7 +135,7 @@ The relationships array would then look something like the following:
 For even more customizability, it's also possible to define Solr configsets.  For example, the following snippet would define one configset, which would be used by all cores.  Specific details can then be overriden by individual cores using `core_properties`, which is equivalent to the Solr `core.properties` file.
 
 ```yaml
-solrsearch:
+search:
     type: solr:8.0
     disk: 1024
     configuration:
@@ -166,7 +166,7 @@ Note that not all core.properties features make sense to specify in the core_pro
 If no configuration is specified, the default configuration is equivalent to:
 
 ```yaml
-solrsearch:
+search:
     type: solr:8.0
     configuration:
         cores:

--- a/src/configuration/services/varnish.md
+++ b/src/configuration/services/varnish.md
@@ -51,7 +51,7 @@ Where `application` is the name of the relationship defined in `services.yaml`. 
 If you have multiple applications fronted by the same Varnish instance then you will need to include logic to determine to which application a request is forwarded.  For example:
 
 ```yaml
-varnish:
+proxy:
     type: varnish:6.0
     relationships:
         blog: 'blog:http'

--- a/src/registry/images/registry.json
+++ b/src/registry/images/registry.json
@@ -3,8 +3,8 @@
     "description": "",
     "disk": false,
     "docs": {
-      "relationship_name": "headless",
-      "service_name": "headless",
+      "relationship_name": "chromeheadlessbrowser",
+      "service_name": "headlessbrowser",
       "url": "\/configuration\/services\/headless-chrome.html"
     },
     "endpoint": "http",
@@ -51,8 +51,8 @@
     "description": "A manufacture service for Elasticsearch",
     "disk": true,
     "docs": {
-      "relationship_name": "elasticsearch",
-      "service_name": "mysearch",
+      "relationship_name": "essearch",
+      "service_name": "search",
       "url": "\/configuration\/services\/elasticsearch.html"
     },
     "endpoint": "elasticsearch",
@@ -107,8 +107,8 @@
     "description": "",
     "disk": true,
     "docs": {
-      "relationship_name": "timedb",
-      "service_name": "influx",
+      "relationship_name": "database",
+      "service_name": "db",
       "url": "\/configuration\/services\/influxdb.html"
     },
     "endpoint": "influxdb",
@@ -157,8 +157,8 @@
     "description": "",
     "disk": true,
     "docs": {
-      "relationship_name": "kafka",
-      "service_name": "mykafka",
+      "relationship_name": "kafkaqueue",
+      "service_name": "queue",
       "url": "\/configuration\/services\/kafka.html"
     },
     "endpoint": "kafka",
@@ -207,7 +207,7 @@
     "disk": true,
     "docs": {
       "relationship_name": "database",
-      "service_name": "mydatabase",
+      "service_name": "db",
       "url": "\/configuration\/services\/mysql.html"
     },
     "endpoint": "mysql",
@@ -231,8 +231,8 @@
     "repo_name": "memcached",
     "disk": false,
     "docs": {
-      "relationship_name": "cache",
-      "service_name": "memcached",
+      "relationship_name": "memcachedcache",
+      "service_name": "cache",
       "url": "\/configuration\/services\/memcached.html"
     },
     "endpoint": "memcached",
@@ -255,7 +255,7 @@
     "disk": true,
     "docs": {
       "relationship_name": "database",
-      "service_name": "mydatabase",
+      "service_name": "db",
       "url": "\/configuration\/services\/mongodb.html"
     },
     "endpoint": "mongodb",
@@ -334,7 +334,7 @@
     "disk": true,
     "docs": {
       "relationship_name": "database",
-      "service_name": "mydatabase",
+      "service_name": "db",
       "url": "\/configuration\/services\/mysql.html"
     },
     "endpoint": "mysql",
@@ -386,7 +386,7 @@
     "disk": true,
     "docs": {
       "relationship_name": "database",
-      "service_name": "mydatabase",
+      "service_name": "db",
       "url": "\/configuration\/services\/postgresql.html"
     },
     "endpoint": "postgresql",
@@ -436,8 +436,8 @@
     "repo_name": "rabbitmq",
     "disk": true,
     "docs": {
-      "relationship_name": "rabbitmq",
-      "service_name": "myrabbitmq",
+      "relationship_name": "rabbitmqqueue",
+      "service_name": "queue",
       "url": "\/configuration\/services\/rabbitmq.html"
     },
     "endpoint": "rabbitmq",
@@ -461,8 +461,8 @@
     "repo_name": "redis",
     "disk": false,
     "docs": {
-      "relationship_name": "applicationcache",
-      "service_name": "rediscache",
+      "relationship_name": "rediscache",
+      "service_name": "cache",
       "url": "\/configuration\/services\/redis.html"
     },
     "endpoint": "redis",
@@ -513,8 +513,8 @@
     "repo_name": "solr",
     "disk": true,
     "docs": {
-      "relationship_name": "solr",
-      "service_name": "mysearch",
+      "relationship_name": "solrsearch",
+      "service_name": "search",
       "url": "\/configuration\/services\/solr.html"
     },
     "endpoint": "solr",
@@ -543,7 +543,7 @@
     "disk": false,
     "docs": {
       "relationship_name": "varnishstats",
-      "service_name": "varnish",
+      "service_name": "proxy",
       "url": "\/configuration\/services\/varnish.html"
     },
     "endpoint": "http+stats",


### PR DESCRIPTION
**Don't merge until Registry-Parser MR !6 is**

DEVREL-321

* All service/relationship names are updated to match the new convention in the registry, and in any other manually written snippets.
* Because the same "database/db" convention is used for mysql, mariadb, and oracle-mysql types, that page is cleaned up a bit so that it's not overly redundant.

## TODO

* Language-examples use relationship names that should be updated to the convention
    * This brings up a question. Language examples is a live site that uses most of the services, including multiple databases that the convention would say should all be the primary "database/db". That won't work on LE, since multiple services can't have the same relationship name. But if registry uses "database/db" for each of these potential primary databases, the code snippets and service usage examples won't match. This is also an issue if console team wants to eventually use snippet files to append/generate  a full relationships block/services.yaml.
* Persistent Redis: The relationship/service name for `redis-persistent` is defined in registry-parser, so there will need to be a separate PR there in order to update the snippet here https://pr-1218-fi5ym5q-652soceglkw4u.eu-3.platformsh.site/configuration/services/redis.html#persistent-redis. I'm thinking "data" for the service name.
    * Registry Parser MR # 6
    * Need to update `pshregistry-parser` to 1.0.4