### PR TITLE
Clarifying which port should be used and when. 

### DIFF
--- a/docs/src/development/email.md
+++ b/docs/src/development/email.md
@@ -58,3 +58,12 @@ mounts:
         source: local
         source_path: spool
 ```
+
+
+### Ports
+
+- Port 465 and 587 should be used to send email to your own external email server.
+- Port 25 should be used to send through PLATFORM_SMTP_HOST. (this is the default in most mailers).
+
+We proxy your emails through our own smtp host, and encrypt them over port 465 before sending them through to the outside world.
+

--- a/docs/src/development/email.md
+++ b/docs/src/development/email.md
@@ -60,10 +60,9 @@ mounts:
 ```
 
 
-### Ports
+## Ports
 
 - Port 465 and 587 should be used to send email to your own external email server.
 - Port 25 should be used to send through PLATFORM_SMTP_HOST. (this is the default in most mailers).
 
 We proxy your emails through our own smtp host, and encrypt them over port 465 before sending them through to the outside world.
-


### PR DESCRIPTION
Customers are sometimes trying to use port 465 for our SMTP_HOST which is not available.
The earlier mention of port 465 is correct. But a section that clarifies this close to the connection instructions might help.