### PR TITLE
fix: remove www from routes redirects

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -62,15 +62,7 @@ https://{default}/:
       "/frameworks/wordpress.html": { "to": "/guides/wordpress/deploy.html", "code": 301, "prefix": false }
       "/frameworks/wordpress/redis.html": { "to": "/guides/wordpress/redis.html", "code": 301, "prefix": false }
 
-"https://www.{default}/":
-    type: redirect
-    to: "https://{default}/"
-
 "https://search.{default}/":
     type: upstream
     upstream: "search:http"
     id: "search"
-
-"https://www.search.{default}/":
-    type: redirect
-    to: "https://search.{default}/"


### PR DESCRIPTION
as we don't seem to be using it
and it's blocking certificate renewal
