### PR TITLE
Update relationship name in solr.md

### DIFF
--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -59,10 +59,10 @@ In your `.platform.app.yaml` file, we now need to open a connection to the new S
 
 ```yaml
 relationships:
-    solrsearch: 'search:main'
+    solr: 'search:main'
 ```
 
-That is, the application's environment would include a `solrsearch` relationship that connects to the `main` endpoint, which is the `maincore` core.
+That is, the application's environment would include a `solr` relationship that connects to the `main` endpoint, which is the `maincore` core.
 
 The key (left side) is the name that will be exposed to the application in the `PLATFORM_RELATIONSHIPS` [variable](/development/variables.md).  The right hand side is the name of the service specified above (`search`) and the endpoint (`main`).  If you named the service or endpoint something than different above, change those values accordingly.
 
@@ -98,7 +98,7 @@ $platformsh->registerFormatter('drupal-solr', function($solr) {
 
 // Update these values to the relationship name (from .platform.app.yaml)
 // and the machine name of the server from your Drupal configuration.
-$relationship_name = 'solrsearch';
+$relationship_name = 'solr';
 $solr_server_name = 'default_solr_server';
 if ($platformsh->hasRelationship($relationship_name)) {
   // Set the connector configuration to the appropriate value, as defined by the formatter above.


### PR DESCRIPTION
I'm suggesting the replacement of `solrsearch` with `solr` for the relationship name in your example, so that it is compatible with the Enterprise environments that use the latter.