### PR TITLE
Document LFU mode for Redis eviction

### DIFF
--- a/docs/src/configuration/services/redis.md
+++ b/docs/src/configuration/services/redis.md
@@ -146,6 +146,8 @@ The default value if not specified is `allkeys-lru`, which will simply remove th
 * noeviction
 * allkeys-lru
 * volatile-lru
+* allkeys-lfu _(Avaialble as of [Redis 4.0](https://redis.io/topics/lru-cache#the-new-lfu-mode))_
+* volatile-lfu _(Avaialble as of [Redis 4.0](https://redis.io/topics/lru-cache#the-new-lfu-mode))_
 * allkeys-random
 * volatile-random
 * volatile-ttl


### PR DESCRIPTION
Only tested if `volatile-lfu`  was accepted during deploy, and it was on Grid so I assume it was passed over to Redis.
However there might be limitations on platform.sh side on this I don't know.