### PR TITLE
Document default PORT value.

### DIFF
--- a/src/languages/python.md
+++ b/src/languages/python.md
@@ -41,7 +41,7 @@ In this example, we use Gunicorn to run our WSGI application.  Configure the `.p
        start: "gunicorn -b 0.0.0.0:$PORT project.wsgi:application"
    ```
 
-   This assumes the WSGI file is `project/wsgi.py` and the WSGI application object is named `application` in the WSGI file.
+   This assumes the WSGI file is `project/wsgi.py` and the WSGI application object is named `application` in the WSGI file. By default, `$PORT` is `8888`.
 
 4. Define the web locations your application is using:
 


### PR DESCRIPTION
When an user is following the python getting started, the $PORT variable
is referenced in the documentation but nowhere in the text it says which
is the default. Fix that by being explicit what are the default in the
first occurance.