### PR TITLE
Remove mention of restrict_robots

### DIFF
--- a/docs/src/administration/web/configure-environment.md
+++ b/docs/src/administration/web/configure-environment.md
@@ -64,9 +64,16 @@ By default, Platform.sh includes an additional `X-Robots-Tag` header on all non-
 X-Robots-Tag: noindex, nofollow
 ```
 
-That tells search engines to not index sites on non-production environments entirely nor traverse links from those sites, even if they are publicly visible.  That keeps non-production sites out of search engine indexes that would dilute the SEO of the production site.  
+That tells search engines to not index sites on non-production environments entirely nor traverse links from those sites, even if they are publicly visible.  That keeps non-production sites out of search engine indexes that would dilute the SEO of the production site, and it cannot be disabled on non-production environments.
 
-On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`]({{< relref "/configuration/app/web.md#locations" >}}).
+On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled automatically and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`]({{< relref "/configuration/app/web.md#locations" >}}).
+
+
+To enable the search-blocker `X-Robots-Tag` header on a production environment, use the [Platform.sh CLI]({{< relref "/development/cli/_index.md" >}}) command below:
+
+```
+platform environment:info restrict_robots true
+```
 
 ### HTTP access control
 

--- a/docs/src/administration/web/configure-environment.md
+++ b/docs/src/administration/web/configure-environment.md
@@ -64,19 +64,7 @@ By default, Platform.sh includes an additional `X-Robots-Tag` header on all non-
 X-Robots-Tag: noindex, nofollow
 ```
 
-That tells search engines to not index sites on non-production environments entirely nor traverse links from those sites, even if they are publicly visible.  That keeps non-production sites out of search engine indexes that would dilute the SEO of the production site.  To disable that feature for a non-production environment, use the [Platform.sh CLI]({{< relref "/development/cli/_index.md" >}}) command below:
-
-```
-platform environment:info restrict_robots false
-```
-
-Or to disable it for a specific environment other than the one that is currently checked out, execute the following:
-
-```bash
-platform environment:info -e ENVNAME restrict_robots false
-```
-
-where `ENVNAME` is the name of the environment.
+That tells search engines to not index sites on non-production environments entirely nor traverse links from those sites, even if they are publicly visible.  That keeps non-production sites out of search engine indexes that would dilute the SEO of the production site.  
 
 On a production instance (the master branch, after a domain has been assigned) the search-blocker is disabled and your application can serve a `robots.txt` file as normal.  However, you must ensure that the file is in your project's web root (the directory where the `/` location maps to) and your application is configured to serve it.  See [the location section in `.platform.app.yaml`]({{< relref "/configuration/app/web.md#locations" >}}).
 


### PR DESCRIPTION
The restrict_robots setting does not have any impact on the x-robots-tag header on non-production environments by design. The setting also does not have any impact on the x-robots-tag header in production environments currently (which is the result of a bug). Removing references to restrict_robots in the public documentation in the meantime.