### PR TITLE
feat: add how-to template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ For style and formatting guidance, see:
 
 ## Adding pages
 
+To get a head start on your page, copy one of the [templates](/docs/templates).
+
 All file names should end in `.md`.
 They should be all lowercase
 and match the page title or a short version of it.

--- a/contributing/markup-format.md
+++ b/contributing/markup-format.md
@@ -190,6 +190,7 @@ highlight=php
 
 ---
 title=Memcached
+file=none
 highlight=python
 ---
 
@@ -201,8 +202,8 @@ from jwcrypto import jws, jwk
 Property    | Description
 ------------|-----------
 `title`     | The title that appears on the tab.
-`highlight` | The language to use for highlighting, as in [code blocks](#code).
-`file`      | Optional. If present, the displayed code comes from the specified local file.
+`highlight` | The language to use for highlighting, as in [code blocks](#code). If set to `false`, content renders as Markdown.
+`file`      | If not set to `none`, the displayed code comes from the specified local file.
 
 ## Reusing content
 

--- a/docs/templates/how-to.md
+++ b/docs/templates/how-to.md
@@ -17,39 +17,44 @@ How to use
 -->
 
 Introduce the topic in 1 or 2 sentences.
-Include reasons why a person might want to do it
+Include reasons why the reader might want to do it
 (the most common use cases).
 Also include what the goal of the task is.
 
 ## Before you begin
 
 Include here any terms the reader might need
-(either defined here or linked to a definition).
-Also any prerequisites they might need to install/know,
+that they might not be familiar with
+(like terms specific to Platform.sh).
+Either define them here or link to a definition elsewhere in the docs.
+
+Also include any prerequisites they might need to install/know,
 such as having the CLI installed or having created a project.
+
 For tasks like installing the CLI,
 link to instructions rather than including them here.
 
-## 1. Do this first
+## 1. Do this step first
 
-This starts the list of steps readers must do in order.
-Order them with numbers.
+This starts the list of steps readers must do in order
+(each step is a separate section in the document).
+Order the steps with numbers.
 The titles should be bare infinitives: https://developers.google.com/style/headings?hl=en
 
 Introduce the purpose of this step very briefly.
 
-Then use an ordered list for the actions to take:
+Then use an ordered list for the actions to take to complete the step:
 
-1. Do this first.
-1. Do this next.
-1. Do this third.
-1. Do this fourth.
+1. Do this action first.
+1. Do this action next.
+1. Do this action third.
+1. Do this action fourth.
 
 Include a short example of what the expected outcome of this step is,
 such as a code example, a description of what the user can do now,
 or (if absolutely necessary) a screenshot.
 
-## 2. Do this second
+## 2. Do this step second
 
 Split into separate steps when there are more than 5--7 actions in a step.
 Also when each separate step has an outcome that be described or shown.
@@ -68,10 +73,10 @@ file=none
 highlight=false
 ---
 
-1. Do this first with the CLI.
-1. Do this next with the CLI.
-1. Do this third with the CLI.
-1. Do this fourth with the CLI.
+1. Do this action first with the CLI.
+1. Do this action next with the CLI.
+1. Do this action third with the CLI.
+1. Do this action fourth with the CLI.
 
 <--->
 
@@ -81,10 +86,10 @@ file=none
 highlight=false
 ---
 
-1. Do this first in the console.
-1. Do this next in the console.
-1. Do this third in the console.
-1. Do this fourth in the console.
+1. Do this action first in the console.
+1. Do this action next in the console.
+1. Do this action third in the console.
+1. Do this action fourth in the console.
 
 {{< /codetabs >}}
 

--- a/docs/templates/how-to.md
+++ b/docs/templates/how-to.md
@@ -1,0 +1,117 @@
+---
+title: Add a title (using an infinitive like this one)
+sidebarTitle: Optional short title if 'title' is long
+description: A short description (up to ~160 characters) of the article that should make sense out of context (like on a listing page).
+---
+
+<!-- 
+When to use
+  When there is a single outcome a user wants to archieve.
+  When you want to explain how to get to the outcome in ordered steps.
+  https://diataxis.fr/how-to-guides/ 
+
+How to use
+  1. Copy this template into the right directory in /src/docs/.
+  2. Rename it to match the title.
+  3. Replace the following content with your own.
+-->
+
+Introduce the topic in 1 or 2 sentences.
+Include reasons why a person might want to do it
+(the most common use cases).
+Also include what the goal of the task is.
+
+## Before you begin
+
+Include here any terms the reader might need
+(either defined here or linked to a definition).
+Also any prerequisites they might need to install/know,
+such as having the CLI installed or having created a project.
+For tasks like installing the CLI,
+link to instructions rather than including them here.
+
+## 1. Do this first
+
+This starts the list of steps readers must do in order.
+Order them with numbers.
+The titles should be bare infinitives: https://developers.google.com/style/headings?hl=en
+
+Introduce the purpose of this step very briefly.
+
+Then use an ordered list for the actions to take:
+
+1. Do this first.
+1. Do this next.
+1. Do this third.
+1. Do this fourth.
+
+Include a short example of what the expected outcome of this step is,
+such as a code example, a description of what the user can do now,
+or (if absolutely necessary) a screenshot.
+
+## 2. Do this second
+
+Split into separate steps when there are more than 5--7 actions in a step.
+Also when each separate step has an outcome that be described or shown.
+
+Introduce the purpose of this step very briefly.
+
+Use an ordered list for the actions to take.
+If the intended audience might be likely to do things in multiple ways,
+split the various ways into tabs so users only see what's relevant to them:
+
+{{< codetabs >}}
+
+---
+title=Using the CLI
+file=none
+highlight=false
+---
+
+1. Do this first with the CLI.
+1. Do this next with the CLI.
+1. Do this third with the CLI.
+1. Do this fourth with the CLI.
+
+<--->
+
+---
+title=In the console
+file=none
+highlight=false
+---
+
+1. Do this first in the console.
+1. Do this next in the console.
+1. Do this third in the console.
+1. Do this fourth in the console.
+
+{{< /codetabs >}}
+
+Include a short example of what the expected outcome of this step is.
+
+## 3. Run these commands
+
+The examples can include commands to run.
+Start by introducing the purpose of this step very briefly.
+
+Use an ordered list for the actions to take:
+
+1. Run `command --options`.
+1. Run `other_command --options`.
+1. Run `third_command --options`.
+
+Include a short example of what the expected outcome of this step is.
+
+```yaml
+outcome:
+    yaml:
+      - beautiful
+      - clean
+      - optimized
+```
+
+## What's next
+
+Include an example of the expected outcome for the task as a whole.
+Link to any further information or other tasks they might want to do next.


### PR DESCRIPTION
The other option would be to have separate template files and explanation files, like the Good Docs Project does: https://github.com/thegooddocsproject/templates/tree/dev/how-to I prefer having the instructions in the file and demonstrating as much as possible through examples rather than explanations. But I'm open to other ways.