### PR TITLE
Remove unnecessary scary sentence.

### DIFF
--- a/docs/src/languages/php/_index.md
+++ b/docs/src/languages/php/_index.md
@@ -19,7 +19,7 @@ To specify a PHP container, use the `type` property in your `.platform.app.yaml`
 
 ## Deprecated versions
 
-The following versions are available but are not receiving security updates from upstream, so their use is not recommended. They will be removed at some point in the future.
+The following versions are available but are not receiving security updates from upstream, so their use is not recommended.
 
 | **Grid** | **Dedicated** |
 |----------------------------------|---------------|


### PR DESCRIPTION
We don't know yet what we're going to do with them. Let's avoid scaring potential customers away for the time being.