### PR TITLE
fix: workaround for broken examples

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,4 +6,6 @@ MinAlertLevel = suggestion # suggestion, warning, or error
 
 [*.md]
 BasedOnStyles = Platform,Vale
-TokenIgnores = {{< .* >}}
+TokenIgnores = {{< .* >}}, \
+file\=.*, \
+highlight\=.*

--- a/docs/src/configuration/services/memcached.md
+++ b/docs/src/configuration/services/memcached.md
@@ -10,7 +10,7 @@ sidebarTitle: "Memcached"
 
 See the [Memcached](https://memcached.org) for more information.
 
-Both Memcached and Redis can be used for application caching.  As a general rule, Memcached is simpler and thus more widely supported while Redis is more robust.  Platform.sh recommends using Redis if possible but Memcached is fully supported if an application favors that cache service."
+Both Memcached and Redis can be used for application caching. As a general rule, Memcached is simpler and thus more widely supported while Redis is more robust. Platform.sh recommends using Redis if possible but Memcached is fully supported if an application favors that cache service."
 
 ## Supported versions
 
@@ -44,7 +44,7 @@ runtime:
         - memcached
 ```
 
-For Python you will need to include a dependency for a Memcached library, either via your requirements.txt file or a global dependency.  As a global dependency you would add the following to `.platform.app.yaml`:
+For Python, you need to include a dependency for a Memcached library, either via your requirements.txt file or a global dependency. As a global dependency you would add the following to `.platform.app.yaml`:
 
 ```yaml
 dependencies:
@@ -55,6 +55,14 @@ dependencies:
 You can then use the service in a configuration file of your application with something like:
 
 {{< codetabs >}}
+
+---
+title=Go
+file=static/files/fetch/examples/golang/memcached
+highlight=go
+---
+
+<--->
 
 ---
 title=Java
@@ -90,7 +98,7 @@ highlight=python
 
 ## Accessing Memcached directly
 
-To access the Memcached service directly you can simply use `netcat` as Memcached does not have a dedicated client tool.  Assuming your Memcached relationship is named `cache`, the host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `cache.internal` and `11211`. Open an [SSH session](/development/ssh/_index.md) and access the Memcached server as follows:
+To access the Memcached service directly you can use `netcat` as Memcached doesn't have a dedicated client tool. Assuming your Memcached relationship is named `cache`, the host name and port number obtained from `PLATFORM_RELATIONSHIPS` would be `cache.internal` and `11211`. Open an [SSH session](/development/ssh/_index.md) and access the Memcached server as follows:
 
 ```bash
 netcat cache.internal 11211

--- a/docs/src/configuration/services/mongodb.md
+++ b/docs/src/configuration/services/mongodb.md
@@ -59,6 +59,14 @@ You can then use the service in a configuration file of your application with so
 {{< codetabs >}}
 
 ---
+title=Go
+file=static/files/fetch/examples/golang/mongodb
+highlight=go
+---
+
+<--->
+
+---
 title=Java
 file=static/files/fetch/examples/java/mongodb
 highlight=java
@@ -92,7 +100,7 @@ highlight=python
 
 ## Exporting data
 
-The most straightforward way to export data from a MongoDB database is to open an SSH tunnel to it and simply export the data directly using MongoDB's tools.
+The most straightforward way to export data from a MongoDB database is to open an SSH tunnel to it and export the data directly using MongoDB's tools.
 
 First, open an SSH tunnel with the Platform.sh CLI:
 
@@ -107,9 +115,9 @@ SSH tunnel opened on port 30000 to relationship: database
 SSH tunnel opened on port 30001 to relationship: redis
 ```
 
-The port may vary in your case.  You also need to obtain the user, password, and database name from the relationships array, as above.
+The port may vary in your case. You also need to obtain the user, password, and database name from the relationships array, as above.
 
-Then, simply connect to that port locally using `mongodump` (or your favorite MongoDB tools) to export all data in that server:
+Then, connect to that port locally using `mongodump` (or your favorite MongoDB tools) to export all data in that server:
 
 ```bash
 mongodump --port 30000 -u main -p main --authenticationDatabase main --db main
@@ -119,7 +127,7 @@ mongodump --port 30000 -u main -p main --authenticationDatabase main --db main
 
 As with any other shell command it can be piped to another command to compress the output or redirect it to a specific file.
 
-For further references please see the [official mongodump documentation](https://docs.mongodb.com/manual/reference/program/mongodump/#bin.mongodump).
+For further references, see the [official `mongodump` documentation](https://docs.mongodb.com/manual/reference/program/mongodump/#bin.mongodump).
 
 ## Upgrading
 

--- a/docs/src/configuration/services/mysql.md
+++ b/docs/src/configuration/services/mysql.md
@@ -4,7 +4,7 @@ weight: 7
 sidebarTitle: "MariaDB/MySQL"
 ---
 
-Platform.sh supports both MariaDB and Oracle MySQL.  While there are some differences at the application level for developers, they function nearly identically from an infrastructure point of view.
+Platform.sh supports both MariaDB and Oracle MySQL. While there are some differences at the application level for developers, they function nearly identically from an infrastructure point of view.
 
 See the [MariaDB documentation](https://mariadb.org/learn/) or [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/) for more information.
 
@@ -22,7 +22,7 @@ Only MariaDB is available on Dedicated and Dedicated Generation 3 environments, 
 {{< image-versions image="mariadb" status="supported" environment="dedicated" >}}
 
 {{< note >}}
-Downgrades of MySQL or MariaDB are not supported. Both will update their own datafiles to a new version automatically but cannot downgrade them. If you want to experiment with a later version without committing to it use a non-master environment.
+Downgrades of MySQL or MariaDB are not supported. Both will update their own data files to a new version automatically but cannot downgrade them. If you want to experiment with a later version without committing to it use a non-master environment.
 
 Dedicated environments do not support any storage engine other than InnoDB. Tables created using the MyISAM storage engine on dedicated environments will not replicate between cluster nodes.
 {{< /note >}}
@@ -62,6 +62,14 @@ You can then use the service in a configuration file of your application with so
 {{< codetabs >}}
 
 ---
+title=Go
+file=static/files/fetch/examples/golang/mysql
+highlight=go
+---
+
+<--->
+
+---
 title=Java
 file=static/files/fetch/examples/java/mysql
 highlight=java
@@ -99,10 +107,10 @@ MySQL schema names can not use system reserved namespace. (mysql, information_sc
 
 ## Multiple databases
 
-If you are using version `10.0` or later of this service it is possible to define multiple databases as well as multiple users with different permissions.  To do so requires defining multiple endpoints.  Under the `configuration` key of your service there are two additional keys:
+If you are using version `10.0` or later of this service it is possible to define multiple databases as well as multiple users with different permissions. To do so requires defining multiple endpoints. Under the `configuration` key of your service there are two additional keys:
 
-* `schemas`:  This is a YAML array listing the databases that should be created.  If not specified, a single database named `main` will be created.
-* `endpoints`: This is a nested YAML array defining different credentials.  Each endpoint may have access to one or more schemas (databases), and may have different levels of permission on each.  The valid permission levels are:
+* `schemas`:  This is a YAML array listing the databases that should be created. If not specified, a single database named `main` will be created.
+* `endpoints`: This is a nested YAML array defining different credentials. Each endpoint may have access to one or more schemas (databases), and may have different levels of permission on each. The valid permission levels are:
   * `ro`: Using this endpoint only SELECT queries are allowed.
   * `rw`: Using this endpoint SELECT queries as well INSERT/UPDATE/DELETE queries are allowed.
   * `admin`: Using this endpoint all queries are allowed, including DDL queries (CREATE TABLE, DROP TABLE, etc.).
@@ -132,11 +140,11 @@ db:
                     legacy: rw
 ```
 
-This example creates a single MySQL/MariaDB service named `mysqldb`.  That server will have two databases, `main` and `legacy`.  There will be three endpoints created.  The first, named `admin`, will have full access to both databases.  The second, `reporter`, will have SELECT query access to the `main` DB but no access to `legacy` at all.  The `importer` user will have SELECT/INSERT/UPDATE/DELETE access (but not DDL access) to the `legacy` database but no access to `main`.
+This example creates a single MySQL/MariaDB service named `mysqldb`. That server will have two databases, `main` and `legacy`. There will be three endpoints created. The first, named `admin`, will have full access to both databases. The second, `reporter`, will have SELECT query access to the `main` DB but no access to `legacy` at all. The `importer` user will have SELECT/INSERT/UPDATE/DELETE access (but not DDL access) to the `legacy` database but no access to `main`.
 
-If a given endpoint has access to multiple databases you should also specify which will be listed by default in the relationships array.  If one isn't specified the `path` property of the relationship will be null.  While that may be acceptable for an application that knows the name of the database to connect to, it would mean that automated tools such as the Platform CLI will not be able to access the database on that relationship. For that reason the `default_schema` property is always recommended.
+If a given endpoint has access to multiple databases you should also specify which will be listed by default in the relationships array. If one isn't specified the `path` property of the relationship will be null. While that may be acceptable for an application that knows the name of the database to connect to, it would mean that automated tools such as the Platform CLI will not be able to access the database on that relationship. For that reason the `default_schema` property is always recommended.
 
-Once those endpoints are defined, you need to expose them to your application as a relationship.  Continuing with our example, this would be a possible corresponding block from `.platform.app.yaml`:
+Once those endpoints are defined, you need to expose them to your application as a relationship. Continuing with our example, this would be a possible corresponding block from `.platform.app.yaml`:
 
 ```yaml
 relationships:
@@ -145,7 +153,7 @@ relationships:
     imports: "db:importer"
 ```
 
-This block defines three relationships, `database`, `reports`, and `imports`.  They'll be available in the `PLATFORM_RELATIONSHIPS` environment variable and all have the same structure documented above, but with different credentials.  You can use those to connect to the appropriate database with the specified restrictions using whatever the SQL access tools are for your language and application.
+This block defines three relationships, `database`, `reports`, and `imports`. They'll be available in the `PLATFORM_RELATIONSHIPS` environment variable and all have the same structure documented above, but with different credentials. You can use those to connect to the appropriate database with the specified restrictions using whatever the SQL access tools are for your language and application.
 
 If no `configuration` block is specified at all, it is equivalent to the following default:
 
@@ -168,7 +176,7 @@ For MariaDB 10.1 and later Oracle MySQL 8.0 and later, a select few configuratio
 
 ### Packet and connection sizing
 
-This value defaults to `16` (in MB).  Legal values are from `1` to `100`.
+This value defaults to `16` (in MB). Legal values are from `1` to `100`.
 
 ```yaml
 db:
@@ -179,7 +187,7 @@ db:
             max_allowed_packet: 64
 ```
 
-The above code will increase the maximum allowed packet size (the size of a query or response) to 64 MB.  However, increasing the size of the maximum packet will also automatically decrease the `max_connections` value.  The number of connections allowed will depend on the packet size and the memory available to the service.  In most cases leaving this value at the default is recommended.
+The above code will increase the maximum allowed packet size (the size of a query or response) to 64 MB. However, increasing the size of the maximum packet will also automatically decrease the `max_connections` value. The number of connections allowed will depend on the packet size and the memory available to the service. In most cases leaving this value at the default is recommended.
 
 ## Character encoding
 
@@ -199,7 +207,7 @@ db:
             default_collation: utf8mb4_unicode_ci
 ```
 
-Note that the effect of this setting is to set the character set and collation of any tables created once those properties are set.  Tables created prior to when those settings are changed will be unaffected by changes to the `services.yaml` configuration.  However, you can change your own table's character set and collation through `ALTER TABLE` commands.  For example:
+Note that the effect of this setting is to set the character set and collation of any tables created once those properties are set. Tables created prior to when those settings are changed will be unaffected by changes to the `services.yaml` configuration. However, you can change your own table's character set and collation through `ALTER TABLE` commands. For example:
 
 ```text
 # To change defaults when creating new tables:
@@ -249,7 +257,7 @@ Outside the application container, you can use Platform CLI `platform sql`.
 
 ## Exporting data
 
-The easiest way to download all data in a MariaDB instance is with the Platform.sh CLI.  If you have a single SQL database, the following command will export all data using the `mysqldump` command to a local file:
+The easiest way to download all data in a MariaDB instance is with the Platform.sh CLI. If you have a single SQL database, the following command will export all data using the `mysqldump` command to a local file:
 
 ```bash
 platform db:dump
@@ -281,7 +289,7 @@ The easiest way to load data into a database is to pipe an SQL dump through the 
 platform sql < my_database_backup.sql
 ```
 
-That will run the database backup against the SQL database on Platform.sh.  That will work for any SQL file, so the usual caveats about importing an SQL dump apply (e.g., it's best to run against an empty database).  As with exporting, you can also specify a specific environment to use and a specific database relationship to use, if there are multiple.
+That will run the database backup against the SQL database on Platform.sh. That will work for any SQL file, so the usual caveats about importing an SQL dump apply (e.g., it's best to run against an empty database). As with exporting, you can also specify a specific environment to use and a specific database relationship to use, if there are multiple.
 
 ```bash
 platform sql --relationship database -e master < my_database_backup.sql
@@ -294,9 +302,9 @@ Taking a backup or a database export before doing so is strongly recommended.
 
 ## Replication
 
-On-site primary/replica support is not available on Grid plans.  On a Dedicated environment, it is provided automatically as part of the default configuration.
+On-site primary/replica support is not available on Grid plans. On a Dedicated environment, it is provided automatically as part of the default configuration.
 
-In abnormal cases you may also enable [remote replication](/guides/general/mysql-replication.md) to your own replica data.  This is an advanced configuration not appropriate for most circumstances (and the replica will not be available to your application), but may be useful for certain backup purposes.
+In abnormal cases you may also enable [remote replication](/guides/general/mysql-replication.md) to your own replica data. This is an advanced configuration not appropriate for most circumstances (and the replica will not be available to your application), but may be useful for certain backup purposes.
 
 ## Troubleshooting
 

--- a/docs/src/configuration/services/postgresql.md
+++ b/docs/src/configuration/services/postgresql.md
@@ -59,6 +59,14 @@ You can then use the service in a configuration file of your application with so
 {{< codetabs >}}
 
 ---
+title=Go
+file=static/files/fetch/examples/golang/postgresql
+highlight=go
+---
+
+<--->
+
+---
 title=Java
 file=static/files/fetch/examples/java/postgresql
 highlight=java
@@ -92,7 +100,7 @@ highlight=python
 
 ## Exporting data
 
-The easiest way to download all data in a PostgreSQL instance is with the Platform CLI.  If you have a single SQL database, the following command will export all data using the `pg_dump` command to a local file:
+The easiest way to download all data in a PostgreSQL instance is with the Platform CLI. If you have a single SQL database, the following command will export all data using the `pg_dump` command to a local file:
 
 ```bash
 platform db:dump
@@ -130,7 +138,7 @@ The easiest way to load data into a database is to pipe an SQL dump through the 
 platform sql < my_database_backup.sql
 ```
 
-That will run the database backup against the SQL database on Platform.sh.  That will work for any SQL file, so the usual caveats about importing an SQL dump apply (e.g., it's best to run against an empty database).  As with exporting, you can also specify a specific environment to use and a specific database relationship to use, if there are multiple.
+That will run the database backup against the SQL database on Platform.sh. That will work for any SQL file, so the usual caveats about importing an SQL dump apply (e.g., it's best to run against an empty database). As with exporting, you can also specify a specific environment to use and a specific database relationship to use, if there are multiple.
 
 ```bash
 platform sql --relationship database -e master < my_database_backup.sql
@@ -143,10 +151,10 @@ Taking a backup or a database export before doing so is strongly recommended.
 
 ## Multiple databases
 
-If you are using version `13` or later of this service it is possible to define multiple databases as well as multiple users with different permissions.  To do so requires defining multiple endpoints.  Under the `configuration` key of your service there are two additional keys:
+If you are using version `13` or later of this service it is possible to define multiple databases as well as multiple users with different permissions. To do so requires defining multiple endpoints. Under the `configuration` key of your service there are two additional keys:
 
-* `databases`:  This is a YAML array listing the databases that should be created.  If not specified, a single database named `main` will be created.
-* `endpoints`: This is a nested YAML object defining different credentials.  Each endpoint may have access to one or more schemas (databases), and may have different levels of permission for each. The valid permission levels are:
+* `databases`:  This is a YAML array listing the databases that should be created. If not specified, a single database named `main` will be created.
+* `endpoints`: This is a nested YAML object defining different credentials. Each endpoint may have access to one or more schemas (databases), and may have different levels of permission for each. The valid permission levels are:
   * `ro`: Using this endpoint only `SELECT` queries are allowed.
   * `rw`: Using this endpoint `SELECT` queries as well as `INSERT`/`UPDATE`/`DELETE` queries are allowed.
   * `admin`: Using this endpoint all queries are allowed, including DDL queries (`CREATE TABLE`, `DROP TABLE`, etc.).
@@ -193,7 +201,7 @@ relationships:
     imports: "dbpostgres:importer"
 ```
 
-Each database will be accessible to your application through the `database`, `reports`, and `imports` relationships. They'll be available in the `PLATFORM_RELATIONSHIPS` environment variable and all have the same structure documented above, but with different credentials.  You can use those to connect to the appropriate database with the specified restrictions using whatever the SQL access tools are for your language and application.
+Each database will be accessible to your application through the `database`, `reports`, and `imports` relationships. They'll be available in the `PLATFORM_RELATIONSHIPS` environment variable and all have the same structure documented above, but with different credentials. You can use those to connect to the appropriate database with the specified restrictions using whatever the SQL access tools are for your language and application.
 
 A service configuration without the `configuration` block defined is equivalent to the following default values:
 
@@ -234,7 +242,7 @@ configuration:
 
 ## Extensions
 
-Platform.sh supports a number of PostgreSQL extensions.  To enable them, list them under the `configuration.extensions` key in your `services.yaml` file, like so:
+Platform.sh supports a number of PostgreSQL extensions. To enable them, list them under the `configuration.extensions` key in your `services.yaml` file, like so:
 
 ```yaml
 db:
@@ -253,59 +261,59 @@ In this case you will have `pg_trgm` installed, providing functions to determine
 The following is the extensive list of supported extensions. Note that you cannot currently add custom
 extensions not listed here.
 
-* **address_standardizer** - Used to parse an address into constituent elements. Generally used to support geocoding address normalization step.
-* **address_standardizer_data_us** - Address Standardizer US dataset example
-* **adminpack** - administrative functions for PostgreSQL
-* **autoinc** - functions for autoincrementing fields
-* **bloom** - bloom access method - signature file based index (requires 9.6 or higher)
-* **btree_gin** - support for indexing common datatypes in GIN
-* **btree_gist** - support for indexing common datatypes in GiST
-* **chkpass** - data type for auto-encrypted passwords
-* **citext** - data type for case-insensitive character strings
-* **cube** - data type for multidimensional cubes
-* **dblink** - connect to other PostgreSQL databases from within a database
-* **dict_int** - text search dictionary template for integers
-* **dict_xsyn** - text search dictionary template for extended synonym processing
-* **earthdistance** - calculate great-circle distances on the surface of the Earth
-* **file_fdw** - foreign-data wrapper for flat file access
-* **fuzzystrmatch** - determine similarities and distance between strings
-* **hstore** - data type for storing sets of (key, value) pairs
-* **insert_username** - functions for tracking who changed a table
-* **intagg** - integer aggregator and enumerator (obsolete)
-* **intarray** - functions, operators, and index support for 1-D arrays of integers
-* **isn** - data types for international product numbering standards
-* **lo** - Large Object maintenance
-* **ltree** - data type for hierarchical tree-like structures
-* **moddatetime** - functions for tracking last modification time
-* **pageinspect** - inspect the contents of database pages at a low level
-* **pg_buffercache** - examine the shared buffer cache
-* **pg_freespacemap** - examine the free space map (FSM)
-* **pg_prewarm** - prewarm relation data (requires 9.6 or higher)
-* **pg_stat_statements** - track execution statistics of all SQL statements executed
-* **pg_trgm** - text similarity measurement and index searching based on trigrams
-* **pg_visibility** - examine the visibility map (VM) and page-level visibility info (requires 9.6 or higher)
-* **pgcrypto** - cryptographic functions
-* **pgrouting** - pgRouting Extension (requires 9.6 or higher)
-* **pgrowlocks** - show row-level locking information
-* **pgstattuple** - show tuple-level statistics
-* **plpgsql** - PL/pgSQL procedural language
-* **postgis** - PostGIS geometry, geography, and raster spatial types and functions
-* **postgis_sfcgal** - PostGIS SFCGAL functions
-* **postgis_tiger_geocoder** - PostGIS tiger geocoder and reverse geocoder
-* **postgis_topology** - PostGIS topology spatial types and functions
-* **postgres_fdw** - foreign-data wrapper for remote PostgreSQL servers
-* **refint** - functions for implementing referential integrity (obsolete)
-* **seg** - data type for representing line segments or floating-point intervals
-* **sslinfo** - information about SSL certificates
-* **tablefunc** - functions that manipulate whole tables, including crosstab
-* **tcn** - Triggered change notifications
-* **timetravel** - functions for implementing time travel
-* **tsearch2** - compatibility package for pre-8.3 text search functions (obsolete, only available for 9.6 and 9.3)
-* **tsm_system_rows** - TABLESAMPLE method which accepts number of rows as a limit (requires 9.6 or higher)
-* **tsm_system_time** - TABLESAMPLE method which accepts time in milliseconds as a limit (requires 9.6 or higher)
-* **unaccent** - text search dictionary that removes accents
-* **uuid-ossp** - generate universally unique identifiers (UUIDs)
-* **xml2** - XPath querying and XSLT
+* `address_standardizer` - Used to parse an address into constituent elements. Generally used to support geocoding address normalization step.
+* `address_standardizer_data_us` - For standardizing addresses based on US dataset example
+* `adminpack` - administrative functions for PostgreSQL
+* `autoinc` - functions for auto-incrementing fields
+* `bloom` - bloom access method - signature file based index (requires 9.6 or higher)
+* `btree_gin` - support for indexing common data types in GIN
+* `btree_gist` - support for indexing common data types in GiST
+* `chkpass` - data type for auto-encrypted passwords
+* `citext` - data type for case-insensitive character strings
+* `cube` - data type for multidimensional cubes
+* `dblink` - connect to other PostgreSQL databases from within a database
+* `dict_int` - text search dictionary template for integers
+* `dict_xsyn` - text search dictionary template for extended synonym processing
+* `earthdistance` - calculate great-circle distances on the surface of the Earth
+* `file_fdw` - foreign-data wrapper for flat file access
+* `fuzzystrmatch` - determine similarities and distance between strings
+* `hstore` - data type for storing sets of (key, value) pairs
+* `insert_username` - functions for tracking who changed a table
+* `intagg` - integer aggregator and enumerator (obsolete)
+* `intarray` - functions, operators, and index support for 1-D arrays of integers
+* `isn` - data types for international product numbering standards
+* `lo` - Large Object maintenance
+* `ltree` - data type for hierarchical tree-like structures
+* `moddatetime` - functions for tracking last modification time
+* `pageinspect` - inspect the contents of database pages at a low level
+* `pg_buffercache` - examine the shared buffer cache
+* `pg_freespacemap` - examine the free space map (FSM)
+* `pg_prewarm` - prewarm relation data (requires 9.6 or higher)
+* `pg_stat_statements` - track execution statistics of all SQL statements executed
+* `pg_trgm` - text similarity measurement and index searching based on trigrams
+* `pg_visibility` - examine the visibility map (VM) and page-level visibility info (requires 9.6 or higher)
+* `pgcrypto` - cryptographic functions
+* `pgrouting` - pgRouting Extension (requires 9.6 or higher)
+* `pgrowlocks` - show row-level locking information
+* `pgstattuple` - show tuple-level statistics
+* `plpgsql` - PL/pgSQL procedural language
+* `postgis` - PostGIS geometry, geography, and raster spatial types and functions
+* `postgis_sfcgal` - PostGIS SFCGAL functions
+* `postgis_tiger_geocoder` - PostGIS tiger geocoder and reverse geocoder
+* `postgis_topology` - PostGIS topology spatial types and functions
+* `postgres_fdw` - foreign-data wrapper for remote PostgreSQL servers
+* `refint` - functions for implementing referential integrity (obsolete)
+* `seg` - data type for representing line segments or floating-point intervals
+* `sslinfo` - information about SSL certificates
+* `tablefunc` - functions that manipulate whole tables, including `crosstab`
+* `tcn` - Triggered change notifications
+* `timetravel` - functions for implementing time travel
+* `tsearch2` - compatibility package for pre-8.3 text search functions (obsolete, only available for 9.6 and 9.3)
+* `tsm_system_rows` - TABLESAMPLE method which accepts number of rows as a limit (requires 9.6 or higher)
+* `tsm_system_time` - TABLESAMPLE method which accepts time in milliseconds as a limit (requires 9.6 or higher)
+* `unaccent` - text search dictionary that removes accents
+* `uuid-ossp` - generate universally unique identifiers (UUIDs)
+* `xml2` - XPath querying and XSLT
 
 {{< note >}}
 Upgrading to PostgreSQL 12 using the `postgis` extension is not currently supported. Attempting to upgrade with this extension enabled will result in a failed deployment that will require support intervention to fix.
@@ -317,13 +325,13 @@ See the [Upgrading to PostgreSQL 12 with `postgis`](#upgrading-to-postgresql-12-
 
 ### Could not find driver
 
-If you see this error: `Fatal error: Uncaught exception 'PDOException' with message 'could not find driver'`, this means you are missing the `pdo_pgsql` PHP extension. You simply need to enable it in your `.platform.app.yaml` (see above).
+If you see this error: `Fatal error: Uncaught exception 'PDOException' with message 'could not find driver'`, this means you are missing the `pdo_pgsql` PHP extension. You need to enable it in your `.platform.app.yaml` (see above).
 
 ## Upgrading
 
-PostgreSQL 10 and later include an upgrade utility that can convert databases from previous versions to version 10 or later.  If you upgrade your service from a previous version of PostgreSQL to version 10 or above (by modifying the `services.yaml` file) the upgrader will run automatically.
+PostgreSQL 10 and later include an upgrade utility that can convert databases from previous versions to version 10 or later. If you upgrade your service from a previous version of PostgreSQL to version 10 or above (by modifying the `services.yaml` file), it upgrades automatically.
 
-The upgrader does not work to upgrade to PostgreSQL 9 versions, so upgrades from PostgreSQL 9.3 to 9.6 are not supported.  Upgrade straight to version 11 instead.
+The utility can't upgrade PostgreSQL 9 versions, so upgrades from PostgreSQL 9.3 to 9.6 are not supported. Upgrade straight to version 11 instead.
 
 {{< note theme="warning" >}}
 Make sure you first test your migration on a separate branch.

--- a/docs/src/configuration/services/rabbitmq.md
+++ b/docs/src/configuration/services/rabbitmq.md
@@ -39,6 +39,14 @@ You can then use the service in a configuration file of your application with so
 {{< codetabs >}}
 
 ---
+title=Go
+file=static/files/fetch/examples/golang/rabbitmq
+highlight=go
+---
+
+<--->
+
+---
 title=Java
 file=static/files/fetch/examples/java/rabbitmq
 highlight=java
@@ -91,7 +99,7 @@ In case you want to access the browser-based UI, you have to use an SSH tunnel. 
 ssh -L 15672:rabbitmqqueue.internal:15672 <projectid>-<branch_ID>@ssh.eu.platform.sh
 ```
 
-After you successfully established a connection, you should be able to open http://localhost:15672 in your browser. You'll find the credentials like mentioned above.
+After you successfully established a connection, you should be able to open `http://localhost:15672` in your browser. You'll find the credentials like mentioned above.
 
 ### From the application container
 
@@ -105,7 +113,7 @@ dependencies:
         amqp-utils: "0.5.1"
 ```
 
-Then, when you SSH into your container, you can simply type any `amqp-` command available to manage your queues.
+Then, when you SSH into your container, you can type any `amqp-` command available to manage your queues.
 
 ## Configuration
 

--- a/docs/src/configuration/services/solr.md
+++ b/docs/src/configuration/services/solr.md
@@ -45,6 +45,14 @@ You can then use the service in a configuration file of your application with so
 {{< codetabs >}}
 
 ---
+title=Go
+file=static/files/fetch/examples/golang/solr
+highlight=go
+---
+
+<--->
+
+---
 title=Java
 file=static/files/fetch/examples/java/solr
 highlight=java
@@ -90,7 +98,7 @@ searchsolr:
         core_config: !archive "<directory>"
 ```
 
-The `directory` parameter points to a directory in the Git repository, in or below the `.platform/` folder. This directory needs to contain everything that Solr needs to start a core. At the minimum, `solrconfig.xml` and `schema.xml`.  For example, place them in `.platform/solr/conf/` such that the `schema.xml` file is located at `.platform/solr/conf/schema.xml`.   You can then reference that path like this -
+The `directory` parameter points to a directory in the Git repository, in or below the `.platform/` folder. This directory needs to contain everything that Solr needs to start a core. At the minimum, `solrconfig.xml` and `schema.xml`. For example, place them in `.platform/solr/conf/` such that the `schema.xml` file is located at `.platform/solr/conf/schema.xml`. You can then reference that path like this -
 
 ```yaml
 searchsolr:
@@ -102,7 +110,7 @@ searchsolr:
 
 ## Solr 6 and later
 
-For Solr 6 and later Platform.sh supports multiple cores via different endpoints.  Cores and endpoints are defined separately, with endpoints referencing cores.  Each core may have its own configuration or share a configuration.  It is best illustrated with an example.
+For Solr 6 and later Platform.sh supports multiple cores via different endpoints. Cores and endpoints are defined separately, with endpoints referencing cores. Each core may have its own configuration or share a configuration. It is best illustrated with an example.
 
 ```yaml
 searchsolr:
@@ -121,11 +129,11 @@ searchsolr:
                 core: extraindex
 ```
 
-The above definition defines a single Solr 8.0 server.  That server has 2 cores defined: `mainindex` &mdash; the configuration for which is in the `.platform/core1-conf` directory &mdash; and `extraindex` &mdash; the configuration for which is in the `.platform/core2-conf` directory.
+The above definition defines a single Solr 8.0 server. That server has 2 cores defined: `mainindex` &mdash; the configuration for which is in the `.platform/core1-conf` directory &mdash; and `extraindex` &mdash; the configuration for which is in the `.platform/core2-conf` directory.
 
-It then defines two endpoints: `main` is connected to the `mainindex` core while `extra` is connected to the `extraindex` core.  Two endpoints may be connected to the same core but at this time there would be no reason to do so.  Additional options may be defined in the future.
+It then defines two endpoints: `main` is connected to the `mainindex` core while `extra` is connected to the `extraindex` core. Two endpoints may be connected to the same core but at this time there would be no reason to do so. Additional options may be defined in the future.
 
-Each endpoint is then available in the relationships definition in `.platform.app.yaml`.  For example, to allow an application to talk to both of the cores defined above its `.platform.app.yaml` file should contain the following:
+Each endpoint is then available in the relationships definition in `.platform.app.yaml`. For example, to allow an application to talk to both of the cores defined above its `.platform.app.yaml` file should contain the following:
 
 ```yaml
 relationships:
@@ -160,7 +168,7 @@ The relationships array would then look something like the following:
 
 ### Configsets
 
-For even more customizability, it's also possible to define Solr configsets.  For example, the following snippet would define one configset, which would be used by all cores.  Specific details can then be overridden by individual cores using `core_properties`, which is equivalent to the Solr `core.properties` file.
+For even more customizability, it's also possible to define Solr configsets. For example, the following snippet would define one configset, which would be used by all cores. Specific details can then be overridden by individual cores using `core_properties`, which is equivalent to the Solr `core.properties` file.
 
 ```yaml
 searchsolr:
@@ -185,7 +193,7 @@ searchsolr:
                 core: arabic_index
 ```
 
-In this example, `.platform/configsets/solr8` contains the configuration definition for multiple cores.  There are then two cores created: `english_index` uses the defined configset, but specifically the `.platform/configsets/solr8/english/schema.xml` file, while `arabic_index` is identical except for using the `.platform/configsets/solr8/arabic/schema.xml` file.  Each of those cores is then exposed as its own endpoint.
+In this example, `.platform/configsets/solr8` contains the configuration definition for multiple cores. There are then two cores created: `english_index` uses the defined configset, but specifically the `.platform/configsets/solr8/english/schema.xml` file, while `arabic_index` is identical except for using the `.platform/configsets/solr8/arabic/schema.xml` file. Each of those cores is then exposed as its own endpoint.
 
 Note that not all core.properties features make sense to specify in the core_properties. Some keys, such as name and dataDir, are not supported, and may result in a solrconfig that fails to work as intended, or at all.
 
@@ -204,7 +212,7 @@ searchsolr:
                 core: collection1
 ```
 
-The default configuration is based on an older version of the Drupal 8 Search API Solr module that is no longer in use.  While it may work for generic cases defining your own custom configuration, core, and endpoint is strongly recommended.
+The default configuration is based on an older version of the Drupal 8 Search API Solr module that is no longer in use. While it may work for generic cases defining your own custom configuration, core, and endpoint is strongly recommended.
 
 ### Limitations
 
@@ -232,7 +240,7 @@ View tunnel details with: platform tunnel:info
 Close tunnels with: platform tunnel:close
 ```
 
-In this example, you can now open `http://localhost:30000/solr/` in a browser to access the Solr admin interface.  Note that you cannot create indexes or users this way, but you can browse the existing indexes and manipulate the stored data.
+In this example, you can now open `http://localhost:30000/solr/` in a browser to access the Solr admin interface. Note that you cannot create indexes or users this way, but you can browse the existing indexes and manipulate the stored data.
 
 
 {{< note >}}
@@ -242,22 +250,22 @@ Platform.sh Dedicated users can use `ssh -L 8888:localhost:8983 <user>@<cluster-
 
 ## Upgrading
 
-The Solr data format sometimes changes between versions in incompatible ways.  Solr does not include a data upgrade mechanism as it is expected that all indexes can be regenerated from stable data if needed.  To upgrade (or downgrade) Solr you will need to use a new service from scratch.
+The Solr data format sometimes changes between versions in incompatible ways. Solr does not include a data upgrade mechanism as it is expected that all indexes can be regenerated from stable data if needed. To upgrade (or downgrade) Solr you will need to use a new service from scratch.
 
 There are two ways of doing that.
 
 ### Destructive
 
-In your `services.yaml` file, change the version of your Solr service *and* its name.  Then update the name in the `.platform.app.yaml` relationships block.
+In your `services.yaml` file, change the version of your Solr service *and* its name. Then update the name in the `.platform.app.yaml` relationships block.
 
-When you push that to Platform.sh, the old service will be deleted and a new one with the name name created, with no data.  You can then have your application reindex data as appropriate.
+When you push that to Platform.sh, the old service is deleted and a new one with the name is created, with no data. You can then have your application re-index data as appropriate.
 
-This approach is simple but has the downside of temporarily having an empty Solr instance, which your application may or may not handle gracefully, and needing to rebuild your index afterward.  Depending on the size of your data that could take a while.
+This approach has the downside of temporarily having an empty Solr instance, which your application may or may not handle gracefully, and needing to rebuild your index afterward. Depending on the size of your data that could take a while.
 
 ### Transitional
 
-For a transitional approach you will temporarily have two Solr services.  Add a second Solr service with the new version a new name and give it a new relationship in `.platform.app.yaml`.  You can optionally run in that configuration for a while to allow your application to populate indexes in the new service as well.
+For a transitional approach you will temporarily have two Solr services. Add a second Solr service with the new version a new name and give it a new relationship in `.platform.app.yaml`. You can optionally run in that configuration for a while to allow your application to populate indexes in the new service as well.
 
-Once you're ready to cut over, remove the old Solr service and relationship.  You may optionally have the new Solr service use the old relationship name if that's easier for your application to handle.  Your application is now using the new Solr service.
+Once you're ready to cut over, remove the old Solr service and relationship. You may optionally have the new Solr service use the old relationship name if that's easier for your application to handle. Your application is now using the new Solr service.
 
-This approach has the benefit of never being without a working Solr instance.  On the downside, it requires two running Solr servers temporarily, each of which will consume resources and need adequate disk space.  Depending on the size of your data that may be a lot of disk space.
+This approach has the benefit of never being without a working Solr instance. On the downside, it requires two running Solr servers temporarily, each of which will consume resources and need adequate disk space. Depending on the size of your data that may be a lot of disk space.

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -1,6 +1,6 @@
 ---
 title: "Go"
-description: Platform.sh supports building and deploying applications written in Go using Go modules.  They are compiled during the Build hook phase, and support both committed dependencies and download-on-demand.
+description: Platform.sh supports building and deploying applications written in Go using Go modules. They are compiled during the Build hook phase, and support both committed dependencies and download-on-demand.
 ---
 
 {{< description >}}
@@ -17,17 +17,17 @@ To specify a Go container, use the `type` property in your `.platform.app.yaml`.
 
 ## Deprecated versions
 
-The following container versions are also available.  However, they are not maintained upstream and as a consequence not recommended to use.
+The following container versions are also available. However, they are not maintained upstream and as a consequence not recommended to use.
 
 {{< image-versions image="golang" status="deprecated" >}}
 
 ## Go modules
 
-The recommended way to handle Go dependencies on Platform.sh is using Go module support in Go 1.11 and later.  That allows the build process to use `go build` directly without any extra steps, and you can specify an output executable file of your choice.  (See the examples below.)
+The recommended way to handle Go dependencies on Platform.sh is using Go module support in Go 1.11 and later. That allows the build process to use `go build` directly without any extra steps, and you can specify an output executable file of your choice. (See the examples below.)
 
 ## Platform.sh variables
 
-Platform.sh exposes relationships and other configuration as [environment variables](/development/variables.md).  To make them easier to access you should use the provided [Config Reader library](https://github.com/platformsh/config-reader-go).  Most notably, it allows a program to determine at runtime what HTTP port it should listen on and what the credentials are to access [other services](/configuration/services/_index.md).
+Platform.sh exposes relationships and other configuration as [environment variables](/development/variables.md). To make them easier to access you should use the provided [Config Reader library](https://github.com/platformsh/config-reader-go). Most notably, it allows a program to determine at runtime what HTTP port it should listen on and what the credentials are to access [other services](/configuration/services/_index.md).
 
 ```go
 package main
@@ -56,7 +56,7 @@ func main() {
 
 ## Building and running the application
 
-Assuming your `go.mod` and `go.sum` files are present in your repository, the application may be built with a simple `go build` command that will produce a working executable.  You can then start it from the `web.commands.start` directive.  Note that the start command _must_ run in the foreground. Should the program terminate for any reason it will be automatically restarted.
+Assuming your `go.mod` and `go.sum` files are present in your repository, the application may be built with the command `go build`, which produces a working executable. You can then start it from the `web.commands.start` directive. Note that the start command _must_ run in the foreground. Should the program terminate for any reason it will be automatically restarted.
 
 The following basic `.platform.app.yaml` file is sufficient to run most Go applications.
 
@@ -90,10 +90,70 @@ web:
 disk: 1024
 ```
 
-Note that there will still be an Nginx proxy server sitting in front of your application.  If desired, certain paths may be served directly by Nginx without hitting your application (for static files, primarily) or you may route all requests to the Go application unconditionally, as in the example above.
+Note that there will still be an Nginx proxy server sitting in front of your application. If desired, certain paths may be served directly by Nginx without hitting your application (for static files, primarily) or you may route all requests to the Go application unconditionally, as in the example above.
+
+## Accessing services
+
+To access various [services](/configuration/services/_index.md) with Go, see the following examples. The individual service pages have more information on configuring each service.
+
+{{< codetabs >}}
+
+---
+title=Memcached
+file=static/files/fetch/examples/golang/memcached
+highlight=go
+markdownify=false
+---
+
+<--->
+
+---
+title=MongoDB
+file=static/files/fetch/examples/golang/mongodb
+highlight=golang
+markdownify=false
+---
+
+<--->
+
+---
+title=MySQL
+file=static/files/fetch/examples/golang/mysql
+highlight=golang
+markdownify=false
+---
+
+<--->
+
+---
+title=PostgreSQL
+file=static/files/fetch/examples/golang/postgresql
+highlight=golang
+markdownify=false
+---
+
+<--->
+
+---
+title=RabbitMQ
+file=static/files/fetch/examples/golang/rabbitmq
+highlight=golang
+markdownify=false
+---
+
+<--->
+
+---
+title=Solr
+file=static/files/fetch/examples/golang/solr
+highlight=golang
+markdownify=false
+---
+
+{{< /codetabs >}}
 
 ## Project templates
 
-Platform.sh offers a project templates for Go applications using the structure described above.  It can be used as a starting point or reference for building your own website or web application.
+Platform.sh offers a project templates for Go applications using the structure described above. It can be used as a starting point or reference for building your own website or web application.
 
 {{< repolist lang="golang" >}}

--- a/docs/static/files/fetch/.gitignore
+++ b/docs/static/files/fetch/.gitignore
@@ -1,5 +1,4 @@
 appyaml
-examples
 routesyaml
 servicesyaml
 docsappyaml

--- a/docs/static/files/fetch/examples/golang/memcached
+++ b/docs/static/files/fetch/examples/golang/memcached
@@ -1,0 +1,38 @@
+package examples
+
+import (
+	"fmt"
+	"github.com/bradfitz/gomemcache/memcache"
+	psh "github.com/platformsh/config-reader-go/v2"
+	gomemcache "github.com/platformsh/config-reader-go/v2/gomemcache"
+)
+
+func UsageExampleMemcached() string {
+
+	// Create a NewRuntimeConfig object to ease reading the Platform.sh environment variables.
+	// You can alternatively use os.Getenv() yourself.
+	config, err := psh.NewRuntimeConfig()
+	checkErr(err)
+
+	// Get the credentials to connect to the Solr service.
+	credentials, err := config.Credentials("memcached")
+	checkErr(err)
+
+	// Retrieve formatted credentials for gomemcache.
+	formatted, err := gomemcache.FormattedCredentials(credentials)
+	checkErr(err)
+
+	// Connect to Memcached.
+	mc := memcache.New(formatted)
+
+	// Set a value.
+	key := "Deploy_day"
+	value := "Friday"
+
+	err = mc.Set(&memcache.Item{Key: key, Value: []byte(value)})
+
+	// Read it back.
+	test, err := mc.Get(key)
+
+	return fmt.Sprintf("Found value <strong>%s</strong> for key <strong>%s</strong>.", test.Value, key)
+}

--- a/docs/static/files/fetch/examples/golang/mongodb
+++ b/docs/static/files/fetch/examples/golang/mongodb
@@ -1,0 +1,67 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	psh "github.com/platformsh/config-reader-go/v2"
+	mongoPsh "github.com/platformsh/config-reader-go/v2/mongo"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"time"
+)
+
+func UsageExampleMongoDB() string {
+
+	// Create a NewRuntimeConfig object to ease reading the Platform.sh environment variables.
+	// You can alternatively use os.Getenv() yourself.
+	config, err := psh.NewRuntimeConfig()
+	checkErr(err)
+
+	// Get the credentials to connect to the Solr service.
+	credentials, err := config.Credentials("mongodb")
+	checkErr(err)
+
+	// Retrieve the formatted credentials for mongo-driver.
+	formatted, err := mongoPsh.FormattedCredentials(credentials)
+	checkErr(err)
+
+	// Connect to MongoDB using the formatted credentials.
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(formatted))
+	checkErr(err)
+
+	// Create a new collection.
+	collection := client.Database("main").Collection("starwars")
+
+	// Clean up after ourselves.
+	err = collection.Drop(context.Background())
+	checkErr(err)
+
+	// Create an entry.
+	res, err := collection.InsertOne(ctx, bson.M{"name": "Rey", "occupation": "Jedi"})
+	checkErr(err)
+
+	id := res.InsertedID
+
+	// Read it back.
+	cursor, err := collection.Find(context.Background(), bson.M{"_id": id})
+	checkErr(err)
+
+	var name string
+	var occupation string
+
+	for cursor.Next(context.Background()) {
+		document := struct {
+			Name       string
+			Occupation string
+		}{}
+		err := cursor.Decode(&document)
+		checkErr(err)
+
+		name = document.Name
+		occupation = document.Occupation
+	}
+
+	return fmt.Sprintf("Found %s (%s)", name, occupation)
+}

--- a/docs/static/files/fetch/examples/golang/mysql
+++ b/docs/static/files/fetch/examples/golang/mysql
@@ -1,0 +1,84 @@
+package examples
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/go-sql-driver/mysql"
+	psh "github.com/platformsh/config-reader-go/v2"
+	sqldsn "github.com/platformsh/config-reader-go/v2/sqldsn"
+)
+
+func UsageExampleMySQL() string {
+
+	// Create a NewRuntimeConfig object to ease reading the Platform.sh environment variables.
+	// You can alternatively use os.Getenv() yourself.
+	config, err := psh.NewRuntimeConfig()
+	checkErr(err)
+
+	// The 'database' relationship is generally the name of the primary SQL database of an application.
+	// That's not required, but much of our default automation code assumes it.
+	credentials, err := config.Credentials("database")
+	checkErr(err)
+
+	// Using the sqldsn formatted credentials package.
+	formatted, err := sqldsn.FormattedCredentials(credentials)
+	checkErr(err)
+
+	db, err := sql.Open("mysql", formatted)
+	checkErr(err)
+
+	defer db.Close()
+
+	// Force MySQL into modern mode.
+	db.Exec("SET NAMES=utf8")
+	db.Exec(\x60SET sql_mode = 'ANSI,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,
+    NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,
+    NO_AUTO_CREATE_USER,ONLY_FULL_GROUP_BY'\x60)
+
+	// Creating a table.
+	sqlCreate := \x60
+CREATE TABLE IF NOT EXISTS PeopleGo (
+id SERIAL PRIMARY KEY,
+name VARCHAR(30) NOT NULL,
+city VARCHAR(30) NOT NULL)\x60
+
+	_, err = db.Exec(sqlCreate)
+	checkErr(err)
+
+	// Insert data.
+	sqlInsert := \x60
+INSERT INTO PeopleGo (name, city) VALUES
+('Neil Armstrong', 'Moon'),
+('Buzz Aldrin', 'Glen Ridge'),
+('Sally Ride', 'La Jolla');\x60
+
+	_, err = db.Exec(sqlInsert)
+	checkErr(err)
+
+	table := \x60<table>
+<thead>
+<tr><th>Name</th><th>City</th></tr>
+</thead>
+<tbody>\x60
+
+	var id int
+	var name string
+	var city string
+
+	rows, err := db.Query("SELECT * FROM PeopleGo")
+	if err != nil {
+		panic(err)
+	} else {
+		for rows.Next() {
+			err = rows.Scan(&id, &name, &city)
+			checkErr(err)
+			table += fmt.Sprintf("<tr><td>%s</td><td>%s</td><tr>\n", name, city)
+		}
+		table += "</tbody>\n</table>\n"
+	}
+
+	_, err = db.Exec("DROP TABLE PeopleGo;")
+	checkErr(err)
+
+	return table
+}

--- a/docs/static/files/fetch/examples/golang/postgresql
+++ b/docs/static/files/fetch/examples/golang/postgresql
@@ -1,0 +1,80 @@
+package examples
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/lib/pq"
+	psh "github.com/platformsh/config-reader-go/v2"
+	libpq "github.com/platformsh/config-reader-go/v2/libpq"
+)
+
+func UsageExamplePostgreSQL() string {
+
+	// Create a NewRuntimeConfig object to ease reading the Platform.sh environment variables.
+	// You can alternatively use os.Getenv() yourself.
+	config, err := psh.NewRuntimeConfig()
+	checkErr(err)
+
+	// The 'database' relationship is generally the name of the primary SQL database of an application.
+	// It could be anything, though, as in the case here where it's called "postgresql".
+	credentials, err := config.Credentials("postgresql")
+	checkErr(err)
+
+	// Retrieve the formatted credentials.
+	formatted, err := libpq.FormattedCredentials(credentials)
+	checkErr(err)
+
+	// Connect.
+	db, err := sql.Open("postgres", formatted)
+	checkErr(err)
+
+	defer db.Close()
+
+	// Creating a table.
+	sqlCreate := \x60
+CREATE TABLE IF NOT EXISTS PeopleGo (
+id SERIAL PRIMARY KEY,
+name VARCHAR(30) NOT NULL,
+city VARCHAR(30) NOT NULL);\x60
+
+	_, err = db.Exec(sqlCreate)
+	checkErr(err)
+
+	// Insert data.
+	sqlInsert := \x60
+INSERT INTO PeopleGo(name, city) VALUES
+('Neil Armstrong', 'Moon'),
+('Buzz Aldrin', 'Glen Ridge'),
+('Sally Ride', 'La Jolla');\x60
+
+	_, err = db.Exec(sqlInsert)
+	checkErr(err)
+
+	table := \x60<table>
+<thead>
+<tr><th>Name</th><th>City</th></tr>
+</thead>
+<tbody>\x60
+
+	var id int
+	var name string
+	var city string
+
+	// Read it back.
+	rows, err := db.Query("SELECT * FROM PeopleGo")
+	if err != nil {
+		panic(err)
+	} else {
+		for rows.Next() {
+			err = rows.Scan(&id, &name, &city)
+			checkErr(err)
+			table += fmt.Sprintf("<tr><td>%s</td><td>%s</td><tr>\n", name, city)
+		}
+		table += "</tbody>\n</table>\n"
+	}
+
+	_, err = db.Exec("DROP TABLE PeopleGo;")
+	checkErr(err)
+
+	return table
+}

--- a/docs/static/files/fetch/examples/golang/rabbitmq
+++ b/docs/static/files/fetch/examples/golang/rabbitmq
@@ -1,0 +1,90 @@
+package examples
+
+import (
+	"fmt"
+	psh "github.com/platformsh/config-reader-go/v2"
+	amqpPsh "github.com/platformsh/config-reader-go/v2/amqp"
+	"github.com/streadway/amqp"
+	"sync"
+)
+
+func UsageExampleRabbitMQ() string {
+
+	// Create a NewRuntimeConfig object to ease reading the Platform.sh environment variables.
+	// You can alternatively use os.Getenv() yourself.
+	config, err := psh.NewRuntimeConfig()
+	checkErr(err)
+
+	// Get the credentials to connect to RabbitMQ.
+	credentials, err := config.Credentials("rabbitmq")
+	checkErr(err)
+
+	// Use the amqp formatted credentials package.
+	formatted, err := amqpPsh.FormattedCredentials(credentials)
+	checkErr(err)
+
+	// Connect to the RabbitMQ server.
+	connection, err := amqp.Dial(formatted)
+	checkErr(err)
+	defer connection.Close()
+
+	// Make a channel.
+	channel, err := connection.Channel()
+	checkErr(err)
+	defer channel.Close()
+
+	// Create a queue.
+	q, err := channel.QueueDeclare(
+		"deploy_days", // name
+		false,         // durable
+		false,         // delete when unused
+		false,         // exclusive
+		false,         // no-wait
+		nil,           // arguments
+	)
+
+	body := "Friday"
+	msg := fmt.Sprintf("Deploying on %s", body)
+
+	// Publish a message.
+	err = channel.Publish(
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(msg),
+		})
+	checkErr(err)
+
+	outputMSG := fmt.Sprintf("[x] Sent '%s' <br>", body)
+
+	// Consume the message.
+	msgs, err := channel.Consume(
+		q.Name, // queue
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	checkErr(err)
+
+	var received string
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		for d := range msgs {
+			received = fmt.Sprintf("[x] Received message: '%s' <br>", d.Body)
+			wg.Done()
+		}
+	}()
+
+	wg.Wait()
+
+	outputMSG += received
+
+	return outputMSG
+}

--- a/docs/static/files/fetch/examples/golang/solr
+++ b/docs/static/files/fetch/examples/golang/solr
@@ -1,0 +1,64 @@
+package examples
+
+import (
+	"fmt"
+	psh "github.com/platformsh/config-reader-go/v2"
+	gosolr "github.com/platformsh/config-reader-go/v2/gosolr"
+	solr "github.com/rtt/Go-Solr"
+)
+
+func UsageExampleSolr() string {
+
+	// Create a NewRuntimeConfig object to ease reading the Platform.sh environment variables.
+	// You can alternatively use os.Getenv() yourself.
+	config, err := psh.NewRuntimeConfig()
+	checkErr(err)
+
+	// Get the credentials to connect to the Solr service.
+	credentials, err := config.Credentials("solr")
+	checkErr(err)
+
+	// Retrieve Solr formatted credentials.
+	formatted, err := gosolr.FormattedCredentials(credentials)
+	checkErr(err)
+
+	// Connect to Solr using the formatted credentials.
+	connection := &solr.Connection{URL: formatted}
+
+	// Add a document and commit the operation.
+	docAdd := map[string]interface{}{
+		"add": []interface{}{
+			map[string]interface{}{"id": 123, "name": "Valentina Tereshkova"},
+		},
+	}
+
+	respAdd, err := connection.Update(docAdd, true)
+	checkErr(err)
+
+	// Select the document.
+	q := &solr.Query{
+		Params: solr.URLParamMap{
+			"q": []string{"id:123"},
+		},
+	}
+
+	resSelect, err := connection.CustomSelect(q, "query")
+	checkErr(err)
+
+	// Delete the document and commit the operation.
+	docDelete := map[string]interface{}{
+		"delete": map[string]interface{}{
+			"id": 123,
+		},
+	}
+
+	resDel, err := connection.Update(docDelete, true)
+	checkErr(err)
+
+	message := fmt.Sprintf(\x60Adding one document - %s<br>
+Selecting document (1 expected): %d<br>
+Deleting document - %s<br>
+  \x60, respAdd, resSelect.Results.NumFound, resDel)
+
+	return message
+}

--- a/docs/static/files/fetch/examples/java/elasticsearch
+++ b/docs/static/files/fetch/examples/java/elasticsearch
@@ -1,0 +1,87 @@
+package sh.platform.languages.sample;
+
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import sh.platform.config.Config;
+import sh.platform.config.Elasticsearch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+
+public class ElasticsearchSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        Elasticsearch elasticsearch = config.getCredential("elasticsearch", Elasticsearch::new);
+
+        // Create an Elasticsearch client object.
+        RestHighLevelClient client = elasticsearch.get();
+
+        try {
+
+            String index = "animals";
+            String type = "mammals";
+            // Index a few document.
+            final List<String> animals = Arrays.asList("dog", "cat", "monkey", "horse");
+            for (String animal : animals) {
+                Map<String, Object> jsonMap = new HashMap<>();
+                jsonMap.put("name", animal);
+                jsonMap.put("age", current().nextInt(1, 10));
+                jsonMap.put("is_cute", current().nextBoolean());
+
+                IndexRequest indexRequest = new IndexRequest(index, type)
+                        .id(animal).source(jsonMap);
+                client.index(indexRequest, RequestOptions.DEFAULT);
+            }
+
+            RefreshRequest refresh = new RefreshRequest(index);
+
+            // Force just-added items to be indexed
+            RefreshResponse refreshResponse = client.indices().refresh(refresh, RequestOptions.DEFAULT);
+
+            // Search for documents.
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+            sourceBuilder.query(QueryBuilders.termQuery("name", "dog"));
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices(index);
+            searchRequest.source(sourceBuilder);
+
+            SearchResponse search = client.search(searchRequest, RequestOptions.DEFAULT);
+
+            for (SearchHit hit : search.getHits()) {
+                String id = hit.getId();
+                final Map<String, Object> source = hit.getSourceAsMap();
+                logger.append(String.format("result id %s source: %s", id, source)).append('\n');
+            }
+
+            // Delete documents.
+            for (String animal : animals) {
+                client.delete(new DeleteRequest(index, type, animal), RequestOptions.DEFAULT);
+            }
+        } catch (IOException exp) {
+            throw new RuntimeException("An error when execute Elasticsearch: " + exp.getMessage());
+        }
+        return logger.toString();
+    }
+}

--- a/docs/static/files/fetch/examples/java/kafka
+++ b/docs/static/files/fetch/examples/java/kafka
@@ -1,0 +1,72 @@
+package sh.platform.languages.sample;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import sh.platform.config.Config;
+import sh.platform.config.Kafka;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class KafkaSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        try {
+            // Get the credentials to connect to the Kafka service.
+            final Kafka kafka = config.getCredential("kafka", Kafka::new);
+            Map<String, Object> configProducer = new HashMap<>();
+            configProducer.putIfAbsent(ProducerConfig.CLIENT_ID_CONFIG, "animals");
+            final Producer<Long, String> producer = kafka.getProducer(configProducer);
+
+            // Sending data into the stream.
+            RecordMetadata metadata = producer.send(new ProducerRecord<>("animals", "lion")).get();
+            logger.append("Record sent with to partition ").append(metadata.partition())
+                    .append(" with offset ").append(metadata.offset()).append('\n');
+
+            metadata = producer.send(new ProducerRecord<>("animals", "dog")).get();
+            logger.append("Record sent with to partition ").append(metadata.partition())
+                    .append(" with offset ").append(metadata.offset()).append('\n');
+
+            metadata = producer.send(new ProducerRecord<>("animals", "cat")).get();
+            logger.append("Record sent with to partition ").append(metadata.partition())
+                    .append(" with offset ").append(metadata.offset()).append('\n');
+
+            // Consumer, read data from the stream.
+            final HashMap<String, Object> configConsumer = new HashMap<>();
+            configConsumer.put(ConsumerConfig.GROUP_ID_CONFIG, "consumerGroup1");
+            configConsumer.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+            Consumer<Long, String> consumer = kafka.getConsumer(configConsumer, "animals");
+            ConsumerRecords<Long, String> consumerRecords = consumer.poll(Duration.ofSeconds(3));
+
+            // Print each record.
+            consumerRecords.forEach(record -> {
+                logger.append("Record: Key " + record.key());
+                logger.append(" value " + record.value());
+                logger.append(" partition " + record.partition());
+                logger.append(" offset " + record.offset()).append('\n');
+            });
+
+            // Commits the offset of record to broker.
+            consumer.commitSync();
+
+            return logger.toString();
+        } catch (Exception exp) {
+            throw new RuntimeException("An error when execute Kafka", exp);
+        }
+    }
+}

--- a/docs/static/files/fetch/examples/java/memcached
+++ b/docs/static/files/fetch/examples/java/memcached
@@ -1,0 +1,38 @@
+package sh.platform.languages.sample;
+
+import net.spy.memcached.MemcachedClient;
+import sh.platform.config.Config;
+
+import java.util.function.Supplier;
+
+import sh.platform.config.Memcached;
+
+public class MemcachedSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        // Get the credentials to connect to the Memcached service.
+        Memcached memcached = config.getCredential("memcached", Memcached::new);
+
+        final MemcachedClient client = memcached.get();
+
+        String key = "cloud";
+        String value = "platformsh";
+
+        // Set a value.
+        client.set(key, 0, value);
+
+        // Read it back.
+        Object test = client.get(key);
+
+        logger.append(String.format("Found value %s for key %s.", test, key));
+
+        return logger.toString();
+    }
+}

--- a/docs/static/files/fetch/examples/java/mongodb
+++ b/docs/static/files/fetch/examples/java/mongodb
@@ -1,0 +1,39 @@
+package sh.platform.languages.sample;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import sh.platform.config.Config;
+import sh.platform.config.MongoDB;
+
+import java.util.function.Supplier;
+
+import static com.mongodb.client.model.Filters.eq;
+
+public class MongoDBSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        // The 'database' relationship is generally the name of primary database of an application.
+        // It could be anything, though, as in the case here here where it's called "mongodb".
+        MongoDB database = config.getCredential("mongodb", MongoDB::new);
+        MongoClient mongoClient = database.get();
+        final MongoDatabase mongoDatabase = mongoClient.getDatabase(database.getDatabase());
+        MongoCollection<Document> collection = mongoDatabase.getCollection("scientist");
+        Document doc = new Document("name", "Ada Lovelace")
+                .append("city", "London");
+
+        collection.insertOne(doc);
+        Document myDoc = collection.find(eq("_id", doc.get("_id"))).first();
+        logger.append(myDoc.toJson()).append('\n');
+        logger.append(collection.deleteOne(eq("_id", doc.get("_id"))));
+        return logger.toString();
+    }
+}

--- a/docs/static/files/fetch/examples/java/mysql
+++ b/docs/static/files/fetch/examples/java/mysql
@@ -1,0 +1,64 @@
+package sh.platform.languages.sample;
+
+import sh.platform.config.Config;
+import sh.platform.config.MySQL;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.function.Supplier;
+
+public class MySQLSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        // The 'database' relationship is generally the name of primary SQL database of an application.
+        // That's not required, but much of our default automation code assumes it.
+        MySQL database = config.getCredential("database", MySQL::new);
+        DataSource dataSource = database.get();
+
+        // Connect to the database
+        try (Connection connection = dataSource.getConnection()) {
+
+            // Creating a table.
+            String sql = "CREATE TABLE JAVA_PEOPLE (" +
+                    " id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY," +
+                    "name VARCHAR(30) NOT NULL," +
+                    "city VARCHAR(30) NOT NULL)";
+
+            final Statement statement = connection.createStatement();
+            statement.execute(sql);
+
+            // Insert data.
+            sql = "INSERT INTO JAVA_PEOPLE (name, city) VALUES" +
+                    "('Neil Armstrong', 'Moon')," +
+                    "('Buzz Aldrin', 'Glen Ridge')," +
+                    "('Sally Ride', 'La Jolla')";
+
+            statement.execute(sql);
+
+            // Show table.
+            sql = "SELECT * FROM JAVA_PEOPLE";
+            final ResultSet resultSet = statement.executeQuery(sql);
+            while (resultSet.next()) {
+                int id = resultSet.getInt("id");
+                String name = resultSet.getString("name");
+                String city = resultSet.getString("city");
+                logger.append(String.format("the JAVA_PEOPLE id %d the name %s and city %s", id, name, city));
+                logger.append('\n');
+            }
+            statement.execute("DROP TABLE JAVA_PEOPLE");
+            return logger.toString();
+        } catch (SQLException exp) {
+            throw new RuntimeException("An error when execute MySQL", exp);
+        }
+    }
+}

--- a/docs/static/files/fetch/examples/java/postgresql
+++ b/docs/static/files/fetch/examples/java/postgresql
@@ -1,0 +1,63 @@
+package sh.platform.languages.sample;
+
+import sh.platform.config.Config;
+import sh.platform.config.MySQL;
+import sh.platform.config.PostgreSQL;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.function.Supplier;
+
+public class PostgreSQLSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        // The 'database' relationship is generally the name of primary SQL database of an application.
+        // It could be anything, though, as in the case here here where it's called "postgresql".
+        PostgreSQL database = config.getCredential("postgresql", PostgreSQL::new);
+        DataSource dataSource = database.get();
+
+        // Connect to the database
+        try (Connection connection = dataSource.getConnection()) {
+
+            // Creating a table.
+            String sql = "CREATE TABLE JAVA_FRAMEWORKS (" +
+                    " id SERIAL PRIMARY KEY," +
+                    "name VARCHAR(30) NOT NULL)";
+
+            final Statement statement = connection.createStatement();
+            statement.execute(sql);
+
+            // Insert data.
+            sql = "INSERT INTO JAVA_FRAMEWORKS (name) VALUES" +
+                    "('Spring')," +
+                    "('Jakarta EE')," +
+                    "('Eclipse JNoSQL')";
+
+            statement.execute(sql);
+
+            // Show table.
+            sql = "SELECT * FROM JAVA_FRAMEWORKS";
+            final ResultSet resultSet = statement.executeQuery(sql);
+            while (resultSet.next()) {
+                int id = resultSet.getInt("id");
+                String name = resultSet.getString("name");
+                logger.append(String.format("the JAVA_FRAMEWORKS id %d the name %s ", id, name));
+                logger.append('\n');
+            }
+            statement.execute("DROP TABLE JAVA_FRAMEWORKS");
+            return logger.toString();
+        } catch (SQLException exp) {
+            throw new RuntimeException("An error when execute PostgreSQL", exp);
+        }
+    }
+}

--- a/docs/static/files/fetch/examples/java/rabbitmq
+++ b/docs/static/files/fetch/examples/java/rabbitmq
@@ -1,0 +1,57 @@
+package sh.platform.languages.sample;
+
+import sh.platform.config.Config;
+import sh.platform.config.RabbitMQ;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.function.Supplier;
+
+public class RabbitMQSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+        try {
+            // Get the credentials to connect to the RabbitMQ service.
+            final RabbitMQ credential = config.getCredential("rabbitmq", RabbitMQ::new);
+            final ConnectionFactory connectionFactory = credential.get();
+
+            // Connect to the RabbitMQ server.
+            final Connection connection = connectionFactory.createConnection();
+            connection.start();
+            final Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Queue queue = session.createQueue("cloud");
+            MessageConsumer consumer = session.createConsumer(queue);
+
+            // Sending a message into the queue.
+            TextMessage textMessage = session.createTextMessage("Platform.sh");
+            textMessage.setJMSReplyTo(queue);
+            MessageProducer producer = session.createProducer(queue);
+            producer.send(textMessage);
+
+            // Receive the message.
+            TextMessage replyMsg = (TextMessage) consumer.receive(100);
+
+            logger.append("Message: ").append(replyMsg.getText());
+
+            // close connections.
+            producer.close();
+            consumer.close();
+            session.close();
+            connection.close();
+            return logger.toString();
+        } catch (Exception exp) {
+            throw new RuntimeException("An error when execute RabbitMQ", exp);
+        }
+    }
+}

--- a/docs/static/files/fetch/examples/java/redis
+++ b/docs/static/files/fetch/examples/java/redis
@@ -1,0 +1,40 @@
+package sh.platform.languages.sample;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import sh.platform.config.Config;
+import sh.platform.config.Redis;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class RedisSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        // The 'database' relationship is generally the name of primary database of an application.
+        // It could be anything, though, as in the case here here where it's called "redis".
+        Redis database = config.getCredential("redis", Redis::new);
+        JedisPool dataSource = database.get();
+
+        // Get a Redis Client
+        final Jedis jedis = dataSource.getResource();
+
+        // Set a values
+        jedis.sadd("cities", "Salvador");
+        jedis.sadd("cities", "London");
+        jedis.sadd("cities", "São Paulo");
+
+        // Read it back.
+        Set<String> cities = jedis.smembers("cities");
+        logger.append("cities: " + cities);
+        jedis.del("cities");
+        return logger.toString();
+    }
+}

--- a/docs/static/files/fetch/examples/java/solr
+++ b/docs/static/files/fetch/examples/java/solr
@@ -1,0 +1,64 @@
+package sh.platform.languages.sample;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.XMLResponseParser;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrInputDocument;
+import sh.platform.config.Config;
+import sh.platform.config.Solr;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public class SolrSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        Solr solr = config.getCredential("solr", Solr::new);
+
+        try {
+
+            final HttpSolrClient solrClient = solr.get();
+            solrClient.setParser(new XMLResponseParser());
+
+            // Add a document
+            SolrInputDocument document = new SolrInputDocument();
+            final String id = "123456";
+            document.addField("id", id);
+            document.addField("name", "Ada Lovelace");
+            document.addField("city", "London");
+            solrClient.add(document);
+            final UpdateResponse response = solrClient.commit();
+            logger.append("Adding one document. Status (0 is success): ")
+                    .append(response.getStatus()).append('\n');
+
+            SolrQuery query = new SolrQuery();
+            query.set("q", "city:London");
+            QueryResponse queryResponse = solrClient.query(query);
+
+            SolrDocumentList results = queryResponse.getResults();
+            logger.append(String.format("Selecting documents (1 expected):  %d \n", results.getNumFound()));
+
+            // Delete one document
+            solrClient.deleteById(id);
+
+            logger.append(String.format("Deleting one document. Status (0 is success):  %s \n",
+                    solrClient.commit().getStatus()));
+        } catch (SolrServerException | IOException exp) {
+            throw new RuntimeException("An error when execute Solr ", exp);
+        }
+
+        return logger.toString();
+    }
+}

--- a/docs/static/files/fetch/examples/nodejs/elasticsearch
+++ b/docs/static/files/fetch/examples/nodejs/elasticsearch
@@ -1,0 +1,63 @@
+const elasticsearch = require("elasticsearch");
+const config = require("platformsh-config").config();
+
+exports.usageExample = async function () {
+    const credentials = config.credentials("elasticsearch");
+
+    const client = new elasticsearch.Client({
+        host: `${credentials.host}:${credentials.port}`,
+    });
+
+    const index = "my_index";
+    const type = "People";
+
+    // Index a few document.
+    const names = ["Ada Lovelace", "Alonzo Church", "Barbara Liskov"];
+
+    const message = {
+        refresh: "wait_for",
+        body: names.flatMap((name) => [
+            { index: { _index: index, _type: type } },
+            { name },
+        ]),
+    };
+
+    await client.bulk(message);
+
+    // Search for documents.
+    const response = await client.search({
+        index,
+        q: "name:Barbara Liskov",
+    });
+
+    const outputRows = response.hits.hits
+        .map(
+            ({ _id: id, _source: { name } }) =>
+                `<tr><td>${id}</td><td>${name}</td></tr>\n`
+        )
+        .join("\n");
+
+    // Clean up after ourselves.
+    await Promise.allSettled(
+        response.hits.hits.map(({ _id: id }) =>
+            client.delete({
+                index: index,
+                type: type,
+                id,
+            })
+        )
+    );
+
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
+};

--- a/docs/static/files/fetch/examples/nodejs/memcached
+++ b/docs/static/files/fetch/examples/nodejs/memcached
@@ -1,0 +1,23 @@
+const Memcached = require('memcached');
+const config = require("platformsh-config").config();
+const { promisify } = require('util');
+
+exports.usageExample = async function() {
+    const credentials = config.credentials('memcached');
+    const client = new Memcached(`${credentials.host}:${credentials.port}`);
+
+    // The MemcacheD client is not Promise-aware, so make it so.
+    const memcachedGet = promisify(client.get).bind(client);
+    const memcachedSet = promisify(client.set).bind(client);
+
+    const key = 'Deploy-day';
+    const value = 'Friday';
+
+    // Set a value.
+    await memcachedSet(key, value, 10);
+
+    // Read it back.
+    const test = await memcachedGet(key);
+
+    return `Found value <strong>${test}</strong> for key <strong>${key}</strong>.`;
+};

--- a/docs/static/files/fetch/examples/nodejs/mongodb
+++ b/docs/static/files/fetch/examples/nodejs/mongodb
@@ -1,0 +1,46 @@
+const mongodb = require("mongodb");
+const config = require("platformsh-config").config();
+
+exports.usageExample = async function () {
+    const credentials = config.credentials("mongodb");
+    const MongoClient = mongodb.MongoClient;
+
+    const client = await MongoClient.connect(
+        config.formattedCredentials("mongodb", "mongodb")
+    );
+
+    const db = client.db(credentials["path"]);
+
+    const collection = db.collection("startrek");
+
+    const documents = [
+        { name: "James Kirk", rank: "Admiral" },
+        { name: "Jean-Luc Picard", rank: "Captain" },
+        { name: "Benjamin Sisko", rank: "Prophet" },
+        { name: "Katheryn Janeway", rank: "Captain" },
+    ];
+
+    await collection.insertMany(documents, { w: 1 });
+
+    const result = await collection.find({ rank: "Captain" }).toArray();
+
+    const outputRows = Object.values(result)
+        .map(({ name, rank }) => `<tr><td>${name}</td><td>${rank}</td></tr>\n`)
+        .join("\n");
+
+    // Clean up after ourselves.
+    collection.deleteMany();
+
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th><th>Rank</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
+};

--- a/docs/static/files/fetch/examples/nodejs/mysql
+++ b/docs/static/files/fetch/examples/nodejs/mysql
@@ -1,0 +1,55 @@
+const mysql = require("mysql2/promise");
+const config = require("platformsh-config").config();
+
+exports.usageExample = async function () {
+    const credentials = config.credentials("database");
+
+    const connection = await mysql.createConnection({
+        host: credentials.host,
+        port: credentials.port,
+        user: credentials.username,
+        password: credentials.password,
+        database: credentials.path,
+    });
+
+    // Creating a table.
+    await connection.query(
+        `CREATE TABLE IF NOT EXISTS People (
+            id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(30) NOT NULL,
+            city VARCHAR(30) NOT NULL
+        )`
+    );
+
+    // Insert data.
+    await connection.query(
+        `INSERT INTO People (name, city)
+        VALUES
+            ('Neil Armstrong', 'Moon'),
+            ('Buzz Aldrin', 'Glen Ridge'),
+            ('Sally Ride', 'La Jolla');`
+    );
+
+    // Show table.
+    const [rows] = await connection.query("SELECT * FROM People");
+
+    // Drop table.
+    await connection.query("DROP TABLE People");
+
+    const outputRows = rows
+        .map(({ name, city }) => `<tr><td>${name}</td><td>${city}</td></tr>\n`)
+        .join("\n");
+
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th><th>City</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
+};

--- a/docs/static/files/fetch/examples/nodejs/postgresql
+++ b/docs/static/files/fetch/examples/nodejs/postgresql
@@ -1,0 +1,57 @@
+const pg = require("pg");
+const config = require("platformsh-config").config();
+
+exports.usageExample = async function () {
+    const credentials = config.credentials("postgresql");
+
+    const client = new pg.Client({
+        host: credentials.host,
+        port: credentials.port,
+        user: credentials.username,
+        password: credentials.password,
+        database: credentials.path,
+    });
+
+    client.connect();
+
+    // Creating a table.
+    await client.query(
+        `CREATE TABLE IF NOT EXISTS People (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(30) NOT NULL,
+            city VARCHAR(30) NOT NULL
+        )`
+    );
+
+    // Insert data.
+    await client.query(
+        `INSERT INTO People (name, city)
+        VALUES
+            ('Neil Armstrong', 'Moon'),
+            ('Buzz Aldrin', 'Glen Ridge'),
+            ('Sally Ride', 'La Jolla');`
+    );
+
+    // Show table.
+    const result = await client.query("SELECT * FROM People");
+
+    // Drop table.
+    await client.query("DROP TABLE People");
+
+    const outputRows = result.rows
+        .map(({ name, city }) => `<tr><td>${name}</td><td>${city}</td></tr>\n`)
+        .join("\n");
+
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th><th>City</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
+};

--- a/docs/static/files/fetch/examples/nodejs/redis
+++ b/docs/static/files/fetch/examples/nodejs/redis
@@ -1,0 +1,23 @@
+const redis = require('redis');
+const config = require("platformsh-config").config();
+const { promisify } = require('util');
+
+exports.usageExample = async function() {
+    const credentials = config.credentials('redis');
+    const client = redis.createClient(credentials.port, credentials.host);
+
+    // The Redis client is not Promise-aware, so make it so.
+    const redisGet = promisify(client.get).bind(client);
+    const redisSet = promisify(client.set).bind(client);
+
+    const key = 'Deploy day';
+    const value = 'Friday';
+
+    // Set a value.
+    await redisSet(key, value);
+
+    // Read it back.
+    const test = await redisGet(key);
+
+    return `Found value <strong>${test}</strong> for key <strong>${key}</strong>.`;
+};

--- a/docs/static/files/fetch/examples/nodejs/solr
+++ b/docs/static/files/fetch/examples/nodejs/solr
@@ -1,0 +1,28 @@
+const solr = require("solr-node");
+const config = require("platformsh-config").config();
+
+exports.usageExample = async function () {
+    const client = new solr(config.formattedCredentials("solr", "solr-node"));
+
+    // Add a document.
+    const addResult = await client.update({
+        id: 123,
+        name: "Valentina Tereshkova",
+    });
+
+    // Flush writes so that we can query against them.
+    await client.softCommit();
+
+    // Select one document:
+    const strQuery = client.query().q();
+    const writeResult = await client.search(strQuery);
+
+    // Delete one document.
+    const deleteResult = await client.delete({ id: 123 });
+
+    return `
+    Adding one document. Status (0 is success): ${addResult.responseHeader.status}<br />
+    Selecting documents (1 expected): ${writeResult.response.numFound}<br />
+    Deleting one document. Status (0 is success): ${deleteResult.responseHeader.status}<br />
+    `;
+};

--- a/docs/static/files/fetch/examples/php/elasticsearch
+++ b/docs/static/files/fetch/examples/php/elasticsearch
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Elasticsearch\ClientBuilder;
+use Platformsh\ConfigReader\Config;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// Get the credentials to connect to the Elasticsearch service.
+$credentials = $config->credentials('elasticsearch');
+
+try {
+    // The Elasticsearch library lets you connect to multiple hosts.
+    // On Platform.sh Standard there is only a single host so just
+    // register that.
+    $hosts = [
+        [
+            'scheme' => $credentials['scheme'],
+            'host' => $credentials['host'],
+            'port' => $credentials['port'],
+        ]
+    ];
+
+    // Create an Elasticsearch client object.
+    $builder = ClientBuilder::create();
+    $builder->setHosts($hosts);
+    $client = $builder->build();
+
+    $index = 'my_index';
+    $type = 'People';
+
+    // Index a few document.
+    $params = [
+        'index' => $index,
+        'type' => $type,
+    ];
+
+    $names = ['Ada Lovelace', 'Alonzo Church', 'Barbara Liskov'];
+
+    foreach ($names as $name) {
+        $params['body']['name'] = $name;
+        $client->index($params);
+    }
+
+    // Force just-added items to be indexed.
+    $client->indices()->refresh(array('index' => $index));
+
+
+    // Search for documents.
+    $result = $client->search([
+        'index' => $index,
+        'type' => $type,
+        'body' => [
+            'query' => [
+                'match' => [
+                    'name' => 'Barbara Liskov',
+                ],
+            ],
+        ],
+    ]);
+
+    if (isset($result['hits']['hits'])) {
+        print <<<TABLE
+<table>
+<thead>
+<tr><th>ID</th><th>Name</th></tr>
+</thead>
+<tbody>
+TABLE;
+        foreach ($result['hits']['hits'] as $record) {
+            printf("<tr><td>%s</td><td>%s</td></tr>\n", $record['_id'], $record['_source']['name']);
+        }
+        print "</tbody>\n</table>\n";
+    }
+
+    // Delete documents.
+    $params = [
+        'index' => $index,
+        'type' => $type,
+    ];
+
+    $ids = array_map(function($row) {
+        return $row['_id'];
+    }, $result['hits']['hits']);
+
+    foreach ($ids as $id) {
+        $params['id'] = $id;
+        $client->delete($params);
+    }
+
+} catch (Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/influxdb
+++ b/docs/static/files/fetch/examples/php/influxdb
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+use InfluxDB\Client;
+use InfluxDB\Database;
+use InfluxDB\Point;
+use InfluxDB\Database\RetentionPolicy;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// Get the credentials to connect to the InfluxDB service.
+$credentials = $config->credentials('influxdb');
+
+try {
+    // Connecting to the InfluxDB server. By default it has no user defined, so you will need to create it.
+    $client = new Client($credentials['host'], $credentials['port']);
+
+    $password = base64_encode(random_bytes(12));
+    $client->admin->createUser('deploy_user', $password, Client\Admin::PRIVILEGE_ALL);
+
+    // Now reconnect with an authenticated connection so that we can access a database.
+    $client = new Client($credentials['host'], $credentials['port'], 'deploy_user', $password);
+    $database = $client->selectDB('deploys');
+
+    // No database is created by default, so it needs to be created by the user.
+    if (!$database->exists()) {
+        $database->create(new RetentionPolicy('test', '1d', 2, true));
+    }
+
+    // Write some data.
+    $points = [
+        new Point(
+            'deploy_time', // name of the measurement
+            0.64, // the measurement value
+            ['host' => 'server01', 'region' => 'us-west'], // optional tags
+            ['cpucount' => 10], // optional additional fields
+            1546556400 // Time precision has to be set to seconds!
+        ),
+        new Point(
+            'deploy_time', // name of the measurement
+            0.84, // the measurement value
+            ['host' => 'server01', 'region' => 'us-west'], // optional tags
+            ['cpucount' => 10], // optional additional fields
+            1547161200 // Time precision has to be set to seconds!
+        ),
+    ];
+    $result = $database->writePoints($points, Database::PRECISION_SECONDS);
+
+    // Read the data back.
+    $result = $database->query('select * from deploy_time LIMIT 5');
+    $points = $result->getPoints();
+
+    if ($points) {
+        print <<<TABLE
+<table>
+<thead>
+<tr><th>Timestamp</th><th>Value</th></tr>
+</thead>
+<tbody>
+TABLE;
+        foreach ($points as $point) {
+            printf("<tr><td>%s</td><td>%s</td></tr>\n", $point['time'], $point['value']);
+        }
+        print "</tbody>\n</table>\n";
+    }
+
+
+    // Drop the database.
+    $database->drop();
+
+    // And remove the user.
+    $client->admin->dropUser('deploy_user');
+
+} catch (Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/memcached
+++ b/docs/static/files/fetch/examples/php/memcached
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// Get the credentials to connect to the Memcached service.
+$credentials = $config->credentials('memcached');
+
+try {
+    // Connecting to Memcached server.
+    $memcached = new Memcached();
+    $memcached->addServer($credentials['host'], $credentials['port']);
+    $memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+
+    $key = "Deploy day";
+    $value = "Friday";
+
+    // Set a value.
+    $memcached->set($key, $value);
+
+    // Read it back.
+    $test = $memcached->get($key);
+
+    printf('Found value <strong>%s</strong> for key <strong>%s</strong>.', $test, $key);
+
+} catch (Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/mongodb
+++ b/docs/static/files/fetch/examples/php/mongodb
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+use MongoDB\Client;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// The 'database' relationship is generally the name of primary database of an application.
+// It could be anything, though, as in the case here here where it's called "mongodb".
+$credentials = $config->credentials('mongodb');
+
+try {
+
+    $server = sprintf('%s://%s:%s@%s:%d/%s',
+        $credentials['scheme'],
+        $credentials['username'],
+        $credentials['password'],
+        $credentials['host'],
+        $credentials['port'],
+        $credentials['path']
+    );
+
+    $client = new Client($server);
+    $collection = $client->main->starwars;
+
+    $result = $collection->insertOne([
+        'name' => 'Rey',
+        'occupation' => 'Jedi',
+    ]);
+
+    $id = $result->getInsertedId();
+
+    $document = $collection->findOne([
+        '_id' => $id,
+    ]);
+
+    // Clean up after ourselves.
+    $collection->drop();
+
+    printf("Found %s (%s)<br />\n", $document->name, $document->occupation);
+
+} catch (\Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/mysql
+++ b/docs/static/files/fetch/examples/php/mysql
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// The 'database' relationship is generally the name of primary SQL database of an application.
+// That's not required, but much of our default automation code assumes it.
+$credentials = $config->credentials('database');
+
+try {
+    // Connect to the database using PDO.  If using some other abstraction layer you would
+    // inject the values from $database into whatever your abstraction layer asks for.
+    $dsn = sprintf('mysql:host=%s;port=%d;dbname=%s', $credentials['host'], $credentials['port'], $credentials['path']);
+    $conn = new \PDO($dsn, $credentials['username'], $credentials['password'], [
+        // Always use Exception error mode with PDO, as it's more reliable.
+        \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        // So we don't have to mess around with cursors and unbuffered queries by default.
+        \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE,
+        // Make sure MySQL returns all matched rows on update queries including
+        // rows that actually didn't have to be updated because the values didn't
+        // change. This matches common behavior among other database systems.
+        \PDO::MYSQL_ATTR_FOUND_ROWS => TRUE,
+    ]);
+
+    // Creating a table.
+    $sql = "CREATE TABLE People (
+      id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+      name VARCHAR(30) NOT NULL,
+      city VARCHAR(30) NOT NULL
+      )";
+    $conn->query($sql);
+
+    // Insert data.
+    $sql = "INSERT INTO People (name, city) VALUES 
+        ('Neil Armstrong', 'Moon'), 
+        ('Buzz Aldrin', 'Glen Ridge'), 
+        ('Sally Ride', 'La Jolla');";
+    $conn->query($sql);
+
+    // Show table.
+    $sql = "SELECT * FROM People";
+    $result = $conn->query($sql);
+    $result->setFetchMode(\PDO::FETCH_OBJ);
+
+    if ($result) {
+        print <<<TABLE
+<table>
+<thead>
+<tr><th>Name</th><th>City</th></tr>
+</thead>
+<tbody>
+TABLE;
+        foreach ($result as $record) {
+            printf("<tr><td>%s</td><td>%s</td></tr>\n", $record->name, $record->city);
+        }
+        print "</tbody>\n</table>\n";
+    }
+
+    // Drop table
+    $sql = "DROP TABLE People";
+    $conn->query($sql);
+
+} catch (\Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/postgresql
+++ b/docs/static/files/fetch/examples/php/postgresql
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// The 'database' relationship is generally the name of primary SQL database of an application.
+// It could be anything, though, as in the case here here where it's called "postgresql".
+$credentials = $config->credentials('postgresql');
+
+try {
+    // Connect to the database using PDO.  If using some other abstraction layer you would
+    // inject the values from $database into whatever your abstraction layer asks for.
+    $dsn = sprintf('pgsql:host=%s;port=%d;dbname=%s', $credentials['host'], $credentials['port'], $credentials['path']);
+    $conn = new \PDO($dsn, $credentials['username'], $credentials['password'], [
+        // Always use Exception error mode with PDO, as it's more reliable.
+        \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        // So we don't have to mess around with cursors and unbuffered queries by default.
+    ]);
+
+    $conn->query("DROP TABLE IF EXISTS People");
+
+    // Creating a table.
+    $sql = "CREATE TABLE IF NOT EXISTS People (
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(30) NOT NULL,
+      city VARCHAR(30) NOT NULL
+      )";
+    $conn->query($sql);
+
+    // Insert data.
+    $sql = "INSERT INTO People (name, city) VALUES
+        ('Neil Armstrong', 'Moon'),
+        ('Buzz Aldrin', 'Glen Ridge'),
+        ('Sally Ride', 'La Jolla');";
+    $conn->query($sql);
+
+    // Show table.
+    $sql = "SELECT * FROM People";
+    $result = $conn->query($sql);
+    $result->setFetchMode(\PDO::FETCH_OBJ);
+
+    if ($result) {
+        print <<<TABLE
+<table>
+<thead>
+<tr><th>Name</th><th>City</th></tr>
+</thead>
+<tbody>
+TABLE;
+        foreach ($result as $record) {
+            printf("<tr><td>%s</td><td>%s</td></tr>\n", $record->name, $record->city);
+        }
+        print "</tbody>\n</table>\n";
+    }
+
+    // Drop table.
+    $sql = "DROP TABLE People";
+    $conn->query($sql);
+
+} catch (\Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/rabbitmq
+++ b/docs/static/files/fetch/examples/php/rabbitmq
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// Get the credentials to connect to the RabbitMQ service.
+$credentials = $config->credentials('rabbitmq');
+
+try {
+
+    $queueName = 'deploy_days';
+
+    // Connect to the RabbitMQ server.
+    $connection = new AMQPStreamConnection($credentials['host'], $credentials['port'], $credentials['username'], $credentials['password']);
+    $channel = $connection->channel();
+
+    $channel->queue_declare($queueName, false, false, false, false);
+
+    $msg = new AMQPMessage('Friday');
+    $channel->basic_publish($msg, '', 'hello');
+
+    echo "[x] Sent 'Friday'<br/>\n";
+
+    // In a real application you't put the following in a separate script in a loop.
+    $callback = function ($msg) {
+        printf("[x] Deploying on %s<br />\n", $msg->body);
+    };
+
+    $channel->basic_consume($queueName, '', false, true, false, false, $callback);
+
+    // This blocks on waiting for an item from the queue, so comment it out in this demo script.
+    //$channel->wait();
+
+    $channel->close();
+    $connection->close();
+
+} catch (Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/redis
+++ b/docs/static/files/fetch/examples/php/redis
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// Get the credentials to connect to the Redis service.
+$credentials = $config->credentials('redis');
+
+try {
+    // Connecting to Redis server.
+    $redis = new Redis();
+    $redis->connect($credentials['host'], $credentials['port']);
+
+    $key = "Deploy day";
+    $value = "Friday";
+
+    // Set a value.
+    $redis->set($key, $value);
+
+    // Read it back.
+    $test = $redis->get($key);
+
+    printf('Found value <strong>%s</strong> for key <strong>%s</strong>.', $test, $key);
+
+} catch (Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/php/solr
+++ b/docs/static/files/fetch/examples/php/solr
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use Platformsh\ConfigReader\Config;
+use Solarium\Client;
+
+// Create a new config object to ease reading the Platform.sh environment variables.
+// You can alternatively use getenv() yourself.
+$config = new Config();
+
+// Get the credentials to connect to the Solr service.
+$credentials = $config->credentials('solr');
+
+try {
+
+    $config = [
+        'endpoint' => [
+            'localhost' => [
+                'host' => $credentials['host'],
+                'port' => $credentials['port'],
+                'path' => "/" . $credentials['path'],
+            ]
+        ]
+    ];
+
+    $client = new Client($config);
+
+    // Add a document
+    $update = $client->createUpdate();
+
+    $doc1 = $update->createDocument();
+    $doc1->id = 123;
+    $doc1->name = 'Valentina Tereshkova';
+
+    $update->addDocuments(array($doc1));
+    $update->addCommit();
+
+    $result = $client->update($update);
+    print "Adding one document. Status (0 is success): " .$result->getStatus(). "<br />\n";
+
+    // Select one document
+    $query = $client->createQuery($client::QUERY_SELECT);
+    $resultset = $client->execute($query);
+    print  "Selecting documents (1 expected): " .$resultset->getNumFound() . "<br />\n";
+
+    // Delete one document
+    $update = $client->createUpdate();
+
+    $update->addDeleteById(123);
+    $update->addCommit();
+    $result = $client->update($update);
+    print "Deleting one document. Status (0 is success): " .$result->getStatus(). "<br />\n";
+
+} catch (Exception $e) {
+    print $e->getMessage();
+}

--- a/docs/static/files/fetch/examples/python/elasticsearch
+++ b/docs/static/files/fetch/examples/python/elasticsearch
@@ -1,0 +1,78 @@
+import elasticsearch
+from platformshconfig import Config
+
+def usage_example():
+
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # Get the credentials to connect to the Elasticsearch service.
+    credentials = config.credentials('elasticsearch')
+
+    try:
+        # The Elasticsearch library lets you connect to multiple hosts.
+        # On Platform.sh Standard there is only a single host so just register that.
+        hosts = {
+            "scheme": credentials['scheme'],
+            "host": credentials['host'],
+            "port": credentials['port']
+        }
+
+        # Create an Elasticsearch client object.
+        client = elasticsearch.Elasticsearch([hosts])
+
+        # Index a few documents
+        es_index = 'my_index'
+        es_type = 'People'
+
+        params = {
+            "index": es_index,
+            "type": es_type,
+            "body": {"name": ''}
+        }
+
+        names = ['Ada Lovelace', 'Alonzo Church', 'Barbara Liskov']
+
+        ids = {}
+
+        for name in names:
+            params['body']['name'] = name
+            ids[name] = client.index(index=params["index"], doc_type=params["type"], body=params['body'])
+
+        # Force just-added items to be indexed.
+        client.indices.refresh(index=es_index)
+
+        # Search for documents.
+        result = client.search(index=es_index, body={
+            'query': {
+                'match': {
+                    'name': 'Barbara Liskov'
+                }
+            }
+        })
+
+        table = '''<table>
+<thead>
+<tr><th>ID</th><th>Name</th></tr>
+</thead>
+<tbody>'''
+
+        if result['hits']['hits']:
+            for record in result['hits']['hits']:
+                table += '''<tr><td>{0}</td><td>{1}</td><tr>\n'''.format(record['_id'], record['_source']['name'])
+            table += '''</tbody>\n</table>\n'''
+
+        # Delete documents.
+        params = {
+            "index": es_index,
+            "type": es_type,
+        }
+
+        for name in names:
+            client.delete(index=params['index'], doc_type=params['type'], id=ids[name]['_id'])
+
+        return table
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/kafka
+++ b/docs/static/files/fetch/examples/python/kafka
@@ -1,0 +1,47 @@
+from json import dumps
+from json import loads
+from kafka import KafkaConsumer, KafkaProducer
+from platformshconfig import Config
+
+
+def usage_example():
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+    # Get the credentials to connect to the Kafka service.
+    credentials = config.credentials('kafka')
+    
+    try:
+        kafka_server = '{}:{}'.format(credentials['host'], credentials['port'])
+        
+        # Producer
+        producer = KafkaProducer(
+            bootstrap_servers=[kafka_server],
+            value_serializer=lambda x: dumps(x).encode('utf-8')
+        )
+        for e in range(10):
+            data = {'number' : e}
+            producer.send('numtest', value=data)
+        
+        # Consumer
+        consumer = KafkaConsumer(
+            bootstrap_servers=[kafka_server],
+            auto_offset_reset='earliest'
+        )
+        
+        consumer.subscribe(['numtest'])
+        
+        output = ''
+        # For demonstration purposes so it doesn't block.
+        for e in range(10):
+            message = next(consumer)
+            output += str(loads(message.value.decode('UTF-8'))["number"]) + ', '
+
+        # What a real implementation would do instead.
+        # for message in consumer:
+        #     output += loads(message.value.decode('UTF-8'))["number"]
+
+        return output
+    
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/memcached
+++ b/docs/static/files/fetch/examples/python/memcached
@@ -1,0 +1,32 @@
+
+import pymemcache
+from platformshconfig import Config
+
+
+def usage_example():
+
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # Get the credentials to connect to the Memcached service.
+    credentials = config.credentials('memcached')
+
+    try:
+        # Try connecting to Memached server.
+        memcached = pymemcache.Client((credentials['host'], credentials['port']))
+        memcached.set('Memcached::OPT_BINARY_PROTOCOL', True)
+
+        key = "Deploy_day"
+        value = "Friday"
+
+        # Set a value.
+        memcached.set(key, value)
+
+        # Read it back.
+        test = memcached.get(key)
+
+        return 'Found value <strong>{0}</strong> for key <strong>{1}</strong>.'.format(test.decode("utf-8"), key)
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/mongodb
+++ b/docs/static/files/fetch/examples/python/mongodb
@@ -1,0 +1,46 @@
+from pymongo import MongoClient
+from platformshconfig import Config
+
+
+def usage_example():
+
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # The 'database' relationship is generally the name of primary SQL database of an application.
+    # It could be anything, though, as in the case here here where it's called "mongodb".
+    credentials = config.credentials('mongodb')
+
+    try:
+        formatted = config.formatted_credentials('mongodb', 'pymongo')
+
+        server = '{0}://{1}:{2}@{3}'.format(
+            credentials['scheme'],
+            credentials['username'],
+            credentials['password'],
+            formatted
+        )
+
+        client = MongoClient(server)
+
+        collection = client.main.starwars
+
+        post = {
+            "name": "Rey",
+            "occupation": "Jedi"
+        }
+
+        post_id = collection.insert_one(post).inserted_id
+
+        document = collection.find_one(
+            {"_id": post_id}
+        )
+
+        # Clean up after ourselves.
+        collection.drop()
+
+        return 'Found {0} ({1})<br />'.format(document['name'], document['occupation'])
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/mysql
+++ b/docs/static/files/fetch/examples/python/mysql
@@ -1,0 +1,72 @@
+import pymysql
+from platformshconfig import Config
+
+
+def usage_example():
+
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # The 'database' relationship is generally the name of primary SQL database of an application.
+    # That's not required, but much of our default automation code assumes it.'
+    credentials = config.credentials('database')
+
+    try:
+        # Connect to the database using PDO. If using some other abstraction layer you would inject the values
+        # from `database` into whatever your abstraction layer asks for.
+
+        conn = pymysql.connect(host=credentials['host'],
+                               port=credentials['port'],
+                               database=credentials['path'],
+                               user=credentials['username'],
+                               password=credentials['password'])
+
+        sql = '''
+                CREATE TABLE People (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(30) NOT NULL,
+                city VARCHAR(30) NOT NULL
+                )
+                '''
+
+        cur = conn.cursor()
+        cur.execute(sql)
+
+        sql = '''
+                INSERT INTO People (name, city) VALUES
+                ('Neil Armstrong', 'Moon'),
+                ('Buzz Aldrin', 'Glen Ridge'),
+                ('Sally Ride', 'La Jolla');
+                '''
+
+        cur.execute(sql)
+
+        # Show table.
+        sql = '''SELECT * FROM People'''
+        cur.execute(sql)
+        result = cur.fetchall()
+
+        table = '''<table>
+<thead>
+<tr><th>Name</th><th>City</th></tr>
+</thead>
+<tbody>'''
+
+        if result:
+            for record in result:
+                table += '''<tr><td>{0}</td><td>{1}</td><tr>\n'''.format(record[1], record[2])
+            table += '''</tbody>\n</table>\n'''
+
+        # Drop table
+        sql = '''DROP TABLE People'''
+        cur.execute(sql)
+
+        # Close communication with the database
+        cur.close()
+        conn.close()
+
+        return table
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/postgresql
+++ b/docs/static/files/fetch/examples/python/postgresql
@@ -1,0 +1,79 @@
+import psycopg2
+from platformshconfig import Config
+
+
+def usage_example():
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # The 'database' relationship is generally the name of primary SQL database of an application.
+    # That's not required, but much of our default automation code assumes it.' \
+    database = config.credentials('postgresql')
+
+    try:
+        # Connect to the database.
+        conn_params = {
+            'host': database['host'],
+            'port': database['port'],
+            'dbname': database['path'],
+            'user': database['username'],
+            'password': database['password']
+        }
+
+        conn = psycopg2.connect(**conn_params)
+
+        # Open a cursor to perform database operations.
+        cur = conn.cursor()
+
+        cur.execute("DROP TABLE IF EXISTS People")
+
+        # Creating a table.
+        sql = '''
+                CREATE TABLE IF NOT EXISTS People (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(30) NOT NULL,
+                city VARCHAR(30) NOT NULL
+                )
+                '''
+
+        cur.execute(sql)
+
+        # Insert data.
+        sql = '''
+                INSERT INTO People (name, city) VALUES
+                ('Neil Armstrong', 'Moon'),
+                ('Buzz Aldrin', 'Glen Ridge'),
+                ('Sally Ride', 'La Jolla');
+                '''
+
+        cur.execute(sql)
+
+        # Show table.
+        sql = '''SELECT * FROM People'''
+        cur.execute(sql)
+        result = cur.fetchall()
+
+        table = '''<table>
+<thead>
+<tr><th>Name</th><th>City</th></tr>
+</thead>
+<tbody>'''
+
+        if result:
+            for record in result:
+                table += '''<tr><td>{0}</td><td>{1}</td><tr>\n'''.format(record[1], record[2])
+            table += '''</tbody>\n</table>\n'''
+
+        # Drop table
+        sql = "DROP TABLE People"
+        cur.execute(sql)
+
+        # Close communication with the database
+        cur.close()
+        conn.close()
+
+        return table
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/rabbitmq
+++ b/docs/static/files/fetch/examples/python/rabbitmq
@@ -1,0 +1,48 @@
+
+import pika
+from platformshconfig import Config
+
+
+def usage_example():
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # Get the credentials to connect to the RabbitMQ service.
+    credentials = config.credentials('rabbitmq')
+
+    try:
+        # Connect to the RabbitMQ server
+        creds = pika.PlainCredentials(credentials['username'], credentials['password'])
+        parameters = pika.ConnectionParameters(credentials['host'], credentials['port'], credentials=creds)
+
+        connection = pika.BlockingConnection(parameters)
+        channel = connection.channel()
+
+        # Check to make sure that the recipient queue exists
+        channel.queue_declare(queue='deploy_days')
+
+        # Try sending a message over the channel
+        channel.basic_publish(exchange='',
+                              routing_key='deploy_days',
+                              body='Friday!')
+
+        # Receive the message
+        def callback(ch, method, properties, body):
+            print(" [x] Received {}".format(body))
+
+        # Tell RabbitMQ that this particular function should receive messages from our 'hello' queue
+        channel.basic_consume('deploy_days',
+                              callback,
+                              auto_ack=False)
+
+        # This blocks on waiting for an item from the queue, so comment it out in this demo script.
+        # print(' [*] Waiting for messages. To exit press CTRL+C')
+        # channel.start_consuming()
+
+        connection.close()
+
+        return " [x] Sent 'Friday!'<br/>"
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/redis
+++ b/docs/static/files/fetch/examples/python/redis
@@ -1,0 +1,29 @@
+from redis import Redis
+from platformshconfig import Config
+
+
+def usage_example():
+
+    # Create a new config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    # Get the credentials to connect to the Redis service.
+    credentials = config.credentials('redis')
+
+    try:
+        redis = Redis(credentials['host'], credentials['port'])
+
+        key = "Deploy day"
+        value = "Friday"
+
+        # Set a value
+        redis.set(key, value)
+
+        # Read it back
+        test = redis.get(key)
+
+        return 'Found value <strong>{0}</strong> for key <strong>{1}</strong>.'.format(test.decode("utf-8"), key)
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/python/solr
+++ b/docs/static/files/fetch/examples/python/solr
@@ -1,0 +1,44 @@
+
+import pysolr
+from xml.etree import ElementTree as et
+import json
+from platformshconfig import Config
+
+
+def usage_example():
+
+    # Create a new Config object to ease reading the Platform.sh environment variables.
+    # You can alternatively use os.environ yourself.
+    config = Config()
+
+    try:
+        # Get the pysolr-formatted connection string.
+        formatted_url = config.formatted_credentials('solr', 'pysolr')
+
+        # Create a new Solr Client using config variables
+        client = pysolr.Solr(formatted_url)
+
+        # Add a document
+        message = ''
+        doc_1 = {
+            "id": 123,
+            "name": "Valentina Tereshkova"
+        }
+
+        result0 = client.add([doc_1], commit=True)
+        client.commit()
+        message += 'Adding one document. Status (0 is success): {} <br />'.format(json.loads(result0)['responseHeader']['status'])
+
+        # Select one document
+        query = client.search('*:*')
+        message += '\nSelecting documents (1 expected): {} <br />'.format(str(query.hits))
+
+        # Delete one document
+        result1 = client.delete(doc_1['id'])
+        client.commit()
+        message += '\nDeleting one document. Status (0 is success): {}'.format(et.fromstring(result1)[0][0].text)
+
+        return message
+
+    except Exception as e:
+        return e

--- a/docs/static/files/fetch/examples/relationships/elasticsearch
+++ b/docs/static/files/fetch/examples/relationships/elasticsearch
@@ -1,0 +1,18 @@
+{
+    "username": null,
+    "scheme": "http",
+    "service": "elasticsearch77",
+    "fragment": null,
+    "ip": "169.254.57.6",
+    "hostname": "jmgjydr275pkj5v7prdj2asgxm.elasticsearch77.service._.eu-3.platformsh.site",
+    "public": false,
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "elasticsearch.internal",
+    "rel": "elasticsearch",
+    "query": [],
+    "path": null,
+    "password": null,
+    "type": "elasticsearch:7.7",
+    "port": 9200,
+    "host_mapped": false
+}

--- a/docs/static/files/fetch/examples/relationships/influxdb
+++ b/docs/static/files/fetch/examples/relationships/influxdb
@@ -1,0 +1,11 @@
+{
+    "service": "influxdb18",
+    "ip": "169.254.234.110",
+    "hostname": "duqbjfn7t4dwr2fi2o7bsvqafy.influxdb18.service._.eu-3.platformsh.site",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "influxdb.internal",
+    "rel": "influxdb",
+    "scheme": "http",
+    "type": "influxdb:1.8",
+    "port": 8086
+}

--- a/docs/static/files/fetch/examples/relationships/kafka
+++ b/docs/static/files/fetch/examples/relationships/kafka
@@ -1,0 +1,11 @@
+{
+    "service": "kafka25",
+    "ip": "169.254.46.170",
+    "hostname": "t7lv3t3ttyh3vyrzgqguj5upwy.kafka25.service._.eu-3.platformsh.site",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "kafka.internal",
+    "rel": "kafka",
+    "scheme": "kafka",
+    "type": "kafka:2.5",
+    "port": 9092
+}

--- a/docs/static/files/fetch/examples/relationships/memcached
+++ b/docs/static/files/fetch/examples/relationships/memcached
@@ -1,0 +1,11 @@
+{
+    "service": "memcached16",
+    "ip": "169.254.34.86",
+    "hostname": "3sdm72jgaxge2b6aunxdlzxyea.memcached16.service._.eu-3.platformsh.site",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "memcached.internal",
+    "rel": "memcached",
+    "scheme": "memcached",
+    "type": "memcached:1.6",
+    "port": 11211
+}

--- a/docs/static/files/fetch/examples/relationships/mongodb
+++ b/docs/static/files/fetch/examples/relationships/mongodb
@@ -1,0 +1,17 @@
+{
+    "username": "main",
+    "scheme": "mongodb",
+    "service": "mongodb36",
+    "ip": "169.254.170.40",
+    "hostname": "blbczy5frqpkt2sfkj2w3zk72q.mongodb36.service._.eu-3.platformsh.site",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "mongodb.internal",
+    "rel": "mongodb",
+    "path": "main",
+    "query": {
+        "is_master": true
+    },
+    "password": "main",
+    "type": "mongodb:3.6",
+    "port": 27017
+}

--- a/docs/static/files/fetch/examples/relationships/mysql
+++ b/docs/static/files/fetch/examples/relationships/mysql
@@ -1,0 +1,20 @@
+{
+    "username": "user",
+    "scheme": "mysql",
+    "service": "mariadb104",
+    "fragment": null,
+    "ip": "169.254.135.53",
+    "hostname": "e3wffyxtwnrxujeyg5u3kvqi6y.mariadb104.service._.eu-3.platformsh.site",
+    "public": false,
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "mysql.internal",
+    "rel": "mysql",
+    "query": {
+        "is_master": true
+    },
+    "path": "main",
+    "password": "",
+    "type": "mariadb:10.4",
+    "port": 3306,
+    "host_mapped": false
+}

--- a/docs/static/files/fetch/examples/relationships/postgresql
+++ b/docs/static/files/fetch/examples/relationships/postgresql
@@ -1,0 +1,17 @@
+{
+    "username": "main",
+    "scheme": "pgsql",
+    "service": "postgresql12",
+    "ip": "169.254.114.234",
+    "hostname": "zydalrxgkhif2czr3xqth3qkue.postgresql12.service._.eu-3.platformsh.site",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "postgresql.internal",
+    "rel": "postgresql",
+    "path": "main",
+    "query": {
+        "is_master": true
+    },
+    "password": "main",
+    "type": "postgresql:12",
+    "port": 5432
+}

--- a/docs/static/files/fetch/examples/relationships/rabbitmq
+++ b/docs/static/files/fetch/examples/relationships/rabbitmq
@@ -1,0 +1,18 @@
+{
+    "username": "guest",
+    "scheme": "amqp",
+    "service": "rabbitmq38",
+    "fragment": null,
+    "ip": "169.254.232.78",
+    "hostname": "iwrccysk3gpam2zdlwdr5fgs2y.rabbitmq38.service._.eu-3.platformsh.site",
+    "public": false,
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "rabbitmq.internal",
+    "rel": "rabbitmq",
+    "query": [],
+    "path": null,
+    "password": "guest",
+    "type": "rabbitmq:3.8",
+    "port": 5672,
+    "host_mapped": false
+}

--- a/docs/static/files/fetch/examples/relationships/redis
+++ b/docs/static/files/fetch/examples/relationships/redis
@@ -1,0 +1,18 @@
+{
+    "username": null,
+    "scheme": "redis",
+    "service": "redis6",
+    "fragment": null,
+    "ip": "169.254.25.97",
+    "hostname": "7mnenhdiz7ecraovljrba6pmiy.redis6.service._.eu-3.platformsh.site",
+    "public": false,
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "redis.internal",
+    "rel": "redis",
+    "query": [],
+    "path": null,
+    "password": null,
+    "type": "redis:6.0",
+    "port": 6379,
+    "host_mapped": false
+}

--- a/docs/static/files/fetch/examples/relationships/solr
+++ b/docs/static/files/fetch/examples/relationships/solr
@@ -1,0 +1,12 @@
+{
+    "service": "solr86",
+    "ip": "169.254.251.226",
+    "hostname": "csjsvtdhmjrdre2uaoeim22xjy.solr86.service._.eu-3.platformsh.site",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "host": "solr.internal",
+    "rel": "solr",
+    "path": "solr\/maincore",
+    "scheme": "solr",
+    "type": "solr:8.6",
+    "port": 8080
+}

--- a/docs/static/scripts/fetch-examples.mjs
+++ b/docs/static/scripts/fetch-examples.mjs
@@ -31,8 +31,17 @@ function ensureSubdir(savePath) {
 async function writeFileFromTarget(target, destination) {
     // Get the file.
     console.log("Fetching", target);
-    const res = await axios.get(target, {responseType: 'arraybuffer'})
-    .catch(error => console.error(`The target ${target} returned an error with code ${error.response.status} and text ${error.response.statusText}`));
+    const res = await axios.get(target, {responseType: 'arraybuffer', timeout: 60000}) // wait 1 minute for a response
+    .catch(error => {
+        // If there's a response from the server, such as 404 or 502
+        if (error.response) {
+            console.error(`The target ${target} returned an error with the code ${error.response.status} and the text '${error.response.statusText}'.`)
+        }
+        // If the request times out or has some other failure
+        else {
+            console.error(`The request to ${target} failed for this reason: ${error.message}.`)
+        }
+    });
     if (res && res.data){
         await fsPromises.writeFile(destination, res.data);
     }

--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -10,6 +10,8 @@ Cloudwatt
 denylist
 Drush
 Fastly
+Galera
+geocod[er|ing]
 glibc
 Goldmark
 hostname
@@ -19,8 +21,10 @@ jpegoptim
 Magento
 Mailchimp
 Memcache
+middleware
 multifactor
 multithread[ed|ing]
+namespace
 [Nn]ginx
 optipng
 pngcrush


### PR DESCRIPTION
Builds currently fail because examples aren't returned. This PR should allow the builds to complete,
by adding a timeout and using the current examples as fallbacks if the examples can't be fetched.
They should be overwritten by anything new.
