### PR TITLE
Use the same service name as in routes.yaml below

### DIFF
--- a/src/configuration/services/varnish.md
+++ b/src/configuration/services/varnish.md
@@ -51,7 +51,7 @@ Where `application` is the name of the relationship defined in `services.yaml`. 
 If you have multiple applications fronted by the same Varnish instance then you will need to include logic to determine to which application a request is forwarded.  For example:
 
 ```yaml
-proxy:
+varnish:
     type: varnish:6.0
     relationships:
         blog: 'blog:http'


### PR DESCRIPTION
In the varnish config example service is called "proxy", while in `routes.yaml` example down on the same page it is addressed as "varnish:http".
Just copying and pasting code chunks will not work because of this. 

This change makes service name the same in both examples.