### PR TITLE
add quotes to stop solr config from failing.

### DIFF
--- a/src/configuration/services/solr.md
+++ b/src/configuration/services/solr.md
@@ -170,7 +170,7 @@ search:
     configuration:
         cores:
             collection1:
-                conf_dir: {}  # This will pick up the default Drupal 8 configuration
+                conf_dir: '{}'  # This will pick up the default Drupal 8 configuration
         endpoints:
             solr:
                 core: collection1


### PR DESCRIPTION
services.solrsearch.configuration.cores.dcc.conf_dir: OrderedDict() is not of type u'string'