### PR TITLE
Remove duplicated extension

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -122,7 +122,6 @@ This is the complete list of extensions that can be enabled:
 | pdo_pgsql        | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | pdo_sqlite       | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | pdo_sqlsrv       |     |     |     | *   | *   | *   | *   | *   |     |
-| http             |     |     | *   |     |     |     |     | *   |     |
 | pgsql            | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | phar             |     |     |     | *   | *   | *   | *   | *   | *   |
 | pinba            | *   | *   | *   |     |     |     |     |     |     |


### PR DESCRIPTION
The  `php` extension is listed twice in the file, not sure if one of the names is wrong or if we should merge the versions. I let you investigate further.