### PR TITLE
Fix link to cloudflare/fastly tls steps.

### DIFF
--- a/src/frameworks/ez/fastly.md
+++ b/src/frameworks/ez/fastly.md
@@ -45,4 +45,4 @@ platform variable:set -e production env:FASTLY_KEY YOUR_ID_HERE
 
 ## Configure Fastly and Platform.sh
 
-See the alternate [Go-live process for Fastly](/golive/steps/fastly.md) on Platform.sh.  This process is the same for any application.
+See the alternate [Go-live process for Fastly](/golive/cdn.html#client-authenticated-tls) on Platform.sh.  This process is the same for any application.


### PR DESCRIPTION
Fixes a broken link.The strictly Fastly page didn't really contain any instructions, so my guess  is this is the section referenced.