### PR TITLE
Update default branch page, now that the CLI allows deleting master

### DIFF
--- a/docs/src/guides/general/default-branch.md
+++ b/docs/src/guides/general/default-branch.md
@@ -28,7 +28,7 @@ $ platform environment:branch main master --title=Main -p <Project ID> --force
 The CLI assumes that you are running this command within a local copy of your repository, so the `--force` flag is included above to bypass that.
 {{< /note >}}
 
-`main` is currently the child of `master`, so use the below command to remove it's parent and make it a top-level branch:
+`main` is currently the child of `master`, so use the below command to remove its parent and make it a top-level branch:
 
 ```bash
 $ platform environment:info -p <Project ID> -e main parent -
@@ -44,10 +44,10 @@ $ platform environment:info -p <Project ID> -e <BRANCH> parent main
 
 ### 2. Reconfigure the default branch
 
-First, you will need to deactivate the `master` environment. Since it is currently the default branch, it is protected, and so the normal `platform environment:delete` CLI command will not work at this stage. This restriction will soon be removed, but for now you can get around this by placing an authenticated cURL request on the project's API with the following CLI command to deactivate it:
+First, you will need to deactivate the `master` environment with the following CLI command:
 
 ```bash
-$ platform project:curl -X POST -p <Project ID> environments/master/deactivate 
+$ platform environment:delete master --no-delete-branch -p <Project ID>
 ```
 
 Once `master` has been deactivated, you can then set the project's `default_branch` property to `main`:
@@ -97,10 +97,10 @@ The CLI assumes that you are running this command within a local copy of your re
 
 ### 2. Deactivate the Master environment
 
-You will need to deactivate the `master` environment. Since it is currently the default branch, it is protected, and so the normal `platform environment:delete` CLI command will not work at this stage. This restriction will soon be removed, but for now you can get around this by placing an authenticated cURL request on the project's API with the following CLI command to deactivate it:
+You will need to deactivate the `master` environment with the following CLI command:
 
 ```bash
-$ platform project:curl -X POST -p <Project ID> environments/master/deactivate 
+$ platform environment:delete master --no-delete-branch -p <Project ID>
 ```
 
 {{< note >}}
@@ -121,11 +121,10 @@ At this point, while the repository considers `main` to be the default branch fo
 $ platform environment:info -p <Project ID> -e main parent -
 ```
 
-You have already deactivated Master, so all that's left now is to delete the `master` branch from the remote repository with one final authenticated request. It's still considered a parent environment and protected, so temporarily update its parent to `main` and then place the request to delete it.
+You have already deactivated Master, so all that's left now is to delete the `master` branch from the remote repository with one final authenticated request.
 
 ```bash
-$ platform environment:info -p <Project ID> -e master parent main
-$ platform environment:delete master -p <Project ID> --delete-branch
+$ platform environment:delete master --delete-branch -p <Project ID>
 ```
 
 You will then be left with "Main" as your top-level parent environment for the project.


### PR DESCRIPTION
The CLI now allows you to delete the main branch (since v3.65.0 https://github.com/platformsh/platformsh-cli/commit/0a8ccbb97b63e53c39ca9f661cd477dd98c548da)