### PR TITLE
Tiny typo

### DIFF
--- a/src/configuration/app/cron.md
+++ b/src/configuration/app/cron.md
@@ -17,7 +17,7 @@ If an application defines both a `web` instance and a `worker` instance, cron ta
 
 ## How do I setup Cron for a typical Drupal site?
 
-The following example runs Drupal's normal cron hook every 20 minutes, using Drush.  It also sets up a second cron task to run Drupal's queue runner on the aggregator_feeds queue every 5 minutes.
+The following example runs Drupal's normal cron hook every 20 minutes, using Drush.  It also sets up a second cron task to run Drupal's queue runner on the aggregator_feeds queue every 7 minutes.
 
 ```yaml
 crons:


### PR DESCRIPTION
Small nit: the docs at https://docs.platform.sh/configuration/app/cron.html#how-do-i-setup-cron-for-a-typical-drupal-site write “aggregator_feeds queue every 5 minutes” but the actual example is 7 minutes