### PR TITLE
502-error-fix

### DIFF
--- a/docs/.platform.app.yaml
+++ b/docs/.platform.app.yaml
@@ -30,7 +30,7 @@ web:
         '/':
             # The public directory of the application relative to its root.
             root: 'public'
-            passthru: true
+            passthru: false
             index: ['index.html']
             scripts: false
             allow: true


### PR DESCRIPTION
This is stop decommissioned pages from serving 502 errors.
 More details in #devrel