### PR TITLE
Database configuration for Lando

### DIFF
--- a/src/development/local/lando.md
+++ b/src/development/local/lando.md
@@ -40,3 +40,22 @@ lando db-import database.sql.gz
 ```
 
 Rsync can download user files easily and efficiently.  See the [exporting tutorial](/tutorials/exporting.md) for information on how to use rsync.
+
+Then you need to update your `sites/default/settings.local.php` to configure your codebase to connect to the local database that you just imported:
+
+```php
+/* Working in local with Lando */
+if (getenv('LANDO') === 'ON') {
+  $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
+  $settings['trusted_host_patterns'] = ['.*'];
+  $settings['hash_salt'] = md5(getenv('LANDO_HOST_IP'));
+  $databases['default']['default'] = [
+    'driver' => 'mysql',
+    'database' => $lando_info['database']['creds']['database'],
+    'username' => $lando_info['database']['creds']['user'],
+    'password' => $lando_info['database']['creds']['password'],
+    'host' => $lando_info['database']['internal_connection']['host'],
+    'port' => $lando_info['database']['internal_connection']['port'],
+  ];
+}
+```

--- a/src/development/local/lando.md
+++ b/src/development/local/lando.md
@@ -21,10 +21,10 @@ recipe: drupal8
 config:
   # Lando defaults to Apache. Switch to nginx to match Platform.sh.
   via: nginx
-  
+
   # Set the webroot to match your .platform.app.yaml.
   webroot: web
-  
+
   # Lando defaults to the latest MySQL release, but Platform.sh uses MariaDB.
   # Specify the version to match what's in services.yaml.
   database: mariadb:10.1
@@ -48,7 +48,7 @@ Then you need to update your `sites/default/settings.local.php` to configure you
 if (getenv('LANDO') === 'ON') {
   $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
   $settings['trusted_host_patterns'] = ['.*'];
-  $settings['hash_salt'] = md5(getenv('LANDO_HOST_IP'));
+  $settings['hash_salt'] = 'CHANGE THIS TO SOME RANDOMLY GENERATED STRING';
   $databases['default']['default'] = [
     'driver' => 'mysql',
     'database' => $lando_info['database']['creds']['database'],


### PR DESCRIPTION
Just importing the Platform.sh database in Lando when using a Platform.sh Drupal template  won't work as is.

Also, we could add a note on how to import files in Lando as well.