### PR TITLE
Standardise yaml indentation in the configuration section.

### DIFF
--- a/docs/src/configuration/app/access.md
+++ b/docs/src/configuration/app/access.md
@@ -14,5 +14,5 @@ The following block in `.platform.app.yaml` will restrict SSH access to just tho
 
 ```yaml
 access:
-  ssh: admin
+    ssh: admin
 ```

--- a/docs/src/configuration/app/build.md
+++ b/docs/src/configuration/app/build.md
@@ -46,18 +46,18 @@ You can specify those dependencies as shown below:
 
 ```yaml
 dependencies:
-  php: # Specify one Composer package per line.
-    drush/drush: '8.0.0'
-  python: # Specify one Python 2 package per line.
-    behave: '*'
-  python2: # Specify one Python 2 package per line.
-    requests: '*'
-  python3: # Specify one Python 3 package per line.
-    numpy: '*'
-  ruby: # Specify one Bundler package per line.
-    sass: '3.4.7'
-  nodejs: # Specify one NPM package per line.
-    pm2: '^4.5.0'
+    php: # Specify one Composer package per line.
+        drush/drush: '8.0.0'
+    python: # Specify one Python 2 package per line.
+        behave: '*'
+    python2: # Specify one Python 2 package per line.
+        requests: '*'
+    python3: # Specify one Python 3 package per line.
+        numpy: '*'
+    ruby: # Specify one Bundler package per line.
+        sass: '3.4.7'
+    nodejs: # Specify one NPM package per line.
+        pm2: '^4.5.0'
 ```
 
 Note that the package name format for each language is defined by the package manager used; similarly, the version constraint string will be interpreted by the package manager.  Consult the appropriate package manager's documentation for the supported formats.
@@ -142,13 +142,13 @@ The following blocks will download a specific version of Sass, then during the b
 
 ```yaml
 dependencies:
-  nodejs:
-    sass: "^1"
+    nodejs:
+        sass: "^1"
 
 hooks:
-  build: |
-    npm install
-    npm run build-css
+    build: |
+        npm install
+        npm run build-css
 ```
 
 ## How can I run certain commands only on certain environments?

--- a/docs/src/configuration/app/firewall.md
+++ b/docs/src/configuration/app/firewall.md
@@ -21,13 +21,13 @@ The `firewall` property defines one or more allowed entries for outbound request
 
 ```yaml
 firewall:
-  outbound:
-    - protocol: tcp
-      domains: ["google.com", "facebook.com"]
-      ports: [80, 443]
-    - protocol: tcp
-      ips: ["1.2.3.4/32"]
-      ports: [22]
+    outbound:
+        - protocol: tcp
+            domains: ["google.com", "facebook.com"]
+            ports: [80, 443]
+      - protocol: tcp
+            ips: ["1.2.3.4/32"]
+            ports: [22]
 ```
 
 The above example allows two outbound rules over TCP.  All other outbound requests will be blocked and will time out eventually (usually after 30 seconds).
@@ -36,9 +36,9 @@ If no rules are specified, the default `firewall` configuration is equivalent to
 
 ```yaml
 firewall:
-  outbound:
-    - protocol: tcp
-      ips: ["0.0.0.0/0"]
+    outbound:
+        - protocol: tcp
+            ips: ["0.0.0.0/0"]
 ```
 
 That is, all outbound TCP traffic is allowed on all ports (aside from port 25, which is always blocked without exception).  In the majority of cases the default is sufficient for most applications.
@@ -83,10 +83,10 @@ That means that, for this configuration:
 
 ```yaml
 firewall:
-  outbound:
-    - ips: ["1.2.3.4/32"]
-      ports: [443]
-    - ports: [80]
+    outbound:
+        - ips: ["1.2.3.4/32"]
+            ports: [443]
+        - ports: [80]
 ```
 
 Requests to port 80 on any IP will be allowed, and requests to 1.2.3.4 on either port 80 or 443 will be allowed, even though the first rule only lists port 443.

--- a/docs/src/configuration/app/storage.md
+++ b/docs/src/configuration/app/storage.md
@@ -63,10 +63,10 @@ A `service` mount works like so:
 
 ```yaml
 mounts:
-  'web/uploads':
-    source: service
-    service: files
-    source_path: uploads
+    'web/uploads':
+        source: service
+        service: files
+        source_path: uploads
 ```
 
 This assumes that a `network-storage` service named `files` has already been defined.  See the [Network Storage](/configuration/services/network-storage.md) page for more details and examples.
@@ -120,9 +120,9 @@ Platform.sh ignores YAML keys that start with a dot. This causes a mount like `.
 
 ```yaml
 mounts:
-  '/.myhiddenfolder':
-    source: local
-    source_path: 'myhiddenfolder'
+    '/.myhiddenfolder':
+        source: local
+        source_path: 'myhiddenfolder'
 ```
 
 ## How do I setup overlapping mount paths?

--- a/docs/src/configuration/app/timezone.md
+++ b/docs/src/configuration/app/timezone.md
@@ -23,12 +23,12 @@ For example:
 timezone: "America/New_York"
     
 crons:
-  backup:
-    spec: '25 1 * * *'
-    cmd: |
-      if [ "$PLATFORM_BRANCH" = master ]; then
-          platform backup:create --yes --no-wait
-      fi
+    backup:
+        spec: '25 1 * * *'
+        cmd: |
+            if [ "$PLATFORM_BRANCH" = master ]; then
+                platform backup:create --yes --no-wait
+            fi
 ```
 
 ## Setting an application runtime timezone

--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -68,11 +68,11 @@ Here is an example of a basic `.platform/routes.yaml` file:
 
 ```yaml
 "https://{default}/":
-  type: upstream
-  upstream: "app:http"
+    type: upstream
+    upstream: "app:http"
 "https://www.{default}/":
-  type: redirect
-  to: "https://{default}/"
+    type: redirect
+    to: "https://{default}/"
 ```
 
 In this example, we will route both the apex domain and the www subdomain to an [application called "app"](/configuration/app/name.md), the www subdomain being redirected to the apex domain using an HTTP 301 `Moved Permanently` response.
@@ -257,9 +257,9 @@ You will also need to [disable request buffering](/configuration/app/web.md#loca
 
 ```yaml
 web:
-  locations:
-    '/':
-      passthru: true
-      request_buffering:
-        enabled: false
+    locations:
+        '/':
+            passthru: true
+            request_buffering:
+                enabled: false
 ```

--- a/docs/src/configuration/routes/cache.md
+++ b/docs/src/configuration/routes/cache.md
@@ -199,22 +199,22 @@ If you need fine-grained caching, you can set up caching rules for several route
 
 ```yaml
 https://{default}/:
-  type: upstream
-  upstream: app:http
-  cache:
-    enabled: true
+    type: upstream
+    upstream: app:http
+    cache:
+        enabled: true
 
 https://{default}/foo/:
-  type: upstream
-  upstream: app:http
-  cache:
-    enabled: false
+    type: upstream
+    upstream: app:http
+    cache:
+        enabled: false
 
 https://{default}/foo/bar/:
-  type: upstream
-  upstream: app:http
-  cache:
-    enabled: true
+    type: upstream
+    upstream: app:http
+    cache:
+        enabled: true
 ```
 
 With this configuration, the following routes are cached:
@@ -238,8 +238,8 @@ Some applications use cookies to invalidate cache responses, but expect other co
 
 ```yaml
 cache:
-  enabled: true
-  cookies: ["MYCOOKIE"]
+    enabled: true
+    cookies: ["MYCOOKIE"]
 ```
 
 ### Cache HTTP and HTTPS separately using the `Vary` header

--- a/docs/src/configuration/routes/redirects.md
+++ b/docs/src/configuration/routes/redirects.md
@@ -25,15 +25,15 @@ In the [`.platform/routes.yaml`](/configuration/routes/_index.md) file you can a
 
 ```yaml
 https://{default}/:
-  # ...
-  redirects:
-    expires: 1d
-    paths:
-      '/from':
-        to: 'https://example.com/'
-      '^/foo/(.*)/bar':
-        to: 'https://example.com/$1'
-        regexp: true
+    # ...
+    redirects:
+        expires: 1d
+        paths:
+            '/from':
+                to: 'https://example.com/'
+            '^/foo/(.*)/bar':
+                to: 'https://example.com/$1'
+                regexp: true
 ```
 
 This format is more rich and works with any type of route, including routes served directly by the application.
@@ -50,13 +50,13 @@ Each rule under `paths` is defined by its key describing the expression to match
 
    ```yaml
    https://{default}/:
-     type: upstream
-     # ...
-     redirects:
-       paths:
-         '^/foo/(.*)/bar':
-            to: 'https://example.com/$1'
-            regexp: true
+       type: upstream
+       # ...
+       redirects:
+           paths:
+               '^/foo/(.*)/bar':
+                    to: 'https://example.com/$1'
+                    regexp: true
    ```
    Note that special arguments in the `to` statement are also valid when `regexp` is set to `true`:
     * `$is_args` will evaluate to `?` or empty string
@@ -67,13 +67,13 @@ Each rule under `paths` is defined by its key describing the expression to match
 
    ```yaml
    https://{default}/:
-     type: upstream
-     # ...
-     redirects:
-       paths:
-         '/from':
-            to: 'https://{default}/to'
-            prefix: true
+       type: upstream
+       # ...
+       redirects:
+           paths:
+               '/from':
+                    to: 'https://{default}/to'
+                    prefix: true
    ```
    with `prefix` set to `true`, `/from` will redirect to `/to` and `/from/another/path` will redirect to `/to/another/path`.
    If `prefix` is set to `false` then `/from` will trigger a redirect, but `/from/another/path` will not.
@@ -83,13 +83,13 @@ Each rule under `paths` is defined by its key describing the expression to match
 
    ```yaml
    https://{default}/:
-     type: upstream
-     # ...
-     redirects:
-       paths:
-         '/from':
-            to: 'https://{default}/to'
-            append_suffix: false
+       type: upstream
+       # ...
+       redirects:
+           paths:
+               '/from':
+                    to: 'https://{default}/to'
+                    append_suffix: false
    ```
    would result in `/from/path/suffix` redirecting to just `/to`. If `append_suffix` was left on its default value of `true`, then `/from/path/suffix` would have redirected to `/to/path/suffix`.
 
@@ -97,15 +97,15 @@ Each rule under `paths` is defined by its key describing the expression to match
 
    ```yaml
    https://{default}/:
-     type: upstream
-     # ...
-     redirects:
-       paths:
-         '/from':
-           to: 'https://example.com/'
-           code: 308
-         '/here':
-           to: 'https://example.com/there'
+       type: upstream
+       # ...
+       redirects:
+           paths:
+               '/from':
+                   to: 'https://example.com/'
+                   code: 308
+               '/here':
+                   to: 'https://example.com/there'
    ```
    In this example, redirects from `/from` would use a `308` HTTP status code, but redirects from `/here` would default to `302`.
 
@@ -113,16 +113,16 @@ Each rule under `paths` is defined by its key describing the expression to match
 
    ```yaml
    https://{default}/:
-     type: upstream
-     # ...
-     redirects:
-       expires: 1d
-       paths:
-         '/from':
-           to: 'https://example.com/'
-         '/here':
-           to: 'https://example.com/there'
-           expires: 2w
+       type: upstream
+       # ...
+       redirects:
+           expires: 1d
+           paths:
+             '/from':
+                 to: 'https://example.com/'
+             '/here':
+                 to: 'https://example.com/there'
+                 expires: 2w
    ```
    In this example, redirects from `/from` would be set to expire in one day, but redirects from `/here` would expire in two weeks.
 

--- a/docs/src/configuration/routes/ssi.md
+++ b/docs/src/configuration/routes/ssi.md
@@ -15,14 +15,14 @@ You can activate or deactivate SSI on a per-route basis in your `.platform/route
     type: upstream
     upstream: "app:http"
     cache:
-      enabled: false
+        enabled: false
     ssi:
         enabled: true
 "https://{default}/time.php":
     type: upstream
     upstream: "app:http"
     cache:
-      enabled: true
+        enabled: true
 ```
 
 It allows you to include in your HTML response directives that will make the server "fill-in" parts of the HTML respecting the caching you setup.

--- a/docs/src/configuration/services/_index.md
+++ b/docs/src/configuration/services/_index.md
@@ -19,12 +19,12 @@ Here is an example of a `.platform/services.yaml` file:
 
 ```yaml
 database1:
-  type: mysql:10.1
-  disk: 2048
+    type: mysql:10.1
+    disk: 2048
 
 database2:
-  type: postgresql:9.6
-  disk: 1024
+    type: postgresql:9.6
+    disk: 1024
 ```
 
 ## Configuration

--- a/docs/src/configuration/services/elasticsearch.md
+++ b/docs/src/configuration/services/elasticsearch.md
@@ -107,8 +107,8 @@ This functionality is generally not required if Elasticsearch is not exposed on 
 
 ```yaml
 "https://es.{default}":
-  type: upstream
-  upstream: search:elasticsearch
+    type: upstream
+    upstream: search:elasticsearch
 ```
 
 ## Plugins

--- a/docs/src/configuration/services/memcached.md
+++ b/docs/src/configuration/services/memcached.md
@@ -49,7 +49,7 @@ For Python you will need to include a dependency for a Memcached library, either
 ```yaml
 dependencies:
     python:
-       python-memcached: '*'
+        python-memcached: '*'
 ```
 
 You can then use the service in a configuration file of your application with something like:

--- a/docs/src/configuration/services/mysql.md
+++ b/docs/src/configuration/services/mysql.md
@@ -199,12 +199,12 @@ Both values can be adjusted at the server level in `services.yaml`:
 
 ```yaml
 db:
-  type: mariadb:10.5
-  disk: 2048
-  configuration:
-    properties:
-      default_charset: utf8mb4
-      default_collation: utf8mb4_unicode_ci
+    type: mariadb:10.5
+    disk: 2048
+    configuration:
+        properties:
+            default_charset: utf8mb4
+            default_collation: utf8mb4_unicode_ci
 ```
 
 Note that the effect of this setting is to set the character set and collation of any tables created once those properties are set.  Tables created prior to when those settings are changed will be unaffected by changes to the `services.yaml` configuration.  However, you can change your own table's character set and collation through `ALTER TABLE` commands.  For example:

--- a/docs/src/configuration/services/rabbitmq.md
+++ b/docs/src/configuration/services/rabbitmq.md
@@ -109,8 +109,8 @@ For example, you can use [amqp-utils](https://github.com/dougbarth/amqp-utils/) 
 
  ```yaml
 dependencies:
-  ruby:
-    amqp-utils: "0.5.1"
+    ruby:
+        amqp-utils: "0.5.1"
 ```
 
 Then, when you SSH into your container, you can simply type any `amqp-` command available to manage your queues.
@@ -123,10 +123,10 @@ You can configure additional [virtual hosts](https://www.rabbitmq.com/vhosts.htm
 
 ```yaml
 rabbitmq:
-  type: rabbitmq:3.8
-  disk: 512
-  configuration:
-    vhosts:
-      - foo
-      - bar
+    type: rabbitmq:3.8
+    disk: 512
+    configuration:
+        vhosts:
+            - foo
+            - bar
 ```

--- a/docs/src/configuration/services/redis.md
+++ b/docs/src/configuration/services/redis.md
@@ -136,7 +136,7 @@ On the Ephemeral `redis` service it is also possible to select the key eviction 
 cache:
     type: redis:5.0
     configuration:
-      maxmemory_policy: allkeys-lru
+        maxmemory_policy: allkeys-lru
 ```
 
 The default value if not specified is `allkeys-lru`, which will simply remove the oldest cache item first.  Legal values are:
@@ -180,7 +180,7 @@ Using the same configuration but with your Redis relationship named `sessionstor
 
 ```yaml
 relationships:
-  sessionstorage: "data:redis"
+    sessionstorage: "data:redis"
 
 variables:
     php:


### PR DESCRIPTION
Per style guide discussion in Slack, All yaml snippets should be 4-spaced for consistency.