### PR TITLE
Remove obsolete Snapshot reference

### DIFF
--- a/src/administration/web.md
+++ b/src/administration/web.md
@@ -78,11 +78,9 @@ Synchronization performs a merge from a parent into a child environment, and the
 You have the option of performing a Sync on only the code, replacing the data (i.e. databases) of that environment from its parent, or both.
 These options are provided in a separate dialog box that will appear when you click the `Sync` button, along with the Platform.sh CLI commands that perform the same action.
 
-Be aware that sync uses the [Snapshot](https://docs.platform.sh/administration/snapshot-and-restore.html#snapshots-and-downtime) mechanism and will have the same caveats.
+Be aware that sync uses the [Backup](https://docs.platform.sh/administration/backup-and-restore.html#backups-and-downtime) mechanism and will have the same caveats.
 
 ![sync confirmation cli](/images/management-console/header-sync-box.png)
-
-Be aware that sync uses the [Backup](https://docs.platform.sh/administration/backup-and-restore.html#backups-and-downtime) mechanism and will have the same caveats.
 
 Note that `Sync` is only available if your branch has no unmerged commits, and can be fast-forwarded.
 


### PR DESCRIPTION
Remove the obsolete message about snapshots. Backup should now be used everywhere.