### PR TITLE
Fix p-limit examples fetchs

### DIFF
--- a/docs/static/scripts/fetch-examples.mjs
+++ b/docs/static/scripts/fetch-examples.mjs
@@ -45,7 +45,7 @@ async function fetchFilesTemplates(data) {
         // Ensure subdirectory exists.
         ensureSubdir(data["savePath"])
         // Place the request and write the file.
-        fetches.push(fetchConcurrency(writeFileFromTarget, target, destination));
+        fetches.push(fetchConcurrency(() => writeFileFromTarget(target, destination)));
     }
 
     await Promise.all(fetches);
@@ -68,7 +68,7 @@ async function fetchFilesExamples(data) {
             var target = `${languageTargetDir}/${data["paths"][language][service]}`;
             var destination = process.cwd() + `${languageDestDir}/${data["paths"][language][service]}`;
             // Place the request and write the file.
-            fetches.push(fetchConcurrency(writeFileFromTarget, target, destination));
+            fetches.push(fetchConcurrency(() => writeFileFromTarget(target, destination)));
         }
 
         await Promise.all(fetches);


### PR DESCRIPTION
Currently running `rm -rf static/files/fetch/* && node static/scripts/fetch-examples.mjs` fail with:

```
Fetching undefined                                                                                                                                                            
Fetching undefined                                                                                                                                                            
(node:90) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received undefined                                   
    at validateString (internal/validators.js:124:11)                                                                                                                         
    at Url.parse (url.js:170:3)                                                                                                                                               
    at Object.urlParse [as parse] (url.js:157:13)                                                                                                                             
    at dispatchHttpRequest (/app/docs/node_modules/axios/lib/adapters/http.js:67:22)                                                                                          
    at new Promise (<anonymous>)                                                                                                                                              
    at httpAdapter (/app/docs/node_modules/axios/lib/adapters/http.js:20:10)                                                                                                  
    at dispatchRequest (/app/docs/node_modules/axios/lib/core/dispatchRequest.js:59:10)                                                                                       
    at async writeFileFromTarget (file:///app/docs/static/scripts/fetch-examples.mjs:34:17)                                                                                   
(Use `node --trace-warnings ...` to show where the warning was created)                                                                                                       
(node:90) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rej
ecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see http
s://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 41)                                                                                                
(node:90) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process
 with a non-zero exit code.
```

Looking at usage it does not match current implementation https://github.com/sindresorhus/p-limit#usage (maybe it has changed did not checked)

With this patch the examples are fetched