### PR TITLE
Added redirectssl to www redirection service

### DIFF
--- a/src/golive/steps/dns.md
+++ b/src/golive/steps/dns.md
@@ -47,6 +47,7 @@ If you are willing to make the `www.` version of your site the canonical version
 If your preferred registrar/DNS provider doesn't support either custom records or the apex domain forwarding options above, the following free services both allow blind redirects and allow you to use a CNAME record to Platform.sh for `www.example.com` and an `A` record to their service at `example.com`, which will in turn send a redirect.
 
 * [WWWizer](http://wwwizer.com/)
+* [redirectssl](http://redirectssl.com/)
 
 ### (Alternate) Using A records
 


### PR DESCRIPTION
Hello,

I am the owner/developer of the service, we have a guide on how to setup on https://redirectssl.com/guides/platformsh let me know if this is not something you guys allow.

If it is I would love to get redirectssl added to the list.

Thanks,