### PR TITLE
NewRelic instructions are PHP-specific

### DIFF
--- a/src/administration/integrations/new-relic.md
+++ b/src/administration/integrations/new-relic.md
@@ -1,6 +1,6 @@
 # New Relic
 
-Platform.sh supports [New Relic APM](https://newrelic.com/products/application-monitoring).
+Platform.sh supports [New Relic APM](https://newrelic.com/products/application-monitoring) for profiling PHP applications. These instructions do not apply to other languages.
 
 ## On a Grid plan
 


### PR DESCRIPTION
As revealed in ZD86807, Trying to follow the PHP instructions to profile a Java application leads to sadness.
The doc page didn't explicitly acknowledge that, and there are no explicit clues that
```
runtime:
    extensions:
        - newrelic
```
is a php-specific thing.