### PR TITLE
TYPO3 guide fixes.

### DIFF
--- a/docs/layouts/shortcodes/guides/config-app.html
+++ b/docs/layouts/shortcodes/guides/config-app.html
@@ -1,7 +1,7 @@
 
-<p>The <code>.platform.app.yaml</code> file is the heart of your application. It has an <a href="{{ relref . "/configuration/app/_index.md" }}">extensive set of options</a> that allow you to configure nearly any aspect of your application. Most of it is explained with comments inline.</p>
+<p>The <code>.platform.app.yaml</code> file is the heart of your application. It has an <a href="{{ relref . "/configuration/app/_index.md" }}">extensive set of options</a> that allow you to configure nearly any aspect of your application. Most of it is explained with comments inline. You can and likely will evolve this file over time as you build out your site.</p>
 
-<p>You can and likely will evolve this file over time as you build out your site.</p>
+<p>{{ .Inner | markdownify }}</p>
 
 {{ $file := printf "static/files/fetch/appyaml/%s" (.Get "template" ) }}
 {{ highlight ( readFile $file ) "yaml" ""}}

--- a/docs/layouts/shortcodes/guides/config-desc.html
+++ b/docs/layouts/shortcodes/guides/config-desc.html
@@ -14,7 +14,7 @@
 
 <div class="highlight">
 <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="c1"># Create empty Platform.sh configuration files</span>
-$ touch .platform.app.yaml && mkdir .platform && touch .platform/routes.yaml && touch .platform/services.yaml</code></pre>
+$ touch .platform.app.yaml && mkdir -p .platform && touch .platform/routes.yaml && touch .platform/services.yaml</code></pre>
 </div>
 
 <p>Now that you've added these files to your project, you can go through and configure each of them for {{ .Get "name" }} one by one in the sections below. Each section covers a particular configuration file, defines what each attribute configures, and then shows a final code snippet that includes the recommended configuration for {{ .Get "name" }} pulled from its template. Within that snippet, be sure to read each of the comments as they provide additional information and reasoning for why {{ .Get "name" }} requires those values.</p>

--- a/docs/src/guides/drupal9/deploy/configure.md
+++ b/docs/src/guides/drupal9/deploy/configure.md
@@ -29,6 +29,6 @@ If a service stores persistent data then it will also have a `disk` key, which s
 
 ## Application container: `.platform.app.yaml`
 
-{{< guides/config-app template="drupal9" >}}
+{{< guides/config-app template="drupal9" >}}{{< /guides/config-app >}}
 
 {{< guide-buttons next="Customize Drupal9" >}}

--- a/docs/src/guides/typo3/deploy/configure.md
+++ b/docs/src/guides/typo3/deploy/configure.md
@@ -30,7 +30,9 @@ If a service stores persistent data then it will also have a `disk` key, which s
 ## Application container: `.platform.app.yaml`
 
 {{< guides/config-app template="typo3" >}}
+
 Note that the command `php vendor/bin/typo3cms install:generatepackagestate` is run during the build hook. The command will make sure all installed extensions are enabled and that they can be ommitted if you commit your own [`PackageStates.php`](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ExtensionManagement/Index.html#package-manager) file.
+
 {{< /guides/config-app >}}
 
 {{< guide-buttons next="Customize TYPO3" >}}

--- a/docs/src/guides/typo3/deploy/configure.md
+++ b/docs/src/guides/typo3/deploy/configure.md
@@ -30,5 +30,7 @@ If a service stores persistent data then it will also have a `disk` key, which s
 ## Application container: `.platform.app.yaml`
 
 {{< guides/config-app template="typo3" >}}
+Note that the command `php vendor/bin/typo3cms install:generatepackagestate` is run during the build hook. The command will make sure all installed extensions are enabled and that they can be ommitted if you commit your own [`PackageStates.php`](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ExtensionManagement/Index.html#package-manager) file.
+{{< /guides/config-app >}}
 
 {{< guide-buttons next="Customize TYPO3" >}}

--- a/docs/src/guides/typo3/deploy/customize.md
+++ b/docs/src/guides/typo3/deploy/customize.md
@@ -67,7 +67,7 @@ baseVariants:
     condition: 'applicationContext == "Development/local"'
   -
     base: '%env(PLATFORM_ROUTES_MAIN)%'
-    condition: 'applicationContext == "Production/local"'
+    condition: 'applicationContext == "Production"'
 ```
 
 {{< /note >}}

--- a/docs/src/guides/wordpress/deploy/configure.md
+++ b/docs/src/guides/wordpress/deploy/configure.md
@@ -31,6 +31,8 @@ If a service stores persistent data then it will also have a `disk` key, which s
 
 Notice that the build `flavor` is set to `composer`, which will automatically download WordPress core, as well as your plugins, themes, and dependencies during the build step as defined in your `composer.json` file. Since WordPress's caching and uploads require write access at runtime, they've been given corresponding [mounts](/configuration/app/storage.md#basic-mounts) defined for them at the bottom of the file. MariaDB will be accessible to WordPress internally at `database.internal` thanks to the relationship definition `database`. The [WordPress CLI](https://packagist.org/packages/wp-cli/wp-cli) is added as a build dependency, but we will still need to add some additional dependencies in the next step so that it can be used by the application and via SSH. 
 
+{{< /guides/config-app >}}
+
 {{< note >}}
 During the template's build hook above, you will see an `rsync` command that allows you to commit and use plugins that are not accessible via Composer. The command moves all non-Composer plugins in a committed `plugins` directory to the final `wp-content/plugins` destination so that they can be enabled through the adminstration panel. 
 


### PR DESCRIPTION
I let this fall behind a bit, so this resubmits the same changes as https://github.com/platformsh/platformsh-docs/pull/1597, but with a cleaner PR.

Ultimately a good thing, since I would have needed to update the WP guide to include the `guides/config-app` end tag anyway post merge. 

Resolves https://github.com/platformsh/platformsh-docs/pull/1597
Resolves https://github.com/platformsh/platformsh-docs/pull/1579