### PR TITLE
Avoid `nvm: not found` on PE

### DIFF
--- a/src/languages/nodejs/nvm.md
+++ b/src/languages/nodejs/nvm.md
@@ -18,6 +18,8 @@ hooks:
         nvm install 9.5.0
     deploy: |
         unset NPM_CONFIG_PREFIX
+        export NVM_DIR="$PLATFORM_APP_DIR/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         nvm use 9.5.0
  ```
    


### PR DESCRIPTION
It sounds like this is required.

To avoid 
```    Deploying applications
      Starting deployment
      Preparing slugs
      Entering maintenance mode
      Running deploy hook
      W: /etc/platform/7q34uh34hl5oa_stg/auto_deploy.sh: 2: /etc/platform/7q34uh34hl5oa_stg/auto_deploy.sh: nvm: not found
```

I don't have the issue on PS though. (project id: `7q34uh34hl5oa`