### PR TITLE
Newrelic does not work on php8

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -109,7 +109,7 @@ This is the complete list of extensions that can be enabled:
 | mysql            | *   | *   | *   |     |     |     |     |     |     |
 | mysqli           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | mysqlnd          | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| newrelic         |     |     | *   | *   | *   | *   | *   | *   | *   |
+| newrelic         |     |     | *   | *   | *   | *   | *   | *   |     |
 | oauth            |     |     |     | *   | *   | *   | *   | *   | *   |
 | odbc             | *   | *   | *   | *   | *   | *   | *   | *   | *   |
 | opcache          |     | *   | *   | *   | *   | *   | *   | *   | *   |


### PR DESCRIPTION
https://github.com/newrelic/newrelic-php-agent/issues/172 needs to be fixed, only then can we roll it out.