### PR TITLE
Make-etc-hosts-easier

### DIFF
--- a/src/golive/steps.md
+++ b/src/golive/steps.md
@@ -55,6 +55,12 @@ In OS X and Linux you can add that IP  to your `/etc/hosts` file.  In Windows th
 
 ![Hosts File](/images/config-files/hosts-file.png)
 
+
+Alternatively there is also an add-on for firefox and google chrome that allow you to dynamically switch DNS IP addresses. No need to fiddle with your hosts files.
+
+* [Firefox LiveHosts add-on](https://addons.mozilla.org/en-US/firefox/addon/livehosts/) 
+* [Google Chrome LiveHosts add-on](https://chrome.google.com/webstore/detail/livehosts/hdpoplemgeaioijkmoebnnjcilfjnjdi?hl=en)
+
 > **note**
 > Do not put the IP address you see here, but the one you got from the ping command.
 > *Also, remember to remove this entry after you have configured DNS!*

--- a/src/golive/steps.md
+++ b/src/golive/steps.md
@@ -56,7 +56,7 @@ In OS X and Linux you can add that IP  to your `/etc/hosts` file.  In Windows th
 ![Hosts File](/images/config-files/hosts-file.png)
 
 
-Alternatively there is also an add-on for firefox and google chrome that allow you to dynamically switch DNS IP addresses. No need to fiddle with your hosts files.
+Alternatively there is also an add-on for Firefox and Google Chrome that allow you to dynamically switch DNS IP addresses without modifying your `hosts` file.
 
 * [Firefox LiveHosts add-on](https://addons.mozilla.org/en-US/firefox/addon/livehosts/) 
 * [Google Chrome LiveHosts add-on](https://chrome.google.com/webstore/detail/livehosts/hdpoplemgeaioijkmoebnnjcilfjnjdi?hl=en)


### PR DESCRIPTION
There is an add-on on chrome and firefox that allows you to do the same thing, but without having to fiddle with /etc/hosts file.
Makes it a lot easier when you set up websites often.