### PR TITLE
Secure platform.sh origin adding Client Authenticated TLS 

### DIFF
--- a/src/golive/cdn.md
+++ b/src/golive/cdn.md
@@ -82,7 +82,7 @@ List of ip ranges for:
 - [CloudFlare](https://www.cloudflare.com/ips/)
 - [Fastly](https://docs.fastly.com/en/guides/accessing-fastlys-ip-ranges)
 
-For CloudFlare, using the HTTP access control is the recommended way of securing your origin.
+*For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.*
 
 ### 2 Client authenticated TLS
 If your CDN offers this option, an alternative way of securing the connection is [client authenticated TLS](/configuration/routes/https.html#client-authenticated-tls).
@@ -94,7 +94,8 @@ CloudFlare has [a very good article](https://support.cloudflare.com/hc/en-us/art
 To activate authenticated TLS follow the following steps:
 
 - Download the correct certificate from your CDN provider.
-     - [CloudFlare](https://support.cloudflare.com/hc/en-us/article_attachments/360044928032/origin-pull-ca.pem)
+     - [CloudFlare](https://support.cloudflare.com/hc/en-us/article_attachments/360044928032/origin-pull-ca.pem) 
+         - *Caveat! an attacker could make a Cloudflare account to bypass your origin restriction. For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.*
      - [Fastly](https://docs.fastly.com/products/waf-tuning-plus-package#authenticated-tls-to-origin)
 - Make sure you have a `.crt` file. If you have have `.pem` file, simply rename it to `cdn.crt`
 - Add the `cdn.crt` to your git repository

--- a/src/golive/cdn.md
+++ b/src/golive/cdn.md
@@ -60,34 +60,31 @@ When using a CDN, you might not want users to access your platform.sh origin dir
 ### 1 Basic HTTP Authentication
 
 #### Password protected
-You can password protect your project using [HTTP access control](https://docs.platform.sh/administration/web/configure-environment.html#http-access-control). 
+You can password protect your project using [HTTP access control](https://docs.platform.sh/administration/web/configure-environment.html#http-access-control).
 
 Make sure that you generate a password of sufficient strength. You can then use share the password with your CDN provider. Make sure the CDN adds a header to authenticate correctly to your origin.
 
-
-Simply add a custom header to the origin request with the base64 encoded username:password.
-
-`Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l` 
-
-
+Add a custom header to the origin request with the base64 encoded username:password.
+For example: `Aladdin:OpenSesame` would become `Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l`.
 
 #### IP whitelisting
 
 If your CDN does not support adding headers to the request to origin, you can allow the IP addresses of your CDN.
 
-*Note: you WILL have to update your configuration when your cdn updates their ip addresses*
+**note**: you WILL have to update your configuration when your cdn updates their ip addresses*
 
 List of ip ranges for:
 
 - [CloudFlare](https://www.cloudflare.com/ips/)
 - [Fastly](https://docs.fastly.com/en/guides/accessing-fastlys-ip-ranges)
 
-*For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.*
+**note**: For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.
 
 ### 2 Client authenticated TLS
+
 If your CDN offers this option, an alternative way of securing the connection is [client authenticated TLS](/configuration/routes/https.html#client-authenticated-tls).
 
-*Note: Please remember to permit your developers to access the origin by creating your own certificate else they won't be able to access the project url directly. (see below)*
+**note**: Please remember to permit your developers to access the origin by creating your own certificate or else they won't be able to access the project url directly. (see below)
 
 CloudFlare has [a very good article](https://support.cloudflare.com/hc/en-us/articles/204899617-Authenticated-Origin-Pulls) on what client authenticated TLS is, and how to set this up.
 
@@ -109,4 +106,4 @@ tls:
             path: cdn.crt
 ```
 
-*Note: The steps above are generally similar but can be different for different CDN providers. Connect with your CDN provider support department for help*
+**note**: The steps above are generally similar but can be different for different CDN providers. Connect with your CDN provider support department for help

--- a/src/golive/cdn.md
+++ b/src/golive/cdn.md
@@ -61,7 +61,7 @@ When using a CDN, you might not want users to access your Platform.sh origin dir
 
 You can password protect your project using [HTTP access control](https://docs.platform.sh/administration/web/configure-environment.html#http-access-control).
 
-Make sure that you generate a password of sufficient strength. You can then use share the password with your CDN provider. Make sure the CDN adds a header to authenticate correctly to your origin.
+Make sure that you generate a password of sufficient strength. You can then share the password with your CDN provider. Make sure the CDN adds a header to authenticate correctly to your origin.
 
 Add a custom header to the origin request with the base64 encoded username:password.
 

--- a/src/golive/cdn.md
+++ b/src/golive/cdn.md
@@ -55,7 +55,7 @@ When using a CDN the Platform.sh router's HTTP cache becomes redundant.  In most
 
 ## Secure/hide your project from being accessed directly
 
-When using a CDN, you might not want users to access your platform.sh origin directly. There are 2 ways to secure your origin.
+When using a CDN, you might not want users to access your Platform.sh origin directly. There are 2 ways to secure your origin.
 
 ### 1 Basic HTTP Authentication
 
@@ -63,7 +63,6 @@ When using a CDN, you might not want users to access your platform.sh origin dir
 You can password protect your project using [HTTP access control](https://docs.platform.sh/administration/web/configure-environment.html#http-access-control).
 
 Make sure that you generate a password of sufficient strength. You can then use share the password with your CDN provider. Make sure the CDN adds a header to authenticate correctly to your origin.
-
 Add a custom header to the origin request with the base64 encoded username:password.
 For example: `Aladdin:OpenSesame` would become `Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l`.
 
@@ -81,6 +80,7 @@ List of ip ranges for:
 **note**: For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.
 
 ### 2 Client authenticated TLS
+
 
 If your CDN offers this option, an alternative way of securing the connection is [client authenticated TLS](/configuration/routes/https.html#client-authenticated-tls).
 

--- a/src/golive/cdn.md
+++ b/src/golive/cdn.md
@@ -53,34 +53,40 @@ When using a CDN the Platform.sh router's HTTP cache becomes redundant.  In most
         enabled: false
 ```
 
-## Secure/hide your project from being accessed directly
+## Preventing direct access
 
-When using a CDN, you might not want users to access your Platform.sh origin directly. There are 2 ways to secure your origin.
+When using a CDN, you might not want users to access your Platform.sh origin directly. There are three ways to secure your origin.
 
-### 1 Basic HTTP Authentication
+### Password protected HTTP Authentication
 
-#### Password protected
 You can password protect your project using [HTTP access control](https://docs.platform.sh/administration/web/configure-environment.html#http-access-control).
 
 Make sure that you generate a password of sufficient strength. You can then use share the password with your CDN provider. Make sure the CDN adds a header to authenticate correctly to your origin.
+
 Add a custom header to the origin request with the base64 encoded username:password.
+
 For example: `Aladdin:OpenSesame` would become `Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l`.
 
-#### IP whitelisting
+Be aware that this approach will apply the same user and password to all development environments, too.  You can have developers enter credentials through their browser, or override the access control setting for each child environment.
+
+> **note**
+> This is the recommended approach for CloudFlare.
+
+### IP whitelisting
 
 If your CDN does not support adding headers to the request to origin, you can allow the IP addresses of your CDN.
 
-**note**: you WILL have to update your configuration when your cdn updates their ip addresses*
+> **note**
+> You *WILL* have to update your configuration when your CDN updates their IP addresses.
 
-List of ip ranges for:
+List of IP ranges for:
 
 - [CloudFlare](https://www.cloudflare.com/ips/)
 - [Fastly](https://docs.fastly.com/en/guides/accessing-fastlys-ip-ranges)
 
-**note**: For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.
+Be aware that this approach will apply the same IP restrictions to all development environments, too.  To remove it from development environments, you will need to disable it on each environment or else create a single child of `master` where it is disabled, and them make all development branches off of that environment.
 
-### 2 Client authenticated TLS
-
+### Client authenticated TLS
 
 If your CDN offers this option, an alternative way of securing the connection is [client authenticated TLS](/configuration/routes/https.html#client-authenticated-tls).
 
@@ -91,7 +97,7 @@ CloudFlare has [a very good article](https://support.cloudflare.com/hc/en-us/art
 To activate authenticated TLS follow the following steps:
 
 - Download the correct certificate from your CDN provider.
-     - [CloudFlare](https://support.cloudflare.com/hc/en-us/article_attachments/360044928032/origin-pull-ca.pem) 
+     - [CloudFlare](https://support.cloudflare.com/hc/en-us/article_attachments/360044928032/origin-pull-ca.pem)
          - *Caveat! an attacker could make a Cloudflare account to bypass your origin restriction. For CloudFlare, using the HTTP access control described above is the recommended way of securing your origin.*
      - [Fastly](https://docs.fastly.com/products/waf-tuning-plus-package#authenticated-tls-to-origin)
 - Make sure you have a `.crt` file. If you have have `.pem` file, simply rename it to `cdn.crt`
@@ -106,4 +112,5 @@ tls:
             path: cdn.crt
 ```
 
-**note**: The steps above are generally similar but can be different for different CDN providers. Connect with your CDN provider support department for help
+> **note**
+> The steps above are generally similar but can vary for different CDN providers. Contact your CDN provider's support department for specific assistance.

--- a/src/golive/cdn.md
+++ b/src/golive/cdn.md
@@ -52,3 +52,51 @@ When using a CDN the Platform.sh router's HTTP cache becomes redundant.  In most
         # Disable the HTTP cache on this route. It will be handled by the CDN instead.
         enabled: false
 ```
+
+## Secure/hide your project from being accessed directly
+
+When using a CDN, you generally don't want users to access your platform.sh project directly. Luckily, you can secure your connection between you and the CDN with [client authenticated TLS](/configuration/routes/https.html#client-authenticated-tls). 
+
+
+*Note: activating authenticated TLS also means that *you* won't be able to access the project url directly either. If you want to connect to your origin, you'll have to add your own certificate to the configuration as well (see below)*
+
+### CloudFlare client authenticated TLS
+
+CloudFlare has [a very good article](https://support.cloudflare.com/hc/en-us/articles/204899617-Authenticated-Origin-Pulls) on what client authenticated TLS is, and how to set this up.
+
+Steps:
+
+- Download [the CloudFlare certificate](https://support.cloudflare.com/hc/en-us/article_attachments/360044928032/origin-pull-ca.pem)
+- Rename the .pem file to `cloudflare.crt`
+- Add the `cloudflare.crt` to your git repository 
+- Add the relevant configuration to your `.platform.app.yaml` file
+```
+tls:
+    client_authentication: "require"
+    client_certificate_authorities:
+        - !include
+            type: string
+            path: cloudflare.crt
+```
+
+### Fastly client authenticated TLS
+
+Fastly offers authenticated TLS but you'll have to generate your own certificate.
+For more information see the [fastly docs](https://docs.fastly.com/products/waf-tuning-plus-package#authenticated-tls-to-origin) on this topic.
+
+Other than that, the process is the same.
+
+- Add the `fastly.crt` to your git repository 
+- Add the relevant configuration to your `.platform.app.yaml` file
+```
+tls:
+    client_authentication: "require"
+    client_certificate_authorities:
+        - !include
+            type: string
+            path: fastly.crt
+```
+
+
+
+


### PR DESCRIPTION
Adding information on how to use Client Authenticated TLS to secure your Platform.sh Origin when using a CDN.