### PR TITLE
Broaden Github token scope to create hooks

### DIFF
--- a/docs/src/integrations/source/github.md
+++ b/docs/src/integrations/source/github.md
@@ -30,6 +30,7 @@ Give it a description and then ensure the token has the following scopes:
 * To integrate with your own private repositories: `repo`
 * To integrate with your organization's private repositories: `repo`
     and `read:org`
+* To automatically create web hooks: `admin:repo_hook`
 
 Copy the token and make a note of it (temporarily).
 


### PR DESCRIPTION
We need a broader scope for the Github token used by our integration, so that we can automatically create web hooks.