### PR TITLE
Update redirects.md

### DIFF
--- a/docs/src/configuration/routes/redirects.md
+++ b/docs/src/configuration/routes/redirects.md
@@ -51,6 +51,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
+       # [...]
      redirects:
        paths:
          '^/foo/(.*)/bar':
@@ -67,6 +68,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
+       # [...]
      redirects:
        paths:
          '/from':
@@ -82,6 +84,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
+       # [...]
      redirects:
        paths:
          '/from':
@@ -95,6 +98,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
+       # [...]
      redirects:
        paths:
          '/from':
@@ -110,6 +114,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
+       # [...]
      redirects:
        expires: 1d
        paths:

--- a/docs/src/configuration/routes/redirects.md
+++ b/docs/src/configuration/routes/redirects.md
@@ -25,7 +25,7 @@ In the [`.platform/routes.yaml`](/configuration/routes/_index.md) file you can a
 
 ```yaml
 https://{default}/:
-  # [...]
+  # ...
   redirects:
     expires: 1d
     paths:
@@ -51,7 +51,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
-       # [...]
+     # ...
      redirects:
        paths:
          '^/foo/(.*)/bar':
@@ -68,7 +68,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
-       # [...]
+     # ...
      redirects:
        paths:
          '/from':
@@ -84,7 +84,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
-       # [...]
+     # ...
      redirects:
        paths:
          '/from':
@@ -98,7 +98,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
-       # [...]
+     # ...
      redirects:
        paths:
          '/from':
@@ -114,7 +114,7 @@ Each rule under `paths` is defined by its key describing the expression to match
    ```yaml
    https://{default}/:
      type: upstream
-       # [...]
+     # ...
      redirects:
        expires: 1d
        paths:


### PR DESCRIPTION
Since the upstream is missing the key (here `app` for e.g):
```
"https://www.{default}/":
  type: upstream
  upstream: "app:http"
  redirects:
```
the snippets will not work out of the box.

That should be clearer, hence adding the comment to help clarify that.