### PR TITLE
Explain why ES plugins removal does not deinstall them

### DIFF
--- a/docs/src/configuration/services/elasticsearch.md
+++ b/docs/src/configuration/services/elasticsearch.md
@@ -156,7 +156,7 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 
 ### Plugins removal
 
-Removing plugins previously added in your `services.yaml` file will not automatically deinstall them from your Elasticsearch instances, this may sound counter intuitive, but it's on purpose and the rationale with it is that deinstalling a plugin usually require carefull toughts about potential data-loss/corruption and almost certainly the need for re-indexing.
+Removing plugins previously added in your `services.yaml` file will not automatically deinstall them from your Elasticsearch instances.  This is deliberate, as removing a plugin may result in data loss or corruption of existing data that relied on that plugin.  Removing a plugin will usually require reindexing.
 
 If you wish to permanently remove a previously-enabled plugin, you will need to follow the "Upgrading" procedure below to create a new instance of Elasticsearch and migrate to it.  In most cases that is not necessary, however, as an unused plugin has no appreciable impact on the server.
 

--- a/docs/src/configuration/services/elasticsearch.md
+++ b/docs/src/configuration/services/elasticsearch.md
@@ -156,7 +156,7 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 
 ### Plugins removal
 
-Removing plugins previously added in your `services.yaml` file will not automatically deinstall them from your Elasticsearch instances.  This is deliberate, as removing a plugin may result in data loss or corruption of existing data that relied on that plugin.  Removing a plugin will usually require reindexing.
+Removing plugins previously added in your `services.yaml` file will not automatically uninstall them from your Elasticsearch instances.  This is deliberate, as removing a plugin may result in data loss or corruption of existing data that relied on that plugin.  Removing a plugin will usually require reindexing.
 
 If you wish to permanently remove a previously-enabled plugin, you will need to follow the "Upgrading" procedure below to create a new instance of Elasticsearch and migrate to it.  In most cases that is not necessary, however, as an unused plugin has no appreciable impact on the server.
 

--- a/docs/src/configuration/services/elasticsearch.md
+++ b/docs/src/configuration/services/elasticsearch.md
@@ -158,6 +158,10 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 
 Removing plugins previously added in your `services.yaml` file will not automatically deinstall them from your Elasticsearch instances, this may sound counter intuitive, but it's on purpose and the rationale with it is that deinstalling a plugin usually require carefull toughts about potential data-loss/corruption and almost certainly the need for re-indexing.
 
+If you have to remove a previously installed plugin for good, the recommended way is:
+1. Rename the service
+2. Reindex your data
+
 ## Upgrading
 
 The Elasticsearch data format sometimes changes between versions in incompatible ways.  Elasticsearch does not include a data upgrade mechanism as it is expected that all indexes can be regenerated from stable data if needed.  To upgrade (or downgrade) Elasticsearch you will need to use a new service from scratch.

--- a/docs/src/configuration/services/elasticsearch.md
+++ b/docs/src/configuration/services/elasticsearch.md
@@ -158,9 +158,7 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 
 Removing plugins previously added in your `services.yaml` file will not automatically deinstall them from your Elasticsearch instances, this may sound counter intuitive, but it's on purpose and the rationale with it is that deinstalling a plugin usually require carefull toughts about potential data-loss/corruption and almost certainly the need for re-indexing.
 
-If you have to remove a previously installed plugin for good, the recommended way is:
-1. Rename the service
-2. Reindex your data
+If you wish to permanently remove a previously-enabled plugin, you will need to follow the "Upgrading" procedure below to create a new instance of Elasticsearch and migrate to it.  In most cases that is not necessary, however, as an unused plugin has no appreciable impact on the server.
 
 ## Upgrading
 

--- a/docs/src/configuration/services/elasticsearch.md
+++ b/docs/src/configuration/services/elasticsearch.md
@@ -154,6 +154,10 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 | mapper-size           | Size mapper plugin, enables the `_size` meta field                                        | *   | *   | *   | *   | *   |
 | repository-s3         | Support for using S3 as a repository for Snapshot/Restore                                 |     | *   | *   | *   | *   |
 
+### Plugins removal
+
+Removing plugins previously added in your `services.yaml` file will not automatically deinstall them from your Elasticsearch instances, this may sound counter intuitive, but it's on purpose and the rationale with it is that deinstalling a plugin usually require carefull toughts about potential data-loss/corruption and almost certainly the need for re-indexing.
+
 ## Upgrading
 
 The Elasticsearch data format sometimes changes between versions in incompatible ways.  Elasticsearch does not include a data upgrade mechanism as it is expected that all indexes can be regenerated from stable data if needed.  To upgrade (or downgrade) Elasticsearch you will need to use a new service from scratch.


### PR DESCRIPTION
This is a suggestion to explain the actual behaviour and remove confusion that may arise from the user perspective while removing previously added ES plugins.