### PR TITLE
fix sass nodejs dependency version

### DIFF
--- a/docs/src/configuration/app/build.md
+++ b/docs/src/configuration/app/build.md
@@ -151,7 +151,7 @@ The following blocks will download a specific version of Sass, then during the b
 ```yaml
 dependencies:
   nodejs:
-    sass: "^3.4.21"
+    sass: "^1"
 
 hooks:
   build: |


### PR DESCRIPTION
The version here is the one for the ruby gem, I guess.
The latest version of the [sass npm package](https://www.npmjs.com/package/sass) is 1.32.6, so just "^1" is fine.