### PR TITLE
Ignore undefined type templates as a quick fix.

### DIFF
--- a/docs/static/scripts/fetch-templates.js
+++ b/docs/static/scripts/fetch-templates.js
@@ -66,7 +66,8 @@ async function getTemplateRuntime(template){
     "strapi": "nodejs",
     "mattermost": "golang",
     "probot": "nodejs",
-    "gatsby-wordpress": "nodejs"
+    "gatsby-wordpress": "nodejs",
+    "quarkus": "java"
   }
 
   var templateData = {
@@ -87,7 +88,6 @@ async function getTemplateRuntime(template){
           'User-Agent': 'Request-Promise'
       }
   };
-
 
   if (!( template.name in parseErrorTemplates )) {
 
@@ -113,6 +113,11 @@ async function getTemplateRuntime(template){
 
 }
 
+function cleanupUndefined(data) {
+  delete data["undefined"];
+  return data
+}
+
 async function fetchTemplates() {
 
     rp(options)
@@ -131,7 +136,8 @@ async function fetchTemplates() {
               count += 1;
               if (count === array.length - 1) {
                 // Write the template data yaml
-                fs.writeFileSync(finalFileLocation, yaml.safeDump(data, {noRefs:true}), function (err) {
+
+                fs.writeFileSync(finalFileLocation, yaml.safeDump(cleanupUndefined(data), {noRefs:true}), function (err) {
                   if (err) throw err;
                 });
               }

--- a/docs/static/scripts/fetch-templates.js
+++ b/docs/static/scripts/fetch-templates.js
@@ -113,11 +113,6 @@ async function getTemplateRuntime(template){
 
 }
 
-function cleanupUndefined(data) {
-  delete data["undefined"];
-  return data
-}
-
 async function fetchTemplates() {
 
     rp(options)
@@ -135,9 +130,10 @@ async function fetchTemplates() {
               }
               count += 1;
               if (count === array.length - 1) {
+                // Delete templates with undefined types
+                delete data["undefined"]
                 // Write the template data yaml
-
-                fs.writeFileSync(finalFileLocation, yaml.safeDump(cleanupUndefined(data), {noRefs:true}), function (err) {
+                fs.writeFileSync(finalFileLocation, yaml.safeDump(data, {noRefs:true}), function (err) {
                   if (err) throw err;
                 });
               }


### PR DESCRIPTION
* `fetch-templates.js` needs improvements, as it will on some templates fail  to retrieve their `type` when writing to `data/templates.yaml` (i.e. multi-apps, `quarkus` which was just merged, and it will certainly do so on `gatsby-strapi` when that's merged hopefully later today.) 
* When `type` is not found, it places them in `templates.yaml` under the key `undefined`.
* The template accordians don't have logic to handle `undefined`, so the `hugo build` fails in that shortcode.
* Right now, when I've seen templates that fail to find the `type`, I've added them to this variable [here](https://github.com/platformsh/platformsh-docs/blob/c63e9ec75ecc1bb117d0f6f2f30eb5843ef1d970/docs/static/scripts/fetch-templates.js#L64) in `fetch-templates.js`. So adding `gatsby-strapi` to that variable would require
```
  const parseErrorTemplates = {
    "hugo": "golang",
    "strapi": "nodejs",
    "mattermost": "golang",
    "probot": "nodejs",
    "gatsby-wordpress": "nodejs",
    "gatsby-strapi": "nodejs"
  }
```
* I'll work on finding a better fix for this, but in the meantime this removes the `undefined` key from the `data/template.yaml` data before the Hugo build takes place. 
* For now then, this will prevent failed docs builds. 