### PR TITLE
Ensure all PHP blocks have a PHP open tag.

### DIFF
--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -189,6 +189,7 @@ Array
 That makes it straightforward to look up the domain of a particular route, regardless of what branch it's on, from within application code.  For example, the following PHP function will retrieve the domain for a specific route id, regardless of the branch it's on.
 
 ```php
+<?php
 function get_domain_for(string $id) {
   foreach ($routes as $domain => $route) {
     if ($route['id'] == $id) {

--- a/docs/src/configuration/services/redis.md
+++ b/docs/src/configuration/services/redis.md
@@ -121,6 +121,7 @@ highlight=python
 Redis 3.0 and above are configured to support up to 64 databases.  Redis does not support distinct users for different databases so the same relationship connection gives access to all databases.  To use a particular database, use the Redis [`select` command](https://redis.io/commands/select) through your API library.  For instance, in PHP you could write:
 
 ```php
+<?php
 $redis->select(0);    // switch to DB 0
 $redis->set('x', '42');    // write 42 to x
 $redis->move('x', 1);    // move to DB 1

--- a/docs/src/development/local/lando.md
+++ b/docs/src/development/local/lando.md
@@ -49,6 +49,7 @@ Rsync can download user files easily and efficiently.  See the [exporting tutori
 Then you need to update your `sites/default/settings.local.php` to configure your codebase to connect to the local database that you just imported:
 
 ```php
+<?php
 /* Working in local with Lando */
 if (getenv('LANDO') === 'ON') {
   $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);

--- a/docs/src/frameworks/drupal7/composer-manager.md
+++ b/docs/src/frameworks/drupal7/composer-manager.md
@@ -31,6 +31,7 @@ To avoid this problem:
 Add the following lines to your `settings.php` file:
 
 ```php
+<?php
 $conf['composer_manager_autobuild_file'] = false;
 $conf['composer_manager_autobuild_packages'] = false;
 ```
@@ -42,6 +43,7 @@ This will force the configs otherwise seen on `admin/config/system/composer-mana
 Composer Manager works by using a Drush command to aggregate all module-provided `composer.json` files into a single file, which can then be installed via a normal Composer command.  Both the generated file and the resulting `vendor` directory must be in the application portion of the file system, that is, not in a writable file mount.  As that is not the default configuration for Composer Manager it will need to be changed.  Add the following lines to your `settings.php` file:
 
 ```php
+<?php
 $conf['composer_manager_vendor_dir'] = '../composer/vendor';
 $conf['composer_manager_file_dir'] = '../composer';
 ```

--- a/docs/src/guides/drupal9/simplesaml.md
+++ b/docs/src/guides/drupal9/simplesaml.md
@@ -131,6 +131,7 @@ Depending on your Identity Provider (IdP), you may need to generate an [SSL/TLS 
 Then add the following line to your `simplesamlphp/config/config.php` file to tell the library where to find the certificate:
 
 ```php
+<?php
 $config['certdir'] = dirname(__DIR__) . '/cert';
 ```
 

--- a/docs/src/guides/typo3/deploy/customize.md
+++ b/docs/src/guides/typo3/deploy/customize.md
@@ -26,11 +26,12 @@ $ composer require pixelant/pxa-lpeh
 Second, you will need to add a timeout which will set an HTTP timeout of at least 3 seconds instead of the default several minutes to a new `public/typo3conf/PlatformshConfiguration.php`. You can see this line in context of the full file in the [configuration](#environment) section below.
 
 ```php
+<?php
 $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout'] = 3;
 ```
 
 {{< note >}}
-The suggested timeout of three seconds above may end up being too short if your TYPO3 instance performs external requests other than to itself as described here. If the instance makes long requests, such as when synchronizing data as a part of a TYPO3 Scheduler task with an external API, it is best instead to place these operations in workers. 
+The suggested timeout of three seconds above may end up being too short if your TYPO3 instance performs external requests other than to itself as described here. If the instance makes long requests, such as when synchronizing data as a part of a TYPO3 Scheduler task with an external API, it is best instead to place these operations in workers.
 {{< /note >}}
 
 You will still need to enable the `pixelant/pxa-lpeh` extension, which you can do by running the command:
@@ -49,7 +50,7 @@ $ composer config extra.typo3/cms.web-dir public && composer update --no-scripts
 
 ## Site
 
-You will have to locate the site configuration file(s), `config.yaml`, in your repository's `config/sites/<SITEID>` subdirectories. For the purposes of this guide, you will need to set the `base` attribute to an environment variable called `PLATFORM_ROUTES_MAIN`. You can also add the definition to your existing `baseVariant` attribute for production if desired. 
+You will have to locate the site configuration file(s), `config.yaml`, in your repository's `config/sites/<SITEID>` subdirectories. For the purposes of this guide, you will need to set the `base` attribute to an environment variable called `PLATFORM_ROUTES_MAIN`. You can also add the definition to your existing `baseVariant` attribute for production if desired.
 
 {{< github repo="platformsh-templates/typo3" file="config/sites/main/config.yaml" lang="yaml" >}}
 
@@ -57,7 +58,7 @@ You will define this environment variable in the next section, but it's purpose 
 
 {{< note >}}
 
-The above `base` configuration only includes the production case - that is, running on Platform.sh - or at least exporting a `PLATFORM_ROUTES_MAIN` environment variable to match during local development. Alternatively, you can place the above definition within a `baseVariant` definition for the production environment alongside another development environment `condition` for local. 
+The above `base` configuration only includes the production case - that is, running on Platform.sh - or at least exporting a `PLATFORM_ROUTES_MAIN` environment variable to match during local development. Alternatively, you can place the above definition within a `baseVariant` definition for the production environment alongside another development environment `condition` for local.
 
 ```yaml
 baseVariants:

--- a/docs/src/languages/php/_index.md
+++ b/docs/src/languages/php/_index.md
@@ -110,6 +110,7 @@ variables:
 The `opcache.preload` value is evaluated as a file path relative to the application root (where `.platform.app.yaml` is), and it may be any PHP script that calls `opcache_compile_file()`.  The following example will preload all `.php` files anywhere in the `vendor` directory:
 
 ```php
+<?php
 $directory = new RecursiveDirectoryIterator(getenv('PLATFORM_APP_DIR') . '/vendor');
 $iterator = new RecursiveIteratorIterator($directory);
 $regex = new RegexIterator($iterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH);


### PR DESCRIPTION
Hugo's code formatting plugin doesn't format PHP code properly unless it's there, which sucks, but meh.  Some were lacking the open tag from the GitBook days.

Some whitespace fixes snuck in as well thanks to my IDE.