### PR TITLE
Fix example of storage shared between apps

### DIFF
--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -57,17 +57,23 @@ It is also possible to have one application mount a `source_path` that is a subd
 
 `app1`:
 
-{{< readFile file="src/registry/images/examples/full/network-storage.app.yaml" highlight="yaml" >}}
+```yaml
+mounts:
+    'web/uploads':
+        source: service
+        service: files
+        source_path: uploads
+```
 
 `app2`:
 
 ```yaml
 mounts:
-    'process':
+    'web/uploads/process':
         source: service
         service: files
         source_path: uploads/incoming
-    'done':
+    'web/uploads/done':
         source: service
         service: files
         source_path: uploads/done

--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -69,11 +69,11 @@ mounts:
 
 ```yaml
 mounts:
-    'web/uploads/process':
+    'process':
         source: service
         service: files
         source_path: uploads/incoming
-    'web/uploads/done':
+    'done':
         source: service
         service: files
         source_path: uploads/done


### PR DESCRIPTION
The example was based on an imported file that has probably changed and no longer fit the example.

Additionally the actual mounts in the configs didn't match what was explained in the text below the example.