### PR TITLE
adding-physical-storage-location-info

### DIFF
--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -126,3 +126,13 @@ It is very important to include the `--no-wait` flag.  If you do not, the cron p
 ### Retention
 
 Please see our [Data Retention Page](/security/data-retention.md).
+
+
+### Physical storage location
+
+Backups are stored on blob storage separate from your cluster (for an AWS backed region, this is S3).
+
+Blob storage is replicated over multiple datacenters so in the rare event that an entire datacenter is destroyed, backups should still be available.
+
+Do keep in mind that in such a rare event. _We_ will be using our own disaster recovery backups to move all projects to another datacenter. The disaster recovery backups are also stored on blob storage so they are also replicated over multiple datacenters.
+

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -39,7 +39,7 @@ Please see our [Data Retention Page](/security/data-retention.md).
 
 Backups are stored on Binary Large OBject (BLOB) storage separate from your cluster (for example, projects on an AWS backed region are stored on S3). Blob storage is replicated over multiple datacenters on different locations - this means that in the rare event of datacenter unavailability, backups will still be available. 
 	
-In such an event, Platform.sh will be use our own disaster recovery backups to move all projects to another datacenter. Disaster recovery backups are also stored on BLOB storage and replicated over multiple datacenters. It is still recommended that you schedule regular backups stored in multiple locations and/or locally alongside this process.
+In such an event, Platform.sh will move all projects to another datacenter. Disaster recovery backups are also stored on BLOB storage and replicated over multiple datacenters. It is still recommended that you schedule regular backups stored in multiple locations and/or locally alongside this process.
 
 ### Automated backups
 

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -27,6 +27,56 @@ $ platform backup:create
 
 Please be aware that triggering a backup will cause a momentary pause in site availability so that all requests can complete, allowing the backup to be taken against a known consistent state.  The total interruption is usually only 15 to 30 seconds and any requests during that time are held temporarily, not dropped.
 
+### Backups and downtime
+
+A backup does cause a momentary pause in service. We recommend running during non-peak hours for your site.
+
+### Retention
+
+Please see our [Data Retention Page](/security/data-retention.md).
+
+### Physical storage location
+
+Backups are stored on Binary Large OBject (BLOB) storage separate from your cluster (for example, projects on an AWS backed region are stored on S3). Blob storage is replicated over multiple datacenters on different locations - this means that in the rare event of datacenter unavailability, backups will still be available. 
+	
+In such an event, Platform.sh will be use our own disaster recovery backups to move all projects to another datacenter. Disaster recovery backups are also stored on BLOB storage and replicated over multiple datacenters. It is still recommended that you schedule regular backups stored in multiple locations and/or locally alongside this process.
+
+### Automated backups
+
+Backups are not triggered automatically on Platform.sh Professional.
+
+Backups may be triggered by calling the CLI from an automated system such as Jenkins or another CI service, or by installing the CLI tool into your application container and triggering the backup via cron.
+
+#### Automated backups using Cron
+
+{{< note >}}
+Automated backups using cron requires you to [get an API token and install the CLI in your application container](/development/cli/api-tokens.md).
+{{< /note >}}
+
+We ask that you not schedule a backup task more than once a day to minimize data usage.
+
+Once the CLI is installed in your application container and an API token configured you can add a cron task to run once a day and trigger a backup.  The CLI will read the existing environment variables in the container and default to the project and environment it is running on. In most cases such backups are only useful on the `master` production environment.
+
+A common cron specification for a daily backup on the `master` environment looks like this:
+
+```yaml
+crons:
+    backup:
+        spec: '0 5 * * *'
+        cmd: |
+            if [ "$PLATFORM_BRANCH" = master ]; then
+                platform backup:create --yes --no-wait
+            fi
+```
+
+(If you have [renamed the default branch](/guides/general/default-branch.md) from `master` to something else, modify the above example accordingly.)
+
+The above cron task will run once a day at 5 am (UTC), and, if the current environment is the master branch, it will run `platform backup:create` on the current project and environment.  The `--yes` flag will skip any user-interaction.  The `--no-wait` flag will cause the command to complete immediately rather than waiting for the backup to complete.
+
+{{< note >}}
+It is very important to include the `--no-wait` flag.  If you do not, the cron process will block and you will be unable to deploy new versions of the site until the backup creation process is complete.
+{{< /note >}}
+
 ## Restore
 
 You will see the backup in the activity feed of your environment in the Platform.sh management console. You can trigger the restore by clicking on the `restore` link. You can also restore the backup to a different environment using the CLI.
@@ -82,60 +132,3 @@ Be aware that the older US and EU regions do not support restoring backups to di
 {{< note >}}
 Restoring a snapshot does not revert any code changes committed to git. The next redeploy of the environment will use the current commit from git.
 {{< /note >}}
-
-## Backups and downtime
-
-A backup does cause a momentary pause in service. We recommend running during non-peak hours for your site.
-
-## Automated backups
-
-Backups are not triggered automatically on Platform.sh Professional.
-
-Backups may be triggered by calling the CLI from an automated system such as Jenkins or another CI service, or by installing the CLI tool into your application container and triggering the backup via cron.
-
-### Automated backups using Cron
-
-{{< note >}}
-Automated backups using cron requires you to [get an API token and install the CLI in your application container](/development/cli/api-tokens.md).
-{{< /note >}}
-
-We ask that you not schedule a backup task more than once a day to minimize data usage.
-
-Once the CLI is installed in your application container and an API token configured you can add a cron task to run once a day and trigger a backup.  The CLI will read the existing environment variables in the container and default to the project and environment it is running on. In most cases such backups are only useful on the `master` production environment.
-
-A common cron specification for a daily backup on the `master` environment looks like this:
-
-```yaml
-crons:
-    backup:
-        spec: '0 5 * * *'
-        cmd: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
-                platform backup:create --yes --no-wait
-            fi
-```
-
-(If you have [renamed the default branch](/guides/general/default-branch.md) from `master` to something else, modify the above example accordingly.)
-
-The above cron task will run once a day at 5 am (UTC), and, if the current environment is the master branch, it will run `platform backup:create` on the current project and environment.  The `--yes` flag will skip any user-interaction.  The `--no-wait` flag will cause the command to complete immediately rather than waiting for the backup to complete.
-
-{{< note >}}
-It is very important to include the `--no-wait` flag.  If you do not, the cron process will block and you will be unable to deploy new versions of the site until the backup creation process is complete.
-{{< /note >}}
-
-### Retention
-
-Please see our [Data Retention Page](/security/data-retention.md).
-
-
-### Physical storage location
-
-Backups are stored on Binary Large OBject (BLOB) storage separate from your cluster (for an AWS backed region, this is S3).
-
-Blob storage is replicated over multiple datacenters on different locations.
-In the rare event, were an entire datacenter is destroyed, unavailable, ... backups should still be available.
-
-Do keep in mind that in such a rare event. _We_ will be using our own disaster recovery backups to move all projects to another datacenter. 
-The disaster recovery backups are also stored on blob storage. This means they are also replicated over multiple datacenters.
-
-This being said, as a general word of advice it's common (and good) practise to have backups at several locations but also locally on your own machine.

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -130,9 +130,12 @@ Please see our [Data Retention Page](/security/data-retention.md).
 
 ### Physical storage location
 
-Backups are stored on blob storage separate from your cluster (for an AWS backed region, this is S3).
+Backups are stored on Binary Large OBject (BLOB) storage separate from your cluster (for an AWS backed region, this is S3).
 
-Blob storage is replicated over multiple datacenters so in the rare event that an entire datacenter is destroyed, backups should still be available.
+Blob storage is replicated over multiple datacenters on different locations.
+In the rare event, were an entire datacenter is destroyed, unavailable, ... backups should still be available.
 
-Do keep in mind that in such a rare event. _We_ will be using our own disaster recovery backups to move all projects to another datacenter. The disaster recovery backups are also stored on blob storage so they are also replicated over multiple datacenters.
+Do keep in mind that in such a rare event. _We_ will be using our own disaster recovery backups to move all projects to another datacenter. 
+The disaster recovery backups are also stored on blob storage. This means they are also replicated over multiple datacenters.
 
+This being said, as a general word of advice it's common (and good) practise to have backups at several locations but also locally on your own machine.


### PR DESCRIPTION
Clarifying that we do store backups in a replicated manner over several datacenters. We _should_ be able to cope with a full datacenter burning down, lets clarify it. 