### PR TITLE
use correct parameter names

### DIFF
--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -38,7 +38,7 @@ platform variable:create --level project --name foo --value bar
 
 Project variables are a good place to store secret information that is needed at build time, such as credentials for a private 3rd party code repository.
 
-By default, project variables will be available at both build time and runtime. You can suppress one or the other with the `--no-visible-build` and `--no-visible-runtime` flags, such as if you want to hide certain credentials from runtime entirely.  For example, the following (silly) example will define a project variable but hide it from both build and runtime:
+By default, project variables will be available at both build time and runtime. You can suppress one or the other with the `--visible-build` and `--visible-runtime` flags, such as if you want to hide certain credentials from runtime entirely.  For example, the following (silly) example will define a project variable but hide it from both build and runtime:
 
 ```bash
 platform variable:create --level project --name foo --value bar --visible-build false --visible-runtime false


### PR DESCRIPTION
--no-visible-build and --no-visible-runtime don't exist

  ```
platform variable:create --level project --name ci_test_hash --value hash123 --no-visible-runtime

                                                     
  [RuntimeException]                                 
  The "--no-visible-runtime" option does not exist.  
                                                     

Usage: platform variable:create [-l|--level LEVEL] [--name NAME] [--value VALUE] [--json JSON] [--sensitive SENSITIVE] [--prefix PREFIX] [--enabled ENABLED] [--inheritable INHERITABLE] [--visible-build VISIBLE-BUILD] [--visible-runtime VISIBLE-RUNTIME] [-p|--project PROJECT] [--host HOST] [-e|--environment ENVIRONMENT] [-W|--no-wait] [--wait] [--] [<name>]

For more information, type: platform help variable:create
```