### PR TITLE
Set conf_dir to empty string.

### DIFF
--- a/docs/src/frameworks/drupal8/solr.md
+++ b/docs/src/frameworks/drupal8/solr.md
@@ -47,7 +47,7 @@ search:
     configuration:
         cores:
             maincore:
-                conf_dir: {}
+                conf_dir: ''
         endpoints:
             main:
                 core: maincore


### PR DESCRIPTION
When following the solr install instructions I found that pushing to platform.sh `conf_dir: {}` resulted on this error:

```
E: Error parsing configuration files:
    - services.solr.configuration.cores.maincore.conf_dir: OrderedDict() is not of type u'string'
```

It seems that conf_dir is expecting a string, so I tried using ' ' instead and it worked. I don't know if this is 100% correct, but I know for sure the documentation needs an update because as it is now, it failed in my case.