### PR TITLE
updated drupal-solr doc to reflect recent developments

### DIFF
--- a/src/frameworks/drupal8/solr.md
+++ b/src/frameworks/drupal8/solr.md
@@ -12,12 +12,12 @@ Advanced Solr service configuration and implementation in other frameworks other
 
 ### 0. Upgrade Symfony Event Dispatcher
 
-If you are running Drupal older than 8.9.0, a small workaround will be needed.  The Solarium library used by Search API Solr requires the 4.3 version of the Symfony Event Dispatcher, whereas Drupal core ships with 3.4.  The Search API Solr issue queue has a [more detailed description](https://www.drupal.org/project/search_api_solr/issues/3085196) of the problem.
+If you are running Drupal older than 9.0, a small workaround will be needed.  The Solarium library used by Search API Solr requires the 4.3 version of the Symfony Event Dispatcher, whereas Drupal core ships with 3.4.  The Search API Solr issue queue has a [more detailed description](https://www.drupal.org/project/search_api_solr/issues/3085196) of the problem.
 
 As noted there, the workaround for now is to run:
 
 ```
-composer require symfony/event-dispatcher:"4.3.4 as 3.4.99"
+composer require symfony/event-dispatcher:"4.3.4 as 3.4.35"
 ```
 
 in your project root and commit the resulting change to `composer.json` and `composer.lock`.  That will cause Composer to install the 4.3 version of Event Dispatcher.  Once [this issue](https://www.drupal.org/project/drupal/issues/2876675) is resolved in core this step will no longer be necessary.


### PR DESCRIPTION
There are two changes here:

1. Changed the wording from `older than 8.9.0` to `older than 9.0`. This was done because the [issue in question](https://www.drupal.org/project/drupal/issues/2876675) was recently closed, and the changes did not make their way into 8.9, but **are** present in 9.0.

2. Changed event-dispatcher's version from `4.3.4 as 3.4.99` to `4.3.4 as 3.4.35`. With `99` in place, composer errors out, complaining about not being able to meet minimum stability level (same behaviour with `minimum-stability` set to dev, alpha, beta, RC).