### PR TITLE
search: don't delete the database files.

### DIFF
--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -4,6 +4,8 @@ type: 'python:3.8'
 
 variables:
     env:
+        # Do not update meilisearch version without having a plan to
+        # delete the .mdb files in data.ms/ on the mounts as well.
         MEILISEARCH_VERSION: 'v0.15.0'
         POETRY_VERSION: '1.1.4'
         POETRY_VIRTUALENVS_IN_PROJECT: true

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -2,8 +2,6 @@
 
 cleanup(){
     echo "* CLEANING UP MOUNTS"
-    # Delete the existing data in mount. Updates to upstream can cause incompatibility failure.
-    rm -rf data.ms/*
     # Clean up output mounts.
     OUTPUT_DIR=output
     rm -f $OUTPUT_DIR/*.json


### PR DESCRIPTION
Meilisearch is using those as its persistent on-disk database. If we
delete them, well, they're gone as soon as Meilisearch restarts for
any reason, and we need to run post_deploy.sh again to scrape
everything and update the index.