### PR TITLE
CM-251: removed compliance guidance about enterprise plans as it is no longer valid

### DIFF
--- a/src/security/compliance-guidance.md
+++ b/src/security/compliance-guidance.md
@@ -10,8 +10,6 @@ Platform.sh provides a Platform as a Service (PaaS) solution which our customers
 
 ## Security & Compensating Controls
 
-* For those customers needing to meet PCI SAQ C or SAQ D, a Platform.sh Enterprise Plan may be needed in order to fully meet your needs. Please [contact us](https://platform.sh/contact) for more information.
-
 * For a list of security measures, please see our [Security page](https://platform.sh/security).
 
 * Please take note that customer environments are deployed in a read-only instance, segregated with GRE and IPSEC tunnels, which often permits compensating controls to be claimed for several PCI requirements.


### PR DESCRIPTION
CM-251: Removed some wording about certain client PCI compliance targets needing PE. This is no longer true.