### PR TITLE
CM-1082: PCI & SOC2 exclusion for OVH-FR-2

### DIFF
--- a/docs/src/security/compliance-guidance.md
+++ b/docs/src/security/compliance-guidance.md
@@ -24,7 +24,9 @@ Cardholder processing activity is discouraged. Please use a third party processo
 
 * Please take note that customer environments are deployed in a read-only instance, segregated with GRE and IPSEC tunnels, which often permits compensating controls to be claimed for several PCI requirements.
 
-* Because customers can use our PaaS in a variety of ways, the best approach with auditors is to focus is on “What do I, the customer, control/configure and how is it managed in a compliant manner?”
+* Because customers can use our PaaS in a variety of ways, the best approach with auditors is to focus on “What do I, the customer, control/configure and how is it managed in a compliant manner?”
+
+* The `OVH-FR-2` region is excluded from our PCI and SOC2 certifications. 
 
 ## Responsibility
 

--- a/docs/src/security/compliance-guidance.md
+++ b/docs/src/security/compliance-guidance.md
@@ -26,7 +26,7 @@ Cardholder processing activity is discouraged. Please use a third party processo
 
 * Because customers can use our PaaS in a variety of ways, the best approach with auditors is to focus on “What do I, the customer, control/configure and how is it managed in a compliant manner?”
 
-* The `OVH-FR-2` region is excluded from our PCI and SOC2 certifications. 
+* The `OVH-FR-2` region is excluded from our PCI and SOC2 certifications.
 
 ## Responsibility
 


### PR DESCRIPTION
Add a note that PCI & SOC2 do not apply to OVH-FR-2. Also fixes a minor grammar issue.