### PR TITLE
Elasticsearch available plugins correction

### DIFF
--- a/src/configuration/services/elasticsearch.md
+++ b/src/configuration/services/elasticsearch.md
@@ -90,7 +90,7 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 | delete-by-query       | Support for deleting documents matching a given query                                     | *   |     |     |     |     |
 | discovery-multicast   | Ability to form a cluster using TCP/IP multicast messages                                 | *   |     |     |     |     |
 | ingest-attachment     | Extract file attachments in common formats (such as PPT, XLS, and PDF)                    |     | *   | *   | *   | *   |
-| ingest-user-agent     | Extracts details from the user agent string a browser sends with its web requests         |     | *   | *   | *   | *   |
+| ingest-user-agent     | Extracts details from the user agent string a browser sends with its web requests         |     | *   | *   | *   |     |
 | lang-javascript       | Javascript language plugin, allows the use of Javascript in Elasticsearch scripts         |     | *   | *   |     |     |
 | lang-python           | Python language plugin, allows the use of Python in Elasticsearch scripts                 | *   | *   | *   |     |     |
 | mapper-annotated-text | Adds support for text fields with markup used to inject annotation tokens into the index  |     |     |     | *   | *   |


### PR DESCRIPTION
ingest-agent is not available on a version 7.2