### PR TITLE
Link to the app config page from the Headers page

### DIFF
--- a/src/development/headers.md
+++ b/src/development/headers.md
@@ -21,7 +21,6 @@ Platform.sh adds a number of response headers automatically to assist in debuggi
 * `X-Platform-Processor`: The ID of the container that generated the response.  The container ID is the cluster ID plus the container name.
 * `X-Platform-Router`: The ID of the router that served the request.  The router ID is the processor ID of the router container, specifically.
 
-
 ## Custom headers
 
 Apart from those listed above, your application is responsible for setting its own response headers.

--- a/src/development/headers.md
+++ b/src/development/headers.md
@@ -20,3 +20,10 @@ Platform.sh adds a number of response headers automatically to assist in debuggi
 * `X-Platform-Cluster`: The ID of the cluster that received the request.  The cluster name is formed from the project ID and environment ID.
 * `X-Platform-Processor`: The ID of the container that generated the response.  The container ID is the cluster ID plus the container name.
 * `X-Platform-Router`: The ID of the router that served the request.  The router ID is the processor ID of the router container, specifically.
+
+
+## Custom headers
+
+Apart from those listed above, your application is responsible for setting its own response headers.
+
+To add headers to static files, use the `headers` key in the application's [web locations configuration](/configuration/app/web.html#how-can-i-control-the-headers-sent-with-my-files).

--- a/src/development/headers.md
+++ b/src/development/headers.md
@@ -26,4 +26,4 @@ Platform.sh adds a number of response headers automatically to assist in debuggi
 
 Apart from those listed above, your application is responsible for setting its own response headers.
 
-To add headers to static files, use the `headers` key in the application's [web locations configuration](/configuration/app/web.html#how-can-i-control-the-headers-sent-with-my-files).
+To add headers to static files, use the `headers` key in the application's [web locations configuration](/configuration/app/web.md#how-can-i-control-the-headers-sent-with-my-files).


### PR DESCRIPTION
I was looking for the static files headers docs, and landed on the Headers page, which looks like it's trying to be comprehensive
https://docs.platform.sh/development/headers.html