### PR TITLE
Merge duplicate for http. Remove 5.6, add 7.3.

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -87,7 +87,7 @@ This is the complete list of extensions that can be enabled:
 | geoip            | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | gettext          |     |     |     | *   | *   | *   | *   | *   | *   |
 | gmp              | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| http             | *   | *   |     |     |     |     |     | *   | *   |
+| http             | *   | *   |     |     |     |     | *   | *   | *   |
 | iconv            |     |     |     | *   | *   | *   | *   | *   | *   |
 | igbinary         |     |     |     | *   | *   | *   | *   | *   | *   |
 | imagick          | *   | *   | *   | *   | *   | *   | *   | *   |     |
@@ -122,7 +122,6 @@ This is the complete list of extensions that can be enabled:
 | pdo_pgsql        | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | pdo_sqlite       | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | pdo_sqlsrv       |     |     |     | *   | *   | *   | *   | *   |     |
-| http             |     |     | *   |     |     |     |     | *   |     |
 | pgsql            | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | phar             |     |     |     | *   | *   | *   | *   | *   | *   |
 | pinba            | *   | *   | *   |     |     |     |     |     |     |


### PR DESCRIPTION
Resolves: https://github.com/platformsh/platformsh-docs/pull/1770

We had two rows in the table for `http` extension support. 

- merges into one row
- We do not support on 5.6
- Adds 7.3 as supported