### PR TITLE
fix: index list pages

### DIFF
--- a/docs/layouts/_default/index.json.json
+++ b/docs/layouts/_default/index.json.json
@@ -1,5 +1,5 @@
 {{- $allDocuments := slice -}}
-{{- range .Site.RegularPages -}}
+{{- range .Site.Pages -}}
   {{- $pageDocuments := partial "meilindex/page" . | transform.Unmarshal -}}
   {{- range $index, $document := $pageDocuments -}}
     {{- $allDocuments = $allDocuments | append $document -}}

--- a/docs/src/configuration/app/_index.md
+++ b/docs/src/configuration/app/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure your application"
+title: "Apps"
 weight: 4
 description: |
   You control your application and the way it will be built and deployed on Platform.sh via a single configuration file, `.platform.app.yaml`, located at the root of your application folder inside your Git repository.

--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure routes"
+title: "Routes"
 weight: 2
 description: |
   Platform.sh allows you to define the routes used in your environments.

--- a/docs/src/configuration/services/_index.md
+++ b/docs/src/configuration/services/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure services"
+title: "Services"
 weight: 3
 description: |
   Platform.sh allows you to completely define and configure the topology and services you want to use on your project.

--- a/docs/src/domains/cdn/_index.md
+++ b/docs/src/domains/cdn/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Content Delivery Networks"
+title: "Content Delivery Networks (CDNs)"
+sidebarTitle: "Content Delivery Networks"
 weight: 3
 layout: single
 ---

--- a/search/main.py
+++ b/search/main.py
@@ -23,7 +23,7 @@ class Search:
         # Data available to the dropdown React app in docs, used to fill out autocomplete results.
         self.displayed_attributes = ['title', 'text', 'url', 'site', 'section']
         # Data actually searchable by our queries.
-        self.searchable_attributes = ['title', 'text', 'section']
+        self.searchable_attributes = ['title', 'text', 'url', 'section']
 
         # Show results for one query with the listed pages, when they by default would not show up as best results. Note: these
         # are not automatically two-way, so that's why they all appear to be defined twice.


### PR DESCRIPTION
so that pages with the name `_index.md` get indexed in search

fixes #1665