### PR TITLE
Fix missing ssh forwarding instructions

### DIFF
--- a/src/development/ssh.md
+++ b/src/development/ssh.md
@@ -71,6 +71,20 @@ You have your SSH keys (if not, take a look at the section above), but you need 
 
 That's it! You're all set. Now you'll be able to use Git and command shells with any Platform.sh environment that your user account is authorized to work with.
 
+### Forwarding keys by default
+
+It may be helpful to set your SSH client to always forward keys to Platform.sh servers, which can simplify other SSH or Rsync commands.  To do so, include a block in your local `~/.ssh/config` file like so:
+
+```
+Host *.us.platform.sh
+       ForwardAgent yes
+
+Host *.eu.platform.sh
+       ForwardAgent yes
+```
+
+(You can include other configuration as desired.)
+
 ![Setting Up Your Project Add SSH Key Done](/images/management-console/account-ssh-keys.png)
 
 ## SSH to your Web Server

--- a/src/development/ssh.md
+++ b/src/development/ssh.md
@@ -83,7 +83,7 @@ Host *.eu.platform.sh
        ForwardAgent yes
 ```
 
-(You can include other configuration as desired.)
+Include one `Host` entry for each Platform.sh region you want to connect to, such as `us-2` or `eu-4`.  (You can include other configuration as desired.)
 
 ![Setting Up Your Project Add SSH Key Done](/images/management-console/account-ssh-keys.png)
 

--- a/src/development/transfer-dedicated.md
+++ b/src/development/transfer-dedicated.md
@@ -60,7 +60,7 @@ That will run a `mysqldump` command on the server, compress it using gzip, and s
 
 To transfer data into either the staging or production environments, you can either download it from your Platform.sh Development environment to your local system first or transfer it directly between environments using SSH based tools (e.g. SCP, Rsync).
 
-First, set up [SSH forwarding](/dedicated/support/ssh-agent.md#forwarding-keys-by-default) by default for Platform.sh domains.
+First, set up [SSH forwarding](/development/ssh.md#forwarding-keys-by-default) by default for Platform.sh domains.
 
 Then run `platform ssh` with the `master` branch checked out to connect to the master dev environment.  Files are the easier data to transfer, and can be done with `rsync`.
 


### PR DESCRIPTION
https://docs.platform.sh/development/transfer-dedicated.html

ref: `First, set up <link>SSH forwarding</link> by default for Platform.sh domains.`
404: https://docs.platform.sh/dedicated/support/ssh-agent.md#forwarding-keys-by-default

Link is broken, pointing to old dedicated enterprise documentation.

Adding the `Forwarding keys by default` instructions to the `ssh.md` documentation and updating the link on `transfer-dedicated.md`.