### PR TITLE
Remove ldap is enable by default.

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -29,7 +29,6 @@ The following extensions are enabled by default:
 * interbase (7.1 and later)
 * intl
 * json (5.6 and later)
-* ldap (7.1 and later)
 * mbstring (7.1 and later)
 * mcrypt (5.6 and earlier)
 * mysql


### PR DESCRIPTION
Available, but not enabled by default on PHP images.