### PR TITLE
Pull in supported version tables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules/*
 .idea/*
 .platform/local/*
 src/registry/images/examples/*
+src/registry/images/tables/*
 src/registry/images/registry.yaml

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -40,6 +40,7 @@ hooks:
       # Gitbook doesn't copy over the generated example configuration files to the built book
       #  automatically, so we have to do that manually.
       cp -r src/registry/images/examples _book/registry/images
+      cp -r src/registry/images/tables _book/registry/images
       cp -r src/registry/images/registry.yaml _book/registry/images/
 
 # There is no need for a writable file mount, so set it to the smallest possible size.

--- a/package-lock.json
+++ b/package-lock.json
@@ -926,9 +926,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "pshregistry-parser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pshregistry-parser/-/pshregistry-parser-1.0.4.tgz",
-      "integrity": "sha512-rol129xe+1v5LgQYmoMnA4fKF5WiskpQkG8SCrbJzwySul8dZKt3I/kdMUX9Hfu8qlXgK+JptwmAAh357J4L+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pshregistry-parser/-/pshregistry-parser-1.1.0.tgz",
+      "integrity": "sha512-Mdq6mPh6SUxuw+hinfEkRu46P4btXs4KJBJOKJcf91qKXKKVxtDJCpQBb/ja6KIBhTpXZuzJz31nMT8XXSa0cg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "platformsh-user-widget": "1.0.49",
-    "pshregistry-parser": "1.0.4",
+    "pshregistry-parser": "1.1.0",
     "eslint": "5.16.0"
   },
   "devDependencies": {},

--- a/src/configuration/app/type.md
+++ b/src/configuration/app/type.md
@@ -1,21 +1,16 @@
 # Type
 
-The `type` key defines the base container image that will be used to run the application.  There is a separate base container image for each primary language for the application, often in multiple versions.  Supported languages include:
+The `type` key defines the base container image that will be used to run the application.  There is a separate base container image for each primary language for the application, often in multiple versions.  
 
-* [`php`](/languages/php.md)
-* [`java`](/languages/java.md)
-* [`nodejs`](/languages/nodejs.md)
-* [`python`](/languages/python.md)
-* [`ruby`](/languages/ruby.md)
-* [`golang`](/languages/go.md)
+## Supported types
 
-See the appropriate language page for all available versions.
+Available languages and their supported versions include:
 
-**Example**
+{% include "../../registry/images/tables/runtimes_supported.md" %}
 
-```yaml
-type: php:7.1
-```
+## Example configuration
+
+{% codesnippet "/registry/images/examples/full/php.app.yaml", language="yaml" %}{% endcodesnippet %}
 
 ## Runtime
 

--- a/src/configuration/services.md
+++ b/src/configuration/services.md
@@ -40,7 +40,7 @@ The `name` you want to give to your service. You are free to name each service a
 
 ### Type
 
-The `type` of your service. It's using the format ``type:version``.
+The `type` of your service. It's using the format `type:version`.
 
 If you specify a version number which is not available, you'll see this error when pushing your changes:
 
@@ -49,6 +49,10 @@ Validating configuration files.
 E: Error parsing configuration files:
     - services.mysql.type: 'mysql:5.6' is not a valid service type.
 ```
+
+Service types and their supported versions include:
+
+{% include "../registry/images/tables/services_supported.md" %}
 
 ### Disk
 

--- a/src/configuration/services/mysql.md
+++ b/src/configuration/services/mysql.md
@@ -59,7 +59,7 @@ Despite these service type differences, MariaDB and Oracle MySQL both use the `m
 
 For MariaDB, the endpoint does not change whether you used the `mysql` or `mariadb` service type:
 
-{% codesnippet "/registry/images/examples/full/mysql.app.yaml", language="yaml" %}{% endcodesnippet %}
+{% codesnippet "/registry/images/examples/full/mariadb.app.yaml", language="yaml" %}{% endcodesnippet %}
 
 The same goes for using the `oracle-mysql` service type as well.
 

--- a/src/gettingstarted/own-code/app-configuration.md
+++ b/src/gettingstarted/own-code/app-configuration.md
@@ -39,14 +39,7 @@ The `.platform.appl.yaml` file is extremely flexible, and can contain many lines
 
   Set `version` to one supported by Platform.sh, which you can find below as well as in the documentation for each language:
 
-| **Language**                     | **`runtime`** | **Supported `version`** |
-|----------------------------------|---------------|-------------------------|
-| [PHP](/languages/php.md)         | `php`         | 7.1, 7.2, 7.3           |
-| [Node.js](/languages/nodejs.md)  | `nodejs`      | 6.11, 8.9, 10           |
-| [Python](/languages/python.md)   | `python`      | 2.7, 3.5, 3.6, 3.7      |
-| [Ruby](/languages/ruby.md)       | `ruby`        | 2.3, 2.4, 2.5, 2.6      |
-| [Go](/languages/go.md)           | `golang`      | 1.11, 1.12              |
-| [Java](/languages/java.md)       | `java`        | 8, 11, 12               |
+{% include "../../registry/images/tables/runtimes_supported.md" %}
 
 * `disk`: The [disk](/configuration/app/storage.md) attribute defines that amount of persistent storage you need to have available for your application, and requires a minimum value of 256 MB.
 

--- a/src/gettingstarted/own-code/app-configuration.md
+++ b/src/gettingstarted/own-code/app-configuration.md
@@ -47,18 +47,11 @@ There are a few additional keys in `.platform.app.yaml` you will likely need to 
 
 * `relationships`: [Relationships](/configuration/app/relationships.md) define how services are mapped within your application. Without this block, an application cannot by default communicate with a service container. Provide a unique name for each relationship and associate it with a service. For example, if in the previous step you defined a MariaDB container in your `.platform/services.yaml` with
 
-    ```yaml
-    mysqldb:
-        type: mysql:10.2
-        disk: 256
-    ```
+    {% codesnippet "/registry/images/examples/full/mariadb.services.yaml", language="yaml" %}{% endcodesnippet %}
 
     You must define a relationship (i.e. `database`) in `.platform.app.yaml` to connect to it:
 
-    ```yaml
-    relationships:
-        database: "mysqldb:mysql"
-    ```
+    {% codesnippet "/registry/images/examples/full/mariadb.app.yaml", language="yaml" %}{% endcodesnippet %}
 
 * [Build and deploy tasks](/configuration/app/build.md): There are a number of ways in which your Git repository is turned into a running application. In general, the build process will run the the build flavor, install dependencies, and then execute the build hook you provide. When the build process is completed, the deploy process will run the deploy hook.
 

--- a/src/gettingstarted/own-code/service-configuration.md
+++ b/src/gettingstarted/own-code/service-configuration.md
@@ -30,23 +30,7 @@ If you're application does not use any services at this point then you can leave
 
   Consult the table below that lists all Platform.sh maintained services, along with their `type` and supported `version`s. The links will take you to each service's dedicated page in the documentation.
 
-| **Service**                                                    | **`type`**        | **Supported `version`**             |
-|----------------------------------------------------------------|-------------------|-------------------------------------|
-| [Elasticsearch](/configuration/services/elasticsearch.md)      | `elasticsearch`   | 5.3, 5.4, 6.5                       |
-| [Headless Chrome](/configuration/services/headless-chrome.md)  | `chrome-headless` | 73                                  |
-| [InfluxDB](/configuration/services/influxdb.md)                | `influxdb`        | 1.2, 1.3, 1.7                       |
-| [Kafka](/configuration/services/kafka.md)                      | `kafka`           | 2.1                                 |
-| [Memcached](/configuration/services/memcached.md)              | `memcached`       | 1.4                                 |
-| [MongoDB](/configuration/services/mongodb.md)                  | `mongodb`         | 3.0, 3.2, 3.4, 3.6                  |
-| [MariaDB](/configuration/services/mysql.md)                    | `mysql`           | 10.0, 10.1, 10.2                    |
-| [MySQL](/configuration/services/mysql.md)                      | `oracle-mysql`    | 5.7, 8.0                            |
-| [Network Storage](/configuration/services/network-storage.md)  | `network-storage` | 1.0                                 |
-| [PostgreSQL](/configuration/services/postgresql.md)            | `postgresql`      | 9.6, 10, 11                         |
-| [RabbitMQ](/configuration/services/rabbitmq.md)                | `rabbitmq`        | 3.5, 3.6, 3.7                       |
-| [Redis](/configuration/services/redis.md)                      | `redis`           | 3.2, 4.0, 5.0                       |
-| [Solr](/configuration/services/solr.md)                        | `solr`            | 3.6, 4.10, 6.3, 6.6, 7.6, 7.7, 8.0  |
-| [Varnish](/configuration/services/varnish.md)                  | `varnish`         | 5.2, 6.0                            |
-
+{% include "../../registry/images/tables/services_supported.md" %}
 
 * `disk`: The `disk` attribute configures the amount of persistent disk that will be allocated between all of your services. Projects by default are allocated 5 GB (5120 MB), and that space can be distributed across all of your services. Note that not all services require disk space. If you specify a `disk` attribute for a service that doesn't use it, like Redis, you will receive an error when trying to push your changes.
 


### PR DESCRIPTION
Supported version tables save to `src/registry/images/table` on build, and `{% include %}` is used to pull them into 

- [Getting Started/Import your own code/Service configuration](https://pr-1235-rarpbva-652soceglkw4u.eu-3.platformsh.site/gettingstarted/own-code/service-configuration.html)
- [Getting Started/Import your own code/Application configuration](https://pr-1235-rarpbva-652soceglkw4u.eu-3.platformsh.site/gettingstarted/own-code/app-configuration.html)
- [Configuration/Apps/Types](https://pr-1235-rarpbva-652soceglkw4u.eu-3.platformsh.site/configuration/app/type.html#supported-types)
- [Configuration/Services#Type](https://pr-1235-rarpbva-652soceglkw4u.eu-3.platformsh.site/configuration/services.html#type)
