### PR TITLE
CM-1530: Update guidance to replace IPSEC with TLS

### DIFF
--- a/docs/src/security/compliance-guidance.md
+++ b/docs/src/security/compliance-guidance.md
@@ -8,21 +8,21 @@ description: |
 
 {{< description >}}
 
-Basic compliance questions can be handled by our support team via a ticket. For more advanced questions or walk-through of a full audit please contact your Platform.sh Account Manager.
+Basic compliance questions can be handled by our support team via a ticket. For more advanced questions, including help with an audit, please contact your Platform.sh Account Manager.
 
 ## Overview
 
 Platform.sh provides a Platform as a Service (PaaS) solution which our customers may use for applications requiring PCI compliance.
 
 {{< note >}}
-Cardholder processing activity is discouraged. Please use a third party processor.
+Cardholder processing activity is discouraged. Please use a third-party processor.
 {{< /note >}}
 
 ## Security & Compensating Controls
 
 * For a list of security measures, please see our [Security page](https://platform.sh/security).
 
-* Please take note that customer environments are deployed in a read-only instance, segregated with GRE and IPSEC tunnels, which often permits compensating controls to be claimed for several PCI requirements.
+* Customer environments are deployed in a read-only instance, segregated with GRE tunnels and encrypted using TLS, which often permits compensating controls to be claimed for several PCI requirements.
 
 * Because customers can use our PaaS in a variety of ways, the best approach with auditors is to focus on “What do I, the customer, control/configure and how is it managed in a compliant manner?”
 
@@ -30,7 +30,7 @@ Cardholder processing activity is discouraged. Please use a third party processo
 
 ## Responsibility
 
-Platform.sh and customers have shared responsibility for ensuring an up to date and secure system.  Compliance is ultimately the responsibility of the customer, however.
+Platform.sh and customers often have shared responsibility for ensuring an up to date and secure environment.  Compliance is ultimately the responsibility of the customer.
 
 Platform.sh is responsible for:
 
@@ -46,12 +46,10 @@ Customers are responsible for:
 
 * **Patch Management** - Customers are responsible for maintaining and patching application code uploaded to Platform.sh, either written by them or by a third party.
 * **Configuration Management** - Customers are responsible for the secure configuration of their application, including Platform.sh configuration and routes managed through YAML files.
-* **Awareness and Training** - Customers are responsible for training their own employees and users in secure software practices.
+* **Awareness and Training** - Customers are responsible for training their own employees and users on secure software practices.
 * **Capacity Management** - Customers are responsible for ensuring their application containers have sufficient resources for their selected tasks.
 * **Access Control** - Customers are responsible for effectively leveraging available access control mechanisms, including proper access control settings, secrets management, ssh keys management, and the use of two-factor authentication.
 * **Backups** - On Platform.sh Professional customers are responsible for all application and database backups.
 
 
-The [Platform.sh PCI Responsibility Matrix](https://docs.google.com/spreadsheets/d/1zLkHpdUoX1VNC3wTipl3g-Z4eHjou-57IrQxE8GH6oA/edit#gid=238986323) (Excel) provides guidance on shared responsibilities to achieve PCI DSS compliance using PCI DSS 3.2 as a reference. This document was prepared by Platform.sh for informational purposes only. It is provided as a courtesy to facilitate customers’ consideration and review of the Platform.sh PCI Responsibility Summary, but the spreadsheet does not replace and is separate from the Platform.sh PCI AOC (available upon request). Customers may use the spreadsheet in conjunction with the Platform.sh PCI AOC solely to facilitate understanding elements of the report. The spreadsheet does not create any warranties, representations, contractual commitments, conditions, or assurances from Platform.sh, its affiliates, vendors, or licensors.
- 
-By opening the linked document you accept and agree to these Terms of Use. If you do not wish to adhere to these Terms of Use, do not open, download, save, or otherwise access the linked document.
+The [Platform.sh PCI Responsibility Matrix](https://docs.google.com/spreadsheets/d/1zLkHpdUoX1VNC3wTipl3g-Z4eHjou-57IrQxE8GH6oA/edit#gid=238986323) (Excel) provides guidance on shared responsibilities to achieve PCI DSS compliance using PCI DSS 3.2 as a reference. This document was prepared by Platform.sh for informational purposes only. The spreadsheet does not create any warranties, representations, contractual commitments, conditions, or assurances from Platform.sh, its affiliates, vendors, or licensors. By opening the linked document you accept and agree to these Terms of Use. If you do not wish to adhere to these Terms of Use, do not open, download, save, or otherwise access the linked document.


### PR DESCRIPTION
CM-1530: Update guidance to replace IPSEC with TLS and clean up some language.