### PR TITLE
Clarifying that customers can download the DPA contract 

### DIFF
--- a/src/security/gdpr.md
+++ b/src/security/gdpr.md
@@ -16,6 +16,5 @@ As part of our measures we have implemented the following:
 * **Security**: We have created [https://platform.sh/security](https://platform.sh/security) to document our security features.
 * **Data Collection**: We've documented information about [what data we collect](/security/data-collection.md).
 * **Data Retention**: We documented information about our [data retention](/security/data-retention.md).
-* **DPA**: We have revised our [Terms of Service](https://platform.sh/tos) and [Privacy Policy](https://platform.sh/privacy-policy) to align with the GDPR. There is also a pre-signed DPA agreement that can be downloaded at the top of the [Privacy Policy](https://platform.sh/privacy-policy)
-
+* **DPA**: We have revised our [Terms of Service](https://platform.sh/tos) and [Privacy Policy](https://platform.sh/privacy-policy) to align with the GDPR and we offer a pre-signed DPA agreement that can be downloaded at the top of the [Privacy Policy](https://platform.sh/privacy-policy)
 

--- a/src/security/gdpr.md
+++ b/src/security/gdpr.md
@@ -16,6 +16,6 @@ As part of our measures we have implemented the following:
 * **Security**: We have created [https://platform.sh/security](https://platform.sh/security) to document our security features.
 * **Data Collection**: We've documented information about [what data we collect](/security/data-collection.md).
 * **Data Retention**: We documented information about our [data retention](/security/data-retention.md).
-* **DPA**: We have revised our [Terms of Service](https://platform.sh/tos) and [Privacy Policy](https://platform.sh/privacy-policy) to align with the GDPR and we offer a GDPR Data Processing Agreement for those Customers who need it.
+* **DPA**: We have revised our [Terms of Service](https://platform.sh/tos) and [Privacy Policy](https://platform.sh/privacy-policy) to align with the GDPR. There is also a pre-signed DPA agreement that can be downloaded at the top of the [Privacy Policy](https://platform.sh/privacy-policy)
 
 


### PR DESCRIPTION
Clarifying that customers can download the DPA contract on the privacy policy page to avoid customers having to open support tickets.