### PR TITLE
Better handle Meilisearch upgrades.

### DIFF
--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -22,7 +22,6 @@ hooks:
 web:
     commands:
       # Run the Meilisearch server
-    #   start: "./meilisearch --http-addr localhost:${PORT} --master-key $PLATFORM_PROJECT_ENTROPY"
       start: !include 
             type: string
             path: start.sh

--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -6,7 +6,7 @@ variables:
     env:
         # Do not update meilisearch version without having a plan to
         # delete the .mdb files in data.ms/ on the mounts as well.
-        MEILISEARCH_VERSION: '0.19.0'
+        MEILISEARCH_VERSION: '0.20.0'
         POETRY_VERSION: '1.1.4'
         POETRY_VIRTUALENVS_IN_PROJECT: true
         POETRY_VIRTUALENVS_CREATE: false

--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -6,7 +6,7 @@ variables:
     env:
         # Do not update meilisearch version without having a plan to
         # delete the .mdb files in data.ms/ on the mounts as well.
-        MEILISEARCH_VERSION: 'v0.19.0'
+        MEILISEARCH_VERSION: '0.19.0'
         POETRY_VERSION: '1.1.4'
         POETRY_VIRTUALENVS_IN_PROJECT: true
         POETRY_VIRTUALENVS_CREATE: false
@@ -23,6 +23,9 @@ web:
     commands:
       # Run the Meilisearch server
       start: "./meilisearch --http-addr localhost:${PORT} --master-key $PLATFORM_PROJECT_ENTROPY"
+      start: !include 
+            type: string
+            path: start.sh
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -6,7 +6,7 @@ variables:
     env:
         # Do not update meilisearch version without having a plan to
         # delete the .mdb files in data.ms/ on the mounts as well.
-        MEILISEARCH_VERSION: 'v0.20.0'
+        MEILISEARCH_VERSION: 'v0.19.0'
         POETRY_VERSION: '1.1.4'
         POETRY_VIRTUALENVS_IN_PROJECT: true
         POETRY_VIRTUALENVS_CREATE: false

--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -4,8 +4,6 @@ type: 'python:3.9'
 
 variables:
     env:
-        # Do not update meilisearch version without having a plan to
-        # delete the .mdb files in data.ms/ on the mounts as well.
         MEILISEARCH_VERSION: '0.20.0'
         POETRY_VERSION: '1.1.4'
         POETRY_VIRTUALENVS_IN_PROJECT: true

--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -22,7 +22,7 @@ hooks:
 web:
     commands:
       # Run the Meilisearch server
-      start: "./meilisearch --http-addr localhost:${PORT} --master-key $PLATFORM_PROJECT_ENTROPY"
+    #   start: "./meilisearch --http-addr localhost:${PORT} --master-key $PLATFORM_PROJECT_ENTROPY"
       start: !include 
             type: string
             path: start.sh

--- a/search/build.sh
+++ b/search/build.sh
@@ -5,7 +5,7 @@ install_meilisearch() {
     echo "* INSTALLING MEILISEARCH"
     # Replicates Meilisearch download (https://github.com/meilisearch/MeiliSearch/blob/master/download-latest.sh) with locked version.
     release_file="meilisearch-linux-amd64"
-    curl -OL "https://github.com/meilisearch/MeiliSearch/releases/download/$MEILISEARCH_VERSION/$release_file"
+    curl -OL "https://github.com/meilisearch/MeiliSearch/releases/download/v$MEILISEARCH_VERSION/$release_file"
     mv "$release_file" "meilisearch"
     chmod 744 "meilisearch"
 }

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -53,8 +53,8 @@ deleteIndexPreMeilisearchUpgrade() {
     # Platform.sh
     else
         MEILI_URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.id == "search") | .key')
-        MEILI_URL_STRIPPED=${MEILI_URL::-1}
-        MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $PLATFORM_PROJECT_ENTROPY" -X GET "$MEILI_URL_STRIPPED/version" | jq -r ".pkgVersion" )
+        ENDPOINT=version
+        MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $PLATFORM_PROJECT_ENTROPY" -X GET "$MEILI_URL$ENDPOINT" | jq -r ".pkgVersion" )
         MEILIVERSION_DB=$(cat data.ms/VERSION)
         echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
         echo "  > Current database version: $MEILIVERSION_DB"

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -55,6 +55,7 @@ deleteIndexPreMeilisearchUpgrade() {
         MEILI_URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.id == "search") | .key')
         ENDPOINT=version
         MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $PLATFORM_PROJECT_ENTROPY" -X GET "$MEILI_URL$ENDPOINT" | jq -r ".pkgVersion" )
+        MEILIVERSION_CONFIG=
         MEILIVERSION_DB=$(cat data.ms/VERSION)
         echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
         echo "  > Current database version: $MEILIVERSION_DB"
@@ -69,7 +70,7 @@ deleteIndexPreMeilisearchUpgrade() {
 update_index(){
     echo "* UPDATING INDEX"
     # Delete data if there is a Meilisearch upgrade.
-    deleteIndexPreMeilisearchUpgrade
+    # deleteIndexPreMeilisearchUpgrade
     # Create indices for templates and docs
     poetry run python createPrimaryIndex.py
     # Update indexes

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -53,7 +53,8 @@ deleteIndexPreMeilisearchUpgrade() {
     # Platform.sh
     else
         MEILI_URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.id == "search") | .key')
-        MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $PLATFORM_PROJECT_ENTROPY" -X GET "$MEILI_URL/version" | jq -r ".pkgVersion" )
+        MEILI_URL_STRIPPED=${MEILI_URL::-1}
+        MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $PLATFORM_PROJECT_ENTROPY" -X GET "$MEILI_URL_STRIPPED/version" | jq -r ".pkgVersion" )
         MEILIVERSION_DB=$(cat data.ms/VERSION)
         echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
         echo "  > Current database version: $MEILIVERSION_DB"

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -33,44 +33,8 @@ scrape(){
     done
 }
 
-# When we upgrade Meilisearch to a new version, the old database becomes incompatible and search fails to deploy. 
-# This function is run before the index is updated. It compares the "live" version @ /version and compares to the 
-#   current database version kept in the `data.ms/VERSION` text file. If not equal, the index is deleted prior to updating
-#   the index. 
-deleteIndexPreMeilisearchUpgrade() {
-
-    # Local
-    if [ -z ${PLATFORM_PROJECT_ENTROPY+x} ]; then 
-        MEILI_URL=http://127.0.0.1:7700
-        MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $MEILI_MASTER_KEY" -X GET "$MEILI_URL/version" | jq -r ".pkgVersion" )
-        MEILIVERSION_DB=$(cat data.ms/VERSION)
-        echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
-        echo "  > Current database version: $MEILIVERSION_DB"
-        if [ "$MEILIVERSION_LIVE" != "$MEILIVERSION_DB" ]; then
-            echo "  > Meilisearch upgraded. Deleting old index."
-            rm -rf data.ms/*
-        fi
-    # Platform.sh
-    else
-        MEILI_URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.id == "search") | .key')
-        ENDPOINT=version
-        MEILIVERSION_LIVE=$(curl -s -H "X-Meili-API-Key: $PLATFORM_PROJECT_ENTROPY" -X GET "$MEILI_URL$ENDPOINT" | jq -r ".pkgVersion" )
-        MEILIVERSION_CONFIG=
-        MEILIVERSION_DB=$(cat data.ms/VERSION)
-        echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
-        echo "  > Current database version: $MEILIVERSION_DB"
-        if [ "$MEILIVERSION_LIVE" != "$MEILIVERSION_DB" ]; then
-            echo "Meilisearch was upgraded. Deleting old index."
-            rm -rf data.ms/*
-        fi
-    fi
-
-}
-
 update_index(){
     echo "* UPDATING INDEX"
-    # Delete data if there is a Meilisearch upgrade.
-    # deleteIndexPreMeilisearchUpgrade
     # Create indices for templates and docs
     poetry run python createPrimaryIndex.py
     # Update indexes

--- a/search/start.sh
+++ b/search/start.sh
@@ -6,10 +6,10 @@
 #   the index. 
 deleteIndexPreMeilisearchUpgrade() {
     MEILIVERSION_DB=$(cat data.ms/VERSION)
-    echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
+    echo "  > Downloaded version: $MEILISEARCH_VERSION"
     echo "  > Current database version: $MEILIVERSION_DB"
-    if [ "$MEILIVERSION_LIVE" != "$MEILIVERSION_DB" ]; then
-        echo "Meilisearch was upgraded. Deleting old index before start."
+    if [ "$MEILISEARCH_VERSION" != "$MEILIVERSION_DB" ]; then
+        echo "  > Meilisearch was upgraded. Deleting old index before start."
         rm -rf data.ms/*
     fi
 }

--- a/search/start.sh
+++ b/search/start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# When we upgrade Meilisearch to a new version, the old database becomes incompatible and search fails to deploy. 
+# This function is run before the index is updated. It compares the "live" version @ /version and compares to the 
+#   current database version kept in the `data.ms/VERSION` text file. If not equal, the index is deleted prior to updating
+#   the index. 
+deleteIndexPreMeilisearchUpgrade() {
+    MEILIVERSION_DB=$(cat data.ms/VERSION)
+    echo "  > Live Meilisearch version: $MEILIVERSION_LIVE"
+    echo "  > Current database version: $MEILIVERSION_DB"
+    if [ "$MEILIVERSION_LIVE" != "$MEILIVERSION_DB" ]; then
+        echo "Meilisearch was upgraded. Deleting old index before start."
+        rm -rf data.ms/*
+    fi
+}
+
+# Delete previous database files if upgrading.
+deleteIndexPreMeilisearchUpgrade
+# Start the server.
+./meilisearch --http-addr localhost:${PORT} --master-key $PLATFORM_PROJECT_ENTROPY


### PR DESCRIPTION
Background:

- Previously, all index data (saved in the mount `data.ms`) was deleted during the `cleanup` function of the `search` app's post deploy hook. The main reason for this is that if Meilisearch was upgraded (`MEILISEARCH_VERSION` var in `.platform.app.yaml`) the database would be incompatible with the new version, and deployment would fail. 
- This was removed here https://github.com/platformsh/platformsh-docs/pull/1723, because if anything went wrong and Meili needed to restar, there would be no data until another redeploy.
- Upgrading Meilisearch makes those old database files incompatible with the new version, and a failed deploy. This happened on the most recent PR #1776, and required sshing in, deleting the contents of `data.ms`, and then a redeploy. 

Update:
- start command calls new file, `start.sh` which includes previous start command
- new function `deleteIndexPreMeilisearchUpgrade` added in that file. compares downloaded version (`MEILISEARCH_VERSION` env var) to "current db" in the `data.ms` mount (`data.ms/VERSION` file.)