### PR TITLE
Cleanup

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,12 +11,11 @@
     "hugo-watch-dev": "hugo server --watch --verbose --buildDrafts --cleanDestinationDir --disableFastRender",
     "hugo-watch-prod": "./hugo",
     "fetch-files": "rm -rf static/files/fetch/* && node static/scripts/fetch.js",
-    "fetch-templates": "node static/scripts/fetch-templates.js",
     "registry-files": "node static/scripts/updateExampleConfigFiles.js",
     "build-searchapp": "cd static/scripts/xss && npm install && npm run-script build",
-    "dev": "npm run fetch-files && npm run fetch-templates && npm run registry-files",
-    "build": "npm run fetch-files && npm run fetch-templates && npm run registry-files && npm run build-searchapp",
-    "prod": "npm run fetch-files && npm run fetch-templates && npm run registry-files && npm run scss-build"
+    "dev": "npm run fetch-files && npm run registry-files",
+    "build": "npm run fetch-files && npm run registry-files && npm run build-searchapp",
+    "prod": "npm run fetch-files && npm run registry-files && npm run scss-build"
   },
   "devDependencies": {
     "autoprefixer": "^9.0.0",

--- a/docs/themes/avocadocs/layouts/partials/header/logo.html
+++ b/docs/themes/avocadocs/layouts/partials/header/logo.html
@@ -13,7 +13,7 @@
     <img class="mr-0" src="{{ .Site.Params.logo | relURL }}" style="max-width: 175px;" {{ if isset .Site.Params.meta "sitename" }}alt="{{ .Site.Params.meta.sitename }}"{{ end }}>
 
     <!-- Version badge -->
-    {{ if ( isset .Site.Params "showversionbadge" ) and ( isset .Site.Params "version" ) }}
+    {{ if and ( isset .Site.Params "showversionbadge" ) ( isset .Site.Params "version" ) }}
       <span class="small">
         <span class="badge badge-light text-space-1">{{ .Site.Params.version }}</span>
       </span>


### PR DESCRIPTION
- fixes `and` syntax in `logo.html` to current. Mostly  relevant for local Hugo installations > 0.72
- removes remaining references to `fetch-templates.js`, so it doesnt run on `npm run dev`