### PR TITLE
Recommend default from address on health emails

### DIFF
--- a/docs/src/integrations/notifications.md
+++ b/docs/src/integrations/notifications.md
@@ -68,10 +68,13 @@ The `recipients` field may be any valid email address, or one of the following s
 To add a new email notification, register a `health.email` integration as follows:
 
 ```bash
-platform integration:add --type health.email --from-address you@example.com --recipients them@example.com --recipients others@example.com
+platform integration:add --type health.email --recipients them@example.com --recipients others@example.com
 ```
 
-The `from-address` is whatever address you want the email to appear to be from.  You must specify one or more `recipients`, each as its own switch.  It is completely fine to use the same email address for both `from-address` and `recipients`.
+The default `from-address` points to the "Platform.sh Bot". You must specify one or more `recipients`, each as its own switch.
+
+You can also configure a custom `from-address`. The `from-address` is whatever address you want the email to appear to be from. It is completely fine to use the same email address for both `from-address` and `recipients`. Note that using SPF logging like `v=spf1 include:spf.protection.outlook.com -all` combined with a custom `from-address`, will result in emails ending up lost / in spam.
+
 
 ### Slack notifications
 

--- a/docs/src/integrations/notifications.md
+++ b/docs/src/integrations/notifications.md
@@ -73,7 +73,7 @@ platform integration:add --type health.email --recipients them@example.com --rec
 
 The default `from-address` points to the "Platform.sh Bot". You must specify one or more `recipients`, each as its own switch.
 
-You can also configure a custom `from-address`. The `from-address` is whatever address you want the email to appear to be from. It is completely fine to use the same email address for both `from-address` and `recipients`. Note that using SPF logging like `v=spf1 include:spf.protection.outlook.com -all` combined with a custom `from-address`, will result in emails ending up lost / in spam.
+You can also configure a custom `from-address`. The `from-address` is whatever address you want the email to appear to be from. It is completely fine to use the same email address for both `from-address` and `recipients`. Note that depending on the configuration of the recipient mail server (including SPF and DKIM DNS entries) when using a custom `from-address`, the email can be marked as spam or lost.
 
 
 ### Slack notifications

--- a/docs/src/integrations/notifications.md
+++ b/docs/src/integrations/notifications.md
@@ -73,7 +73,7 @@ platform integration:add --type health.email --recipients them@example.com --rec
 
 The default `from-address` points to the "Platform.sh Bot". You must specify one or more `recipients`, each as its own switch.
 
-You can also configure a custom `from-address`. The `from-address` is whatever address you want the email to appear to be from. It is completely fine to use the same email address for both `from-address` and `recipients`. Note that depending on the configuration of the recipient mail server (including SPF and DKIM DNS entries) when using a custom `from-address`, the email can be marked as spam or lost.
+You can also configure a custom `--from-address`. The `--from-address` is whatever address you want the email to appear to be from. It is completely fine to use the same email address for both `from-address` and `recipients`. Note that depending on the configuration of the recipient mail server (including SPF and DKIM DNS entries) when using a custom `from-address`, the email can be marked as spam or lost.
 
 
 ### Slack notifications


### PR DESCRIPTION
This PR adds a note about using a custom from email address in health emails, and removes the custom from email address from the example on setting it up as it's not recommended.

cc/ @acervulus who identified the possible issues with the custom from email addresses 