### PR TITLE
Ensure failed curl requests do not download code

### DIFF
--- a/docs/src/development/cli/_index.md
+++ b/docs/src/development/cli/_index.md
@@ -18,7 +18,7 @@ Find detailed information on [setting up a local development environment](/getti
 You can install the CLI easily using this command:
 
 ```bash
-curl -sS https://platform.sh/cli/installer | php
+curl -fsS https://platform.sh/cli/installer | php
 ```
 
 You can find the system requirements and more information in the [installation instructions on GitHub](https://github.com/platformsh/platformsh-cli/blob/master/README.md#installation).
@@ -136,5 +136,5 @@ Upon starting Bash, you will be asked to choose a username. According to the art
 Once Bash for Windows is installed, you can install the Platform.sh CLI with the same command as above:
 
 ```bash
-curl -sS https://platform.sh/cli/installer | php
+curl -fsS https://platform.sh/cli/installer | php
 ```

--- a/docs/src/development/cli/api-tokens.md
+++ b/docs/src/development/cli/api-tokens.md
@@ -58,7 +58,7 @@ Second, add a build hook to your `.platform.app.yaml` file to download the CLI a
 ```yaml
 hooks:
     build: |
-        curl -sS https://platform.sh/cli/installer | php
+        curl -fsS https://platform.sh/cli/installer | php
 ```
 
 This will download the CLI to a known directory, `.platformsh/bin`, which will be added to the PATH at runtime (via the .environment file). Because the API token is available, the CLI will now be able to run authenticated commands, acting as the user who created the token.

--- a/docs/src/frameworks/ibexa/_index.md
+++ b/docs/src/frameworks/ibexa/_index.md
@@ -43,7 +43,7 @@ It serves as a wrapper that allows you to run console commands from within the c
 eZ Launchpad's approach is to stay as decoupled as possible from your development machine and your remote hosting whether you are Linux or Mac OSX. To install run:
 
 ```bash
-curl -LSs https://ezsystems.github.io/launchpad/install_curl.bash | bash
+curl -fLSs https://ezsystems.github.io/launchpad/install_curl.bash | bash
 ```
 
 Then you can start to use it to initialize your Ibexa DXP project on top Docker.

--- a/docs/src/gettingstarted/introduction/own-code/cli-install.md
+++ b/docs/src/gettingstarted/introduction/own-code/cli-install.md
@@ -17,13 +17,13 @@ In the previous steps you checked that the requirements on your computer were me
     * **Installing on OSX or Linux**
 
        ```bash
-       curl -sS https://platform.sh/cli/installer | php
+       curl -fsS https://platform.sh/cli/installer | php
        ```
 
     * **Installing on Windows**
 
        ```bash
-       curl https://platform.sh/cli/installer -o cli-installer.php
+       curl -f https://platform.sh/cli/installer -o cli-installer.php
        php cli-installer.php
        ```
 

--- a/docs/src/gettingstarted/introduction/template/cli-install.md
+++ b/docs/src/gettingstarted/introduction/template/cli-install.md
@@ -19,13 +19,13 @@ With all of the requirements met, install the CLI to start developing with Platf
     * **Installing on OSX or Linux**
 
        ```bash
-       curl -sS https://platform.sh/cli/installer | php
+       curl -fsS https://platform.sh/cli/installer | php
        ```
 
     * **Installing on Windows**
 
        ```bash
-       curl https://platform.sh/cli/installer -o cli-installer.php
+       curl -f https://platform.sh/cli/installer -o cli-installer.php
        php cli-installer.php
        ```
 

--- a/docs/src/languages/nodejs/nvm.md
+++ b/docs/src/languages/nodejs/nvm.md
@@ -24,7 +24,7 @@ hooks:
         unset NPM_CONFIG_PREFIX
         export NVM_DIR="$PLATFORM_APP_DIR/.nvm"
         # install.sh will automatically install NodeJS based on the presence of $NODE_VERSION
-        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
+        curl -f -o- https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh | bash
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
  ```
 

--- a/docs/src/languages/php/tuning.md
+++ b/docs/src/languages/php/tuning.md
@@ -58,7 +58,7 @@ Change to the `/tmp` directory (or any other non-web-accessible writable directo
 
 ```bash
 cd /tmp
-curl -sO http://gordalina.github.io/cachetool/downloads/cachetool.phar
+curl -fsO http://gordalina.github.io/cachetool/downloads/cachetool.phar
 php cachetool.phar opcache:status --fcgi=$SOCKET
 ```
 


### PR DESCRIPTION
Adds the --fail (-f) curl option to commands that download code, meaning that
only an error message will be shown and no data will be output. This protects
against the case where incorrect code may be output and executed even if the
HTTP request fails. Nevertheless, the server and TLS connection must still be
trusted.

Closes #1581