### PR TITLE
Source Operations with external Git integration

### DIFF
--- a/src/configuration/app/source-operations.md
+++ b/src/configuration/app/source-operations.md
@@ -56,9 +56,7 @@ Git integration can be configured to send commits made to the Platform.sh Git re
 
 > **note**
 >
-> Source Operations will only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
-> If your integration is configured with `fetch_branches`, it will create a Platform.sh environment for all the branches in the upstream repository. In that case, the commits triggered by a source operations will be pushed back to the Platform.sh remote.
-> If your integration is configured with `build_pull_requests`, it will create a Platform.sh environment for all the pull requests in the upstream repository. In that case, the commits triggered by a source operation will not be pushed back to the Platform.sh remote.
+> Source Operations can only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
 
 ## Automated Source Operations using cron
 

--- a/src/configuration/app/source-operations.md
+++ b/src/configuration/app/source-operations.md
@@ -57,8 +57,8 @@ Git integration can be configured to send commits made to the Platform.sh Git re
 > **note**
 >
 > Source Operations will only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
-> If your intfegration is configured with `fetch_branches`, it will create a Platform.sh environment for all the branches in the upstream repository. In that case, the commits triggered by a source operations will be pushed back to the Platform.sh remote.
-> If your intfegration is configured with `build_pull_requests`, it will create a Platform.sh environment for all the pull requests in the upstream repository. In that case, the commits triggered by a source operation will not be pushed back to the Platform.sh remote.
+> If your integration is configured with `fetch_branches`, it will create a Platform.sh environment for all the branches in the upstream repository. In that case, the commits triggered by a source operations will be pushed back to the Platform.sh remote.
+> If your integration is configured with `build_pull_requests`, it will create a Platform.sh environment for all the pull requests in the upstream repository. In that case, the commits triggered by a source operation will not be pushed back to the Platform.sh remote.
 
 ## Automated Source Operations using cron
 

--- a/src/configuration/app/source-operations.md
+++ b/src/configuration/app/source-operations.md
@@ -56,7 +56,9 @@ Git integration can be configured to send commits made to the Platform.sh Git re
 
 > **note**
 >
-> Source Operations can only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
+> Currently, this configuration requires the `enable_codesource_integration_push` setting to be turned on by a Platform.sh staff and is only available to selected Beta customers.
+
+Source Operations can only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
 
 ## Automated Source Operations using cron
 

--- a/src/configuration/app/source-operations.md
+++ b/src/configuration/app/source-operations.md
@@ -3,13 +3,13 @@ search:
     keywords: ['.platform.app.yaml', 'automated', 'code', 'source', 'update', 'operation', 'dependencies', 'auto']
 ---
 
-# Source operations
+# [Beta] Source operations
 
 > **note**
 >
-> Source Operations are currently in Beta.  While the syntax is not expected to change, some behavior might in the future.
+> Source Operations are currently in Beta. While the syntax is not expected to change, some behavior might in the future.
 >
-> Also be aware that Source Operations are not compatible with [3rd party repository integrations](/administration/integrations.md) at this time. If you use a 3rd party repository then any changes from Source Operations will be overwritten by the integration.
+> Also, Source Operations are only available to Enterprise and Elite customers. Contact our sales team for more information.
 
 An application can define a number of operations that apply to its source code and that can be automated.
 
@@ -49,6 +49,14 @@ When this operation is triggered:
 * At the end of the process, if any commits were created, the new commits are pushed to the repository and the normal build process of the environment is triggered.
 
 Note that these operations run in an isolated container: it is not part of the runtime cluster of the environment, and doesn't require the environment to be running.  Also be aware that if multiple applications in a single project both result in a new commit, that will appear as two distinct commits in the Git history but only a single new build/deploy cycle will occur.
+
+## Source Operations with an external Git integration
+
+Git integration can be configured to send commits made to the Platform.sh Git remote, to the upstream repository instead. This means that if a source operation did generate a new commit, the commit will be pushed to the upstream repository.
+
+> **note**
+>
+> Source Operations will only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
 
 ## Automated Source Operations using cron
 

--- a/src/configuration/app/source-operations.md
+++ b/src/configuration/app/source-operations.md
@@ -57,6 +57,8 @@ Git integration can be configured to send commits made to the Platform.sh Git re
 > **note**
 >
 > Source Operations will only be triggered on environment created by a branch, and not to environment created by a Pull Request on the external upstream (GitHub, Bitbucket, Gitlab).
+> If your intfegration is configured with `fetch_branches`, it will create a Platform.sh environment for all the branches in the upstream repository. In that case, the commits triggered by a source operations will be pushed back to the Platform.sh remote.
+> If your intfegration is configured with `build_pull_requests`, it will create a Platform.sh environment for all the pull requests in the upstream repository. In that case, the commits triggered by a source operation will not be pushed back to the Platform.sh remote.
 
 ## Automated Source Operations using cron
 


### PR DESCRIPTION
- [ ] Document that the `enable_codesource_integration_push` setting needs to be enabled for this to work.