### PR TITLE
Fix redis for native php sessions.

### DIFF
--- a/src/configuration/services/redis.md
+++ b/src/configuration/services/redis.md
@@ -135,19 +135,16 @@ redis-cli -h applicationcache.internal -p 6379
 
 Using the same configuration but with your Redis relationship named `sessionstorage`:
 
-```yaml
-# .platform/services.yaml
-cache:
-    type: redis:5.0
-```
-
 `.platform/services.yaml`
 
 {% codesnippet "/registry/images/examples/full/redis.services.yaml", language="yaml" %}{% endcodesnippet %}
 
 `.platform.app.yaml`
 
-{% codesnippet "/registry/images/examples/full/redis.services.yaml", language="yaml" %}{% endcodesnippet %}
+```yaml
+relationships:
+  sessionstorage: "cache:redis"
+```
 
 ```yaml
 # .platform.app.yaml


### PR DESCRIPTION
Fixes copypasta on this section https://docs.platform.sh/configuration/services/redis.html#using-redis-as-handler-for-native-php-sessions, which should retain the `sessionstorage` relationship name.