### PR TITLE
Improvement to TYPO3 Deployment Guide

### DIFF
--- a/docs/src/guides/typo3/deploy/_index.md
+++ b/docs/src/guides/typo3/deploy/_index.md
@@ -8,7 +8,7 @@ description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy TYPO3.
 ---
 
-TYPO3 is an Open Source Enterprise PHP-based CMS framework. The recommended way to deploy TYPO3 on Platform.sh is by using Composer, the PHP package management suite. 
+TYPO3 is an Open Source Enterprise PHP-based CMS framework. The recommended way to deploy TYPO3 on Platform.sh is by using Composer, the PHP package management suite.
 
 This guide assumes you are using the well-supported Composer flavor of TYPO3. Going through the steps below you will have two options:
 
@@ -23,17 +23,3 @@ If you have a TYPO3 site that is not using Composer, there is a useful guide in 
 
 {{< guides/tools >}}
 
-## Sign up for Platform.sh and initialize your project
-
-{{< guides/signup name="TYPO3" template="typo3" >}}
-
-```bash
-$ composer create-project typo3/cms-base-distribution <PROJECT_NAME> ^10
-$ cd <PROJECT_NAME>
-$ git init
-$ git add . && git commit -m "Init TYPO3 from upstream."
-```
-
-{{< /guides/signup >}}
-
-{{< guide-buttons next="Configure repository" type="first" >}}

--- a/docs/src/guides/typo3/deploy/_index.md
+++ b/docs/src/guides/typo3/deploy/_index.md
@@ -24,3 +24,8 @@ If you have no TYPO3 site to start from, Platform.sh maintains a ready-made [TYP
 
 {{< guides/tools >}}
 
+## Repository integration with Bitbucket, GitHub, or GitLab
+
+Platform.sh allows you to [maintain your code base in a third party repository](/integrations/source/_index.md) such as Bitbucket, GitHub, or GitLab and link it to your Platform.sh project. The remote repository is the canonical, definitive copy of your application code and the Platform.sh project is just a read-only mirror.
+
+Note that when a source integration is enabled, you should not push code directly to the Platform.sh repository. It will get overwritten the next time the integration is triggered.

--- a/docs/src/guides/typo3/deploy/_index.md
+++ b/docs/src/guides/typo3/deploy/_index.md
@@ -10,13 +10,14 @@ description: |
 
 TYPO3 is an Open Source Enterprise PHP-based CMS framework. The recommended way to deploy TYPO3 on Platform.sh is by using Composer, the PHP package management suite.
 
-This guide assumes you are using the well-supported Composer flavor of TYPO3. Going through the steps below you will have two options:
-
-1. You already have a [Composer flavored TYPO3](https://github.com/TYPO3/TYPO3.CMS.BaseDistribution) site your are trying to deploy. In this case, you will able to go through each step to make the recommended changes to your repository to prepare it for Platform.sh.
-2. You have no code at this point. In this case, Platform.sh maintains a ready-made [TYPO3 template](https://github.com/platformsh-templates/typo3) that you will be able to deploy very quickly. The steps below will then hopefully help to clarify why the modifications have been made to a base TYPO3 project.
+This guide assumes you have a [Composer flavored TYPO3](https://github.com/TYPO3/TYPO3.CMS.BaseDistribution) site your are trying to deploy. In this case, you will able to go through each step to make the recommended changes to your repository to prepare it for Platform.sh.
 
 {{< note >}}
 If you have a TYPO3 site that is not using Composer, there is a useful guide in the TYPO3 documentation for [Migrating a TYPO3 Project to Composer](https://docs.typo3.org/m/typo3/guide-installation/master/en-us/MigrateToComposer/Index.html) you can follow before proceeding.
+{{< /note >}}
+
+{{< note >}}
+If you have no TYPO3 site to start from, Platform.sh maintains a ready-made [TYPO3 template](https://github.com/platformsh-templates/typo3) that you will be able to deploy very quickly. You won't need to follow this guide.
 {{< /note >}}
 
 ## Tools

--- a/docs/src/guides/typo3/deploy/configure.md
+++ b/docs/src/guides/typo3/deploy/configure.md
@@ -29,6 +29,152 @@ If a service stores persistent data then it will also have a `disk` key, which s
 
 ## Application container: `.platform.app.yaml`
 
-{{< guides/config-app template="typo3" >}}
+The `platform.app.yaml` file is the heart of your application. It has an [extensive set of options](/configuration/app/_index.md) that allow you to configure nearly any aspect of your application. Most of it is explained with comments inline.</p>
+
+You can and likely will evolve this file over time as you build out your site.
+
+The example `platform.app.yaml` file below will work for most TYPO3 instances.
+
+Please note that it includes a relationship to a Redis service. This service will have to be defined in the `routes.yaml` file. You'll also notice that the command `php vendor/bin/typo3cms install:generatepackagestate` is run during the build phase. It will make sure all installed extensions are enabled and can be ommitted if you commit your own [`PackageStates.php`](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ExtensionManagement/Index.html#package-manager) file.
+
+```yaml
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: php:7.4
+
+runtime:
+    # Enable the redis extension so TYPO3 can communicate with the Redis cache.
+    extensions:
+        - redis
+
+# Composer build tasks run prior to build hook, which runs
+# composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
+# if composer.json is detected.
+build:
+    flavor: composer
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+#
+# NOTE: Be sure to update database and Redis configuration in `public/typo3conf/PlatformshConfiguration.php`
+# if you rename the relationships here.
+relationships:
+    # MariaDB/MySQL will then be accessible to the app from 'database' relationship.
+    # The service name `db` must match the top-level attribute in `.platform/services.yaml`.
+    database: 'db:mysql'
+
+    # Redis will then be accessible to the app from 'rediscache' relationship.
+    # The service name `cache` must match the top-level attribute in `.platform/services.yaml`.
+    rediscache: 'cache:redis'
+
+# The configuration of app when it is exposed to the web.
+web:
+    # How the application container responds to incoming requests.
+    locations:
+        # All requests not otherwise specified follow these rules.
+        '/':
+            # The folder from which to serve static assets, for this location.
+            # This is a filesystem path, relative to the application root.
+            root: 'public'
+
+            # Redirect any incoming request to TYPO3's front controller.
+            passthru: '/index.php'
+
+            # File to consider first when serving requests for a directory.
+            index:
+                - 'index.php'
+
+            # Deny access to all static files, except those specifically allowed below.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+        # Default Storage location where TYPO3 expects media resources to be located.
+        # Writable at runtime with the mount `public/fileadmin`.
+        '/fileadmin':
+            root: 'public/fileadmin'
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+            allow: true
+            passthru: '/index.php'
+
+        # Directory for temporary files that should be publicly available (e.g. generated images).
+        # Writable at runtime with the mount `publi/typo3temp`.
+        '/typo3temp/assets':
+            root: 'public/typo3temp/assets'
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+            allow: true
+            passthru: '/index.php'
+
+        # Local TYPO3 installation settings.
+        '/typo3conf/LocalConfiguration.php':
+            allow: false
+
+        # Additional TYPO3 installation settings.
+        '/typo3conf/AdditionalConfiguration.php':
+            allow: false
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    # Directory for temporary files. It contains subdirectories (see below) for
+    # temporary files of extensions and TYPO3 components.
+    "public/typo3temp":
+        source: local
+        source_path: "typo3temp"
+    # Default Storage location where TYPO3 expects media resources to be located.
+    "public/fileadmin":
+        source: local
+        source_path: "fileadmin"
+    # Contains system files, like caches, logs, sessions
+    "var":
+        source: local
+        source_path: "var"
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+        # Generates the `PackageStates.php` file from the `composer.json` configuration
+        php vendor/bin/typo3cms install:generatepackagestate
+
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+crons:
+     # Run TYPO3's Scheduler tasks every 5 minutes.
+    typo3:
+        spec: "*/5 * * * *"
+        cmd: "vendor/bin/typo3 scheduler:run"
+```
 
 {{< guide-buttons next="Customize TYPO3" >}}

--- a/docs/src/guides/typo3/deploy/customize.md
+++ b/docs/src/guides/typo3/deploy/customize.md
@@ -30,7 +30,7 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout'] = 3;
 ```
 
 {{< note >}}
-The suggested timeout of three seconds above may end up being too short if your TYPO3 instance performs external requests other than to itself as described here. If the instance makes long requests, such as when synchronizing data as a part of a TYPO3 Scheduler task with an external API, it is best instead to place these operations in workers. 
+The suggested timeout of three seconds above may end up being too short if your TYPO3 instance performs external requests other than to itself as described here. If the instance makes long requests, such as when synchronizing data as a part of a TYPO3 Scheduler task with an external API, it is best instead to place these operations in workers.
 {{< /note >}}
 
 You will still need to enable the `pixelant/pxa-lpeh` extension, which you can do by running the command:
@@ -49,7 +49,7 @@ $ composer config extra.typo3/cms.web-dir public && composer update --no-scripts
 
 ## Site
 
-You will have to locate the site configuration file(s), `config.yaml`, in your repository's `config/sites/<SITEID>` subdirectories. For the purposes of this guide, you will need to set the `base` attribute to an environment variable called `PLATFORM_ROUTES_MAIN`. You can also add the definition to your existing `baseVariant` attribute for production if desired. 
+You will have to locate the site configuration file(s), `config.yaml`, in your repository's `config/sites/<SITEID>` subdirectories. For the purposes of this guide, you will need to set the `base` attribute to an environment variable called `PLATFORM_ROUTES_MAIN`. You can also add the definition to your existing `baseVariant` attribute for production if desired.
 
 {{< github repo="platformsh-templates/typo3" file="config/sites/main/config.yaml" lang="yaml" >}}
 
@@ -57,7 +57,7 @@ You will define this environment variable in the next section, but it's purpose 
 
 {{< note >}}
 
-The above `base` configuration only includes the production case - that is, running on Platform.sh - or at least exporting a `PLATFORM_ROUTES_MAIN` environment variable to match during local development. Alternatively, you can place the above definition within a `baseVariant` definition for the production environment alongside another development environment `condition` for local. 
+The above `base` configuration only includes the production case - that is, running on Platform.sh - or at least exporting a `PLATFORM_ROUTES_MAIN` environment variable to match during local development. Alternatively, you can place the above definition within a `baseVariant` definition for the production environment alongside another development environment `condition` for local.
 
 ```yaml
 baseVariants:
@@ -66,7 +66,7 @@ baseVariants:
     condition: 'applicationContext == "Development/local"'
   -
     base: '%env(PLATFORM_ROUTES_MAIN)%'
-    condition: 'applicationContext == "Production/local"'
+    condition: 'applicationContext == "Production'
 ```
 
 {{< /note >}}

--- a/docs/src/guides/typo3/deploy/deploy.md
+++ b/docs/src/guides/typo3/deploy/deploy.md
@@ -11,47 +11,6 @@ description: |
 
 {{< guides/deployment >}}
 
-## Post-install (new site)
-
-The following section will only be relevant when deploying the TYPO3 template or creating a new site from scratch locally using Composer. If migrating an existing site, you can move on to the next step. 
-
-```yaml
-    # The deploy hook runs after your application has been deployed and started.
-    # Code cannot be modified at this point but the database is available.
-    # The site is not accepting requests while this script runs so keep it
-    # fast.
-    deploy: |
-        # Exit hook immediately if a command exits with a non-zero status.
-        set -e
-
-        # Set TYPO3 site defaults on first deploy.
-        if [ ! -f var/platformsh.installed ]; then
-            # Copy the created LocalConfiguration into the writable location.
-            cp public/typo3conf/LocalConfiguration.FromSource.php var/LocalConfiguration.php
-
-            # On first install, create an inital admin user with a default password.
-            # *CHANGE THIS VALUE IMMEDIATELY AFTER INSTALLATION*
-            php vendor/bin/typo3cms install:setup \
-                --install-steps-config=src/SetupDatabase.yaml \
-                --site-setup-type=no \
-                --site-name="TYPO3 on Platform.sh" \
-                --admin-user-name=admin \
-                --admin-password=password \
-                --skip-extension-setup \
-                --no-interaction
-
-            # Sets up all extensions that are marked as active in the system.
-            php vendor/bin/typo3cms extension:setupactive || true
-
-            # Create file that indicates first deploy and installation has been completed.
-            touch var/platformsh.installed
-        fi;
-```
-
-The template is designed to run the TYPO3 installer only on the first deploy by creating a placeholder `platformsh.installed` on the `var` mount. You should not remove this file unless you want the next deployment to run through the installer again.
-
-Next, when the deploy hook ran through the installer, it set an intial username and password for the TYPO3 site, which you will want to update immediately. Visit `/typo3` on the generated url for the environment and login with those temporary `admin` credentials. Then click on the user icon in the top right of the page and go to User Settings > Password to update.
-
 ## Data migration
 
 If you are moving an existing site to Platform.sh, then in addition to code you will also need to migrate your data.


### PR DESCRIPTION
Special focus on making the guide applicable to users moving an existing site to Platform.sh. The difference between this approach and that used in the deploy template is quite considerable.

(This PR is input to @chadwcarlson and shouldn't be merged outright.)