### PR TITLE
Update self-indexing: valid json, some cleanup

### DIFF
--- a/docs/layouts/_default/index.json.json
+++ b/docs/layouts/_default/index.json.json
@@ -1,9 +1,11 @@
 {{- $index := slice -}}
 {{- range .Site.Pages -}}
-  {{- $url := chomp ( partial "meilindex/getURL" . ) -}}
-  {{- $subsections := chomp (.TableOfContents | plainify) -}}
-  {{- $text := chomp ( partial "meilindex/getText" . ) -}}
-  {{- $section := chomp ( partial "meilindex/getSection" . ) -}}
-  {{- $index = $index | append (dict "title" .Title "documentId" .File.UniqueID "site" "docs" "rank" 1 "url" $url "subsections" $subsections "text" $text "section" $section ) -}}
+  {{- if ne ( partial "meilindex/getSection" . ) "DELETE" -}}
+    {{- $url := chomp ( partial "meilindex/getURL" . ) -}}
+    {{- $subsections := chomp (.TableOfContents | plainify) -}}
+    {{- $text := chomp ( partial "meilindex/getText" . ) -}}
+    {{- $section := chomp ( partial "meilindex/getSection" . ) -}}
+    {{- $index = $index | append (dict "title" .Title "documentId" .File.UniqueID "site" "docs" "rank" 1 "url" $url "subsections" $subsections "text" $text "section" $section ) -}}
+  {{- end -}}
 {{- end -}}
 {{- $index | jsonify -}}

--- a/docs/layouts/_default/index.json.json
+++ b/docs/layouts/_default/index.json.json
@@ -1,0 +1,9 @@
+{{- $index := slice -}}
+{{- range .Site.RegularPages -}}
+  {{- $url := chomp ( partial "meilindex/getURL" . ) -}}
+  {{- $subsections := chomp (.TableOfContents | plainify) -}}
+  {{- $text := chomp ( partial "meilindex/getText" . ) -}}
+  {{- $section := chomp ( partial "meilindex/getSection" . ) -}}
+  {{- $index = $index | append (dict "title" .Title "documentId" .File.UniqueID "site" "docs" "rank" 1 "url" $url "subsections" $subsections "text" $text "section" $section ) -}}
+{{- end -}}
+{{- $index | jsonify -}}

--- a/docs/layouts/_default/index.json.json
+++ b/docs/layouts/_default/index.json.json
@@ -1,5 +1,5 @@
 {{- $index := slice -}}
-{{- range .Site.RegularPages -}}
+{{- range .Site.Pages -}}
   {{- $url := chomp ( partial "meilindex/getURL" . ) -}}
   {{- $subsections := chomp (.TableOfContents | plainify) -}}
   {{- $text := chomp ( partial "meilindex/getText" . ) -}}

--- a/docs/layouts/partials/meilindex/getSection.html
+++ b/docs/layouts/partials/meilindex/getSection.html
@@ -4,6 +4,12 @@
   <!-- Everything in Getting started uses that section -->
   {{- if eq .Section "gettingstarted" -}}
     {{- $section = "Getting started" -}}
+  <!-- The other section doesn't have a title since ignored from sidebar. Give generic. -->
+  {{- else if eq .Section "other" -}}
+    {{- $section = .Site.Params.author -}}
+  <!-- We don't want registry stuff to be searchable. -->
+  {{- else if eq .Section "registry" -}}
+    {{- $section = "DELETE" -}}
   <!-- Otherwise, title of the current section -->
   {{- else -}}
     {{- with .CurrentSection -}}
@@ -15,8 +21,16 @@
   {{- $section = .Site.Params.author -}}
 <!-- List Pages, use the top level section -->
 {{- else -}}
-  {{- with .GetPage .Section -}}
-    {{- $section = .Title -}}
+  <!-- This isn't a page, so let's not inlude it. -->
+  {{- if eq .Section "other" -}}
+    {{- $section = "DELETE" -}}
+  <!-- We don't want registry stuff to be searchable. -->
+  {{- else if eq .Section "registry" -}}
+    {{- $section = "DELETE" -}}
+  {{- else -}}
+    {{- with .GetPage .Section -}}
+      {{- $section = .Title -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- $section -}}

--- a/docs/layouts/partials/meilindex/getSection.html
+++ b/docs/layouts/partials/meilindex/getSection.html
@@ -1,34 +1,22 @@
-{{- $tempURL := index ( split .RelPermalink "." ) 0 -}}
-
-{{- $url := "/" -}}
-{{- if ne $tempURL "/index" -}}
-  {{- $url = printf "%s.html" $tempURL -}}
-{{- end -}}
-
-{{- $sections := split $url "/" -}}
 {{- $section := "" -}}
-
-{{- if le (len $sections) 3}}
-  {{- if isset .Site.Data.indexing.replacements .Section }}
-    {{- $section = index .Site.Data.indexing.replacements .Section }}
-  {{- else }}
-    {{- $section =  .Section | humanize }}
-  {{- end }}
-{{- else }}
-  {{- if in .Site.Data.indexing.priority .Section }}
-    {{- if isset .Site.Data.indexing.replacements .Section }}
-      {{- $section =  index .Site.Data.indexing.replacements .Section }}
-    {{- else }}
-      {{- $section =  .Section | humanize }}
-    {{- end }}
-  {{- else }}
-    {{- $subsection := index $sections 2}}
-    {{- if isset .Site.Data.indexing.replacements $subsection }}
-      {{- $section =  index .Site.Data.indexing.replacements $subsection }}
-    {{- else }}
-      {{- $section =  $subsection | humanize }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-
+<!-- Regular single pages -->
+{{- if .IsPage -}}
+  <!-- Everything in Getting started uses that section -->
+  {{- if eq .Section "gettingstarted" -}}
+    {{- $section = "Getting started" -}}
+  <!-- Otherwise, title of the current section -->
+  {{- else -}}
+    {{- with .CurrentSection -}}
+      {{- $section = .Title -}}
+    {{- end -}}
+  {{- end -}}
+<!-- Just Platform.sh for the home page -->
+{{- else if .IsHome -}}
+  {{- $section = .Site.Params.author -}}
+<!-- List Pages, use the top level section -->
+{{- else -}}
+  {{- with .GetPage .Section -}}
+    {{- $section = .Title -}}
+  {{- end -}}
+{{- end -}}
 {{- $section -}}

--- a/docs/layouts/partials/meilindex/getSection.html
+++ b/docs/layouts/partials/meilindex/getSection.html
@@ -1,17 +1,8 @@
-
 {{- $tempURL := index ( split .RelPermalink "." ) 0 -}}
 
 {{- $url := "/" -}}
 {{- if ne $tempURL "/index" -}}
   {{- $url = printf "%s.html" $tempURL -}}
-{{- end -}}
-
-{{- $contentSplitPTAG := ( split .Content "p>" ) -}}
-{{- $text := index ( split ( index $contentSplitPTAG 1) "</" ) 0 | safeHTML -}}
-
-{{- $title := .Title }}
-{{- if isset .Page.Params "sidebartitle" -}}
-  {{- $title = .Page.Params.sidebartitle -}}
 {{- end -}}
 
 {{- $sections := split $url "/" -}}
@@ -39,22 +30,5 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $text := "" -}}
-{{- range .PlainWords -}}
-  {{- if in . "\\" -}}
-  {{- else -}}
-    {{- $cs := htmlUnescape . -}}
-    {{- $replaceChar := replace $cs "\"" " " -}}
-    {{- $text =  printf "%s %s" $text $replaceChar -}}
-  {{- end -}}
-{{- end -}}
-{
-    "site": "docs",
-    "section": "{{ $section }}",
-    "title": "{{ $title }}",
-    "url": "{{ $url }}",
-    "documentId": "{{ .File.UniqueID }}",
-    "rank": 1,
-    "text": "{{ if .IsPage }}{{ $text }}{{ else }}{{ chomp .Description }}{{ end }}",
-    "subsections": "{{ .TableOfContents | plainify }}"
-}
+
+{{- $section -}}

--- a/docs/layouts/partials/meilindex/getText.html
+++ b/docs/layouts/partials/meilindex/getText.html
@@ -1,18 +1,28 @@
+<!-- Get body text for search index -->
 {{- $text := "" -}}
 {{- range .PlainWords -}}
   {{- if in . "\\" -}}
   {{- else -}}
+    <!-- Unescape HTML escape codes -->
     {{- $cs := htmlUnescape . -}}
+    <!-- Replace extra "\" characters -->
     {{- $replaceChar := replace $cs "\"" " " -}}
     {{- $text =  printf "%s %s" $text $replaceChar -}}
   {{- end -}}
 {{- end -}}
 
 {{- $finalText := "" -}}
+<!-- Use formatted body text if regular page -->
 {{- if .IsPage -}}
   {{- $finalText = $text -}}
+<!-- Otherwise (list page) use desription -->
 {{- else -}}
-  {{- chomp .Description -}}
+  <!-- Check if it's been set to a single layout first -->
+  {{- if isset .Params "layout" -}}
+    {{- $finalText = $text | safeHTML -}}
+  {{- else -}}
+    {{- $finalText = .Description | safeHTML -}}
+  {{- end -}}
 {{- end -}}
 
-{{ $finalText }}
+{{- $finalText -}}

--- a/docs/layouts/partials/meilindex/getText.html
+++ b/docs/layouts/partials/meilindex/getText.html
@@ -1,0 +1,18 @@
+{{- $text := "" -}}
+{{- range .PlainWords -}}
+  {{- if in . "\\" -}}
+  {{- else -}}
+    {{- $cs := htmlUnescape . -}}
+    {{- $replaceChar := replace $cs "\"" " " -}}
+    {{- $text =  printf "%s %s" $text $replaceChar -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $finalText := "" -}}
+{{- if .IsPage -}}
+  {{- $finalText = $text -}}
+{{- else -}}
+  {{- chomp .Description -}}
+{{- end -}}
+
+{{ $finalText }}

--- a/docs/layouts/partials/meilindex/getURL.html
+++ b/docs/layouts/partials/meilindex/getURL.html
@@ -1,0 +1,6 @@
+{{- $tempURL := index ( split .RelPermalink "." ) 0 -}}
+{{- $url := "/" -}}
+{{- if ne $tempURL "/index" -}}
+  {{- $url = printf "%s.html" $tempURL -}}
+{{- end -}}
+{{ $url }}

--- a/docs/layouts/partials/meilindex/getURL.html
+++ b/docs/layouts/partials/meilindex/getURL.html
@@ -1,3 +1,4 @@
+<!-- Handles URL for the page. If home, use the default "/" -->
 {{- $tempURL := index ( split .RelPermalink "." ) 0 -}}
 {{- $url := "/" -}}
 {{- if ne $tempURL "/index" -}}

--- a/docs/themes/avocadocs/layouts/_default/index.json.json
+++ b/docs/themes/avocadocs/layouts/_default/index.json.json
@@ -1,1 +1,0 @@
-{{- $numPages := len .Site.Pages -}}{{- $count := 0 -}}[{{- range .Site.Pages -}}{{- chomp ( partial "json/createindex.json" . ) -}}{{- $count = add $count 1 -}}{{- if ne $count $numPages -}},{{- end -}}{{- end -}}]

--- a/scratch
+++ b/scratch
@@ -1,0 +1,6 @@
+{{- $url := chomp ( partial "meilindex/getURL" . ) -}}
+{{- $subsections := chomp (.TableOfContents | plainify) -}}
+{{- $text := chomp ( partial "meilindex/getText" . ) -}}
+{{- $section := chomp ( partial "meilindex/getSection" . ) -}}
+{{- $index = $index | append (dict "title" .Title "documentId" .File.UniqueID "site" "docs" "rank" 1 "url" $url "subsections" $subsections "text" $text "section" $section ) -}}
+{{- $index | jsonify -}}

--- a/scratch
+++ b/scratch
@@ -1,6 +1,0 @@
-{{- $url := chomp ( partial "meilindex/getURL" . ) -}}
-{{- $subsections := chomp (.TableOfContents | plainify) -}}
-{{- $text := chomp ( partial "meilindex/getText" . ) -}}
-{{- $section := chomp ( partial "meilindex/getSection" . ) -}}
-{{- $index = $index | append (dict "title" .Title "documentId" .File.UniqueID "site" "docs" "rank" 1 "url" $url "subsections" $subsections "text" $text "section" $section ) -}}
-{{- $index | jsonify -}}


### PR DESCRIPTION
- all self-indexing moved out  of theme
- `index.json.json` uses [jsonify](https://gohugo.io/functions/jsonify/) to ensure final object is valid json. breaks otherwise
- `json/createIndex` removed, broken up into three smaller  partials.
- all `registry` pages + `other` list page not searchable