### PR TITLE
Add browser.close() to Pupeteer on errors

### DIFF
--- a/docs/src/configuration/services/headless-chrome.md
+++ b/docs/src/configuration/services/headless-chrome.md
@@ -89,8 +89,9 @@ exports.takeScreenshot = async function (url) {
 
         return browser
 
-    } catch (e) {
-        return Promise.reject(e);
+    } catch (error) {
+        console.error({ error }, 'Something happened!');
+        browser.close();
     }
 };
 ```


### PR DESCRIPTION
Following best pactices for terminating sessions on errors: https://docs.browserless.io/docs/best-practices.html#make-sure-you-close-your-session