### PR TITLE
Clean up and clarify list terms

### DIFF
--- a/docs/src/administration/sso.md
+++ b/docs/src/administration/sso.md
@@ -22,9 +22,7 @@ A deactivated user will no longer be able to use SSH, Git, or other Platform.sh 
 
 ## Service users
 
-If you have a service user with an email address under your SSO domain, e.g. `machine-user@example.com`, you can whitelist that user so that they will not be required to authenticate through your identity provider.
-
-Please open a support ticket if you need to whitelist a user.
+If you want to make an exception to exclude a user (e.g. `machine-user@example.com`) from being forced to use your identity provider, please open a support ticket.
 
 ## SSO providers
 

--- a/docs/src/configuration/app/firewall.md
+++ b/docs/src/configuration/app/firewall.md
@@ -17,7 +17,7 @@ The outbound firewall is currently in Beta.  While the syntax is not expected to
 
 ## Syntax
 
-The `firewall` property defines one or more whitelist entries for outbound requests.  Its basic syntax is as follows:
+The `firewall` property defines one or more safelist entries for outbound requests.  Its basic syntax is as follows:
 
 ```yaml
 firewall:
@@ -55,7 +55,7 @@ The default and only legal value for the protocol is `tcp`.  Outbound UDP ports 
 
 This property is an array of IP addresses in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).  CIDR allows you to specify a range of IP addresses in a compact format, using a bitmask.  Most commonly the bitmask is 8, 16, or 32 but that is not required.
 
-For example, `1.2.3.4/8` will match any IP address whose first 8 bits match `1.2.3.4`, which corresponds to the first segment.  Therefore it will allow `1.*.*.*`.  In comparison, `1.2.3.4/24` will allow `1.2.3.*`.  A mask of 32 will match only the IP address specified, so to whitelist a single specific IP you must write `1.2.3.4/32`.
+For example, `1.2.3.4/8` will match any IP address whose first 8 bits match `1.2.3.4`, which corresponds to the first segment.  Therefore it will allow `1.*.*.*`.  In comparison, `1.2.3.4/24` will allow `1.2.3.*`.  A mask of 32 will match only the IP address specified, so to safelist a single specific IP you must write `1.2.3.4/32`.
 
 [IP Address Guide](https://ipaddressguide.com/cidr) has a useful CIDR format calculator.
 
@@ -71,7 +71,7 @@ If no `ips` property is specified, requests to any IP address are permitted on t
 
 ## Multiple rules
 
-It is possible to define an arbitrary number of whitelist firewall rules, as in the example above.  If multiple rules are specified, a given outbound request will be allowed if it matches ANY of the defined rules.
+It is possible to define an arbitrary number of safelist firewall rules, as in the example above.  If multiple rules are specified, a given outbound request will be allowed if it matches ANY of the defined rules.
 
 That means that, for this configuration:
 
@@ -87,6 +87,6 @@ Requests to port 80 on any IP will be allowed, and requests to 1.2.3.4 on either
 
 ## Usage considerations
 
-Be aware that many services your application may wish to connect to will be using a domain name that is not on a fixed IP address, or is load-balanced between multiple IP addresses.  You will need to contact the administrator of that service in order to determine the correct IP addresses to whitelist.
+Be aware that many services your application may wish to connect to will be using a domain name that is not on a fixed IP address, or is load-balanced between multiple IP addresses.  You will need to contact the administrator of that service in order to determine the correct IP addresses to safelist.
 
-Also be aware that many services are behind a Content Delivery Network (CDN).  For most CDNs, routing is done via domain name, not IP address, so thousands of domain names may share the same public IP addresses at the CDN.  If you whitelist the IP address of a CDN, you will in most cases be whitelisting many or all of the other customers hosted behind that CDN.  That has security implications and limits the usefulness of this configuration option.
+Also be aware that many services are behind a Content Delivery Network (CDN).  For most CDNs, routing is done via domain name, not IP address, so thousands of domain names may share the same public IP addresses at the CDN.  If you safelist the IP address of a CDN, you will in most cases be safelisting many or all of the other customers hosted behind that CDN.  That has security implications and limits the usefulness of this configuration option.

--- a/docs/src/configuration/app/web.md
+++ b/docs/src/configuration/app/web.md
@@ -124,7 +124,7 @@ A full list of the possible subkeys for `locations` is below.
 
 The rules block warrants its own discussion as it allows overriding most other keys according to a regular expression. The key of each item under the `rules` block is a regular expression matching paths more specifically than the `locations` block entries.  If an incoming request matches the rule, then its handling will be overridden by the properties under the rule.  Note that it will override the entire rule in the case of a compound rule like `headers`.  (See example below.)
 
-For example, the following file will serve dynamic requests from `index.php` in the `public` directory and disallow requests for static files anywhere.  Then it sets a rule to explicitly whitelist common image file formats, and sets a cache lifetime for them of 5 minutes.
+For example, the following file will serve dynamic requests from `index.php` in the `public` directory and disallow requests for static files anywhere.  Then it sets a rule to allow common image file formats, and set their cache lifetime to 5 minutes.
 
 ```yaml
 web:
@@ -179,7 +179,7 @@ web:
 
 ## How can I serve a static-only site?
 
-Although most websites today have some dynamic component, static site generators are a valid way to build a site.  This documentation is built using a tool called Hugo, and served by Platform.sh as a static site.  You can see the [entire repository](https://github.com/platformsh/platformsh-docs) on GitHub.  The `.platform.app.yaml` file it uses is listed below.  Note in particular the `web.commands.start` directive. There needs to be some background process so it's set to the `sleep` shell command, which will simply block forever (or some really long time, as computers don't know about forever) and restart if needed.  The file also runs the Hugo build process, and then whitelists the files to serve.
+Although most websites today have some dynamic component, static site generators are a valid way to build a site.  This documentation is built using a tool called Hugo, and served by Platform.sh as a static site.  You can see the [entire repository](https://github.com/platformsh/platformsh-docs) on GitHub.  The `.platform.app.yaml` file it uses is listed below.  Note in particular the `web.commands.start` directive. There needs to be some background process so it's set to the `sleep` shell command, which will simply block forever (or some really long time, as computers don't know about forever) and restart if needed.  The file also runs the Hugo build process, and then safelists the files to serve.
 
 {{< readFile file="static/files/fetch/docsappyaml/platformsh-docs" highlight="yaml" >}}
 

--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -198,7 +198,7 @@ function get_domain_for(string $id) {
 }
 ```
 
-That can be used, for example, for inbound request whitelisting, a feature of many PHP frameworks.
+That can be used, for example, for inbound hostname validation, a feature of many PHP frameworks.
 
 ## Route attributes
 

--- a/docs/src/configuration/routes/cache.md
+++ b/docs/src/configuration/routes/cache.md
@@ -137,7 +137,7 @@ A full list of HTTP headers is available on [Wikipedia](https://en.wikipedia.org
 
 ### `cookies`
 
-A whitelist of cookie names to include values for in the cache key.
+A safelist of cookie names to include values for in the cache key.
 
 All cookies will bypass the cache when using the default (`['*']`) or if the `Set-Cookie` header is present.
 
@@ -155,7 +155,7 @@ cache:
 **Values:**
 * `['*']`: any request with a cookie will bypass the cache [default]
 * `[]`: Ignore all cookies
-* `['cookie_1','cookie_2']`: A whitelist of cookies to include in the cache key. All other cookies are ignored.
+* `['cookie_1','cookie_2']`: A safelist of cookies to include in the cache key. All other cookies are ignored.
 {{< /note >}}
 
 A cookie value may also be a regular expression.  An entry that begins and ends with a `/` will be interpreted as a PCRE regular expression to match the cookie name.  For example:

--- a/docs/src/dedicated/architecture/options.md
+++ b/docs/src/dedicated/architecture/options.md
@@ -46,7 +46,7 @@ By default, Platform.sh will serve generic Platform.sh-branded error pages for e
 
 ## IP restrictions
 
-Platform.sh supports project-level IP restrictions (whitelisting) and HTTP Basic authentication.  These may be configured through the Development Environment and will be automatically replicated from the `production` and `staging` branches to the production and staging environments, respectively.
+Platform.sh supports project-level IP restrictions (safelisting) and HTTP Basic authentication.  These may be configured through the Development Environment and will be automatically replicated from the `production` and `staging` branches to the production and staging environments, respectively.
 
 {{< note >}}
 Changing access control will trigger a new deploy of the current environment. However, the changes will not propagate to child environments until they are manually redeployed.

--- a/docs/src/dedicated/overview/security.md
+++ b/docs/src/dedicated/overview/security.md
@@ -16,7 +16,7 @@ All Dedicated Clusters are single-tenant.  The three VMs are exclusively used by
 
 Outgoing TCP traffic is not firewalled.  Outgoing UDP traffic is disallowed.
 
-The Development Environment deploys each branch as a series of containers hosted on a shared underlying VM.  Many customers will generally share the same VM.  However, all containers are whitelisted to connect only to other containers in their same environment, and even then only if an explicit "relationship" has been defined by the user via configuration file.
+The Development Environment deploys each branch as a series of containers hosted on a shared underlying VM.  Many customers will generally share the same VM.  However, containers are only allowed to connect to other containers in their same environment, and even then only if an explicit "relationship" has been defined by the user via configuration file.
 
 ## Security incident handling procedure
 

--- a/docs/src/development/public-ips.md
+++ b/docs/src/development/public-ips.md
@@ -8,7 +8,7 @@ description: |
 
 {{< description >}}
 
-Use the inbound IP addresses if you have a corporate firewall which blocks outgoing SSH connections.  In that case, simply add our IP addresses for inbound traffic below to your whitelist.
+Use the inbound IP addresses if you have a corporate firewall which blocks outgoing SSH connections.  In that case, simply add our IP addresses for inbound traffic below to your safelist.
 
 {{< note >}}
 These IP addresses are stable, but not guaranteed to never change. Prior to any future change, all affected customers will receive ample warning.

--- a/docs/src/frameworks/drupal7/simplesaml.md
+++ b/docs/src/frameworks/drupal7/simplesaml.md
@@ -15,7 +15,7 @@ The `drupal` build flavor will move that directory to the `public/sites/default/
 
 ## Include SimpleSAML cookies in the cache key
 
-The SimpleSAML client uses additional cookies besides the Drupal session cookie that need to be whitelisted for the cache.  To do so, modify your `routes.yaml` file for the route that points to your Drupal site and add two additional cookies to the `cache.cookies` line.  It should end up looking approximately like this:
+The SimpleSAML client uses additional cookies besides the Drupal session cookie that need to be safelisted for the cache.  To do so, modify your `routes.yaml` file for the route that points to your Drupal site and add two additional cookies to the `cache.cookies` line.  It should end up looking approximately like this:
 
 ```yaml
 "https://{default}/":

--- a/docs/src/frameworks/drupal8/simplesaml.md
+++ b/docs/src/frameworks/drupal8/simplesaml.md
@@ -19,7 +19,7 @@ Once that's run, commit both `composer.json` and `composer.lock` to your reposit
 
 ## Include SimpleSAML cookies in the cache key
 
-The SimpleSAML client uses additional cookies besides the Drupal session cookie that need to be whitelisted for the cache.  To do so, modify your `routes.yaml` file for the route that points to your Drupal site and add two additional cookies to the `cache.cookies` line.  It should end up looking approximately like this:
+The SimpleSAML client uses additional cookies besides the Drupal session cookie that need to be safelisted for the cache.  To do so, modify your `routes.yaml` file for the route that points to your Drupal site and add two additional cookies to the `cache.cookies` line.  It should end up looking approximately like this:
 
 ```yaml
 "https://{default}/":

--- a/docs/src/frameworks/wordpress/_index.md
+++ b/docs/src/frameworks/wordpress/_index.md
@@ -11,6 +11,6 @@ Platform.sh strongly recommends starting new WordPress projects from our [WordPr
 
 ## Plugin compatibility
 
-Platform.sh does not blacklist any WordPress plugins.  However, some plugins are known to require write access to their own file system as part of their setup process.  That is not possible on Platform.sh.  The file system where code lives is read-only for security reasons and cannot be written to from the application, only during the [build hook]({{< relref "/configuration/app/build.md" >}}).
+Platform.sh does not ban any WordPress plugins.  However, some plugins are known to require write access to their own file system as part of their setup process.  That is not possible on Platform.sh.  The file system where code lives is read-only for security reasons and cannot be written to from the application, only during the [build hook]({{< relref "/configuration/app/build.md" >}}).
 
 In some cases that can be worked around by copying a file as part of the build hook process.  In other cases the plugin is simply incompatible with Platform.sh.  If you find a plugin that tries to write to its own directory we recommend filing an issue with that plugin, as such behavior should be viewed as a security bug.

--- a/docs/src/golive/cdn/_index.md
+++ b/docs/src/golive/cdn/_index.md
@@ -77,7 +77,7 @@ Be aware that this approach will apply the same user and password to all develop
 This is the recommended approach for CloudFlare.
 {{< /note >}}
 
-### IP whitelisting
+### IP safelisting
 
 If your CDN does not support adding headers to the request to origin, you can allow the IP addresses of your CDN.
 

--- a/docs/src/integrations/activity/_index.md
+++ b/docs/src/integrations/activity/_index.md
@@ -100,7 +100,7 @@ The following example executes only for backup actions on the `master` environme
 platform integration:update --events=environment.backup --environments=master nadbowmhd67do
 ```
 
-There is also an `--exclude-environments` switch to blacklist environments by name rather than whitelist.
+There is also an `--exclude-environments` switch to exclude some environments by name.
 
 As a general rule, it is better to have an activity script only execute on the specific events and branches you're interested in rather than firing on all activities and then filtering out undesired use cases in the script itself.
 

--- a/docs/src/languages/php/tuning.md
+++ b/docs/src/languages/php/tuning.md
@@ -15,7 +15,7 @@ To change your PHP version, simply change the `type` key in your `.platform.app.
 
 ## Ensure that the router cache is properly configured
 
-Although not PHP-specific, a common source of performance issues is a misconfigured cache.  The most common issue is not whitelisting session cookies, which results in a site with any cookies at all, including from analytics tools, never being cached.  See the [router cache]({{< relref "/configuration/routes/cache.md" >}}) documentation, and the [cookie entry]({{< relref "/configuration/routes/cache.md#cookies" >}}) specifically.
+Although not PHP-specific, a common source of performance issues is a misconfigured cache.  The most common issue is not safelisting session cookies, which results in a site with any cookies at all, including from analytics tools, never being cached.  See the [router cache]({{< relref "/configuration/routes/cache.md" >}}) documentation, and the [cookie entry]({{< relref "/configuration/routes/cache.md#cookies" >}}) specifically.
 
 You will also need to ensure that your application is sending the correct `cache-control` header.  The router cache will obey whatever cache headers your application sends, so send it good ones.
 


### PR DESCRIPTION
Follows on from #1449 

Removes `blacklist` and `whitelist` and uses the term `safelist` as a noun or verb where there isn't a clearer alternative.