### PR TITLE
Use production environment type instead of branch name

### DIFF
--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -65,23 +65,21 @@ Automated backups using cron requires you to [get an API token and install the C
 
 We ask that you not schedule a backup task more than once a day to minimize data usage.
 
-Once the CLI is installed in your application container and an API token configured you can add a cron task to run once a day and trigger a backup.  The CLI will read the existing environment variables in the container and default to the project and environment it is running on. In most cases such backups are only useful on the `master` production environment.
+Once the CLI is installed in your application container and an API token configured you can add a cron task to run once a day and trigger a backup.  The CLI will read the existing environment variables in the container and default to the project and environment it is running on. In most cases such backups are only useful on the production environment.
 
-A common cron specification for a daily backup on the `master` environment looks like this:
+A common cron specification for a daily backup on the production environment looks like this:
 
 ```yaml
 crons:
     backup:
         spec: '0 5 * * *'
         cmd: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
+            if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
                 platform backup:create --yes --no-wait
             fi
 ```
 
-(If you have [renamed the default branch](/guides/general/default-branch.md) from `master` to something else, modify the above example accordingly.)
-
-The above cron task will run once a day at 5 am (UTC), and, if the current environment is the master branch, it will run `platform backup:create` on the current project and environment.  The `--yes` flag will skip any user-interaction.  The `--no-wait` flag will cause the command to complete immediately rather than waiting for the backup to complete.
+The above cron task will run once a day at 5 am (UTC), and, if the current environment is the production environment, it will run `platform backup:create` on the current project and environment.  The `--yes` flag will skip any user-interaction.  The `--no-wait` flag will cause the command to complete immediately rather than waiting for the backup to complete.
 
 {{< note >}}
 It is very important to include the `--no-wait` flag.  If you do not, the cron process will block and you will be unable to deploy new versions of the site until the backup creation process is complete.

--- a/docs/src/configuration/app/build.md
+++ b/docs/src/configuration/app/build.md
@@ -158,17 +158,15 @@ hooks:
 
 The `deploy` and `post_deploy` hooks have access to all of the same [environment variables](/development/variables.md) as the application does normally, which makes it possible to vary those hooks based on the environment.  A common example is to enable certain modules only in non-production environments.  Because the hook is simply a shell script we have full access to all shell scripting capabilities, such as `if/then` directives.
 
-The following example checks the `$PLATFORM_BRANCH` variable to see if we're in a production environment (the `master` branch) or not.
+The following example checks the `$PLATFORM_ENVIRONMENT_TYPE` variable to see if we're in a production environment or not.
 
 ```yaml
 hooks:
     deploy: |
-        if [ "$PLATFORM_BRANCH" = master ]; then
-            # Run commands only when deploying on master
+        if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
+            # Run commands only when deploying to production
         else
-            # Run commands only when deploying on dev environments
+            # Run commands only when deploying on development or staging environments
         fi
         # Commands to run regardless of the environment
 ```
-
-(If you have [renamed the default branch](/guides/general/default-branch.md) from `master` to something else, modify the above example accordingly.)

--- a/docs/src/configuration/app/timezone.md
+++ b/docs/src/configuration/app/timezone.md
@@ -26,7 +26,7 @@ crons:
     backup:
         spec: '25 1 * * *'
         cmd: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
+            if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
                 platform backup:create --yes --no-wait
             fi
 ```

--- a/docs/src/development/cli/api-tokens.md
+++ b/docs/src/development/cli/api-tokens.md
@@ -93,7 +93,7 @@ crons:
     backup:
         spec: '0 5 * * *'
         cmd: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
+            if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
                 platform backup:create --yes --no-wait
             fi
 ```

--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -24,9 +24,12 @@ If variables have the same names at different levels, the [variables are given p
 
 ### Use application-provided variables
 
-Set variables [in code](/configuration/app/variables.md) using the `.platform.app.yaml` file. These values will be the same across all environments and present in the Git repository, which makes them a poor fit for API keys and other such secrets.
+Set variables [in code](/configuration/app/variables.md) using the `.platform.app.yaml` file.
+These values are the same across all environments and present in the Git repository,
+which makes them a poor fit for API keys and other such secrets.
 
-They are better fits for uses such as configuration for consistent builds across every environment, including setting [PHP configuration values](#php-specific-variables).
+They're better fits for uses such as configuration for consistent builds across every environment,
+including setting [PHP configuration values](#php-specific-variables).
 
 Application variables are available at both build time and runtime.
 
@@ -49,7 +52,7 @@ Variables have several Boolean options you can set in the console or the CLI:
 | Option    | CLI flag            | Default | Description |
 | --------- | ------------------- | ------- | ----------- |
 | JSON      | `--json`            | `false` | Whether the variable is a JSON-serialized value (`true`) or a string (`false`). |
-| Sensitive | `--sensitive`       | `false` | If set to `true`, the variable's value is hidden in the console and in CLI responses for added security. It is still readable within the app container. |
+| Sensitive | `--sensitive`       | `false` | If set to `true`, the variable's value is hidden in the console and in CLI responses for added security. It's still readable within the app container. |
 | Runtime   | `--visible-runtime` | `true`  | Whether the variable is available at runtime. |
 | Build     | `--visible-build`   | `true`  | Whether the variable is available at build time. |
 
@@ -97,7 +100,9 @@ $ platform variable:create -e main --name paypal_id --inheritable false --sensit
 
 Other environments don't inherit it and get either a project variable of the same name if it exists or no value at all. 
 
-Note that changing an environment variable causes that environment to be redeployed so the new value is available. However, child environments are *not* redeployed. To make the new value accessible to those environments, redeploy them manually.
+Note that changing an environment variable causes that environment to be redeployed so the new value is available.
+However, child environments are *not* redeployed.
+To make the new value accessible to those environments, redeploy them manually.
 
 #### Example environment variable
 
@@ -110,15 +115,21 @@ $ platform variable:create -l environment -e main --prefix env: --name NODE_ENV 
 $ platform variable:create -l environment -e staging --prefix env: --name NODE_ENV --value development --visible-build true --inheritable true
 ```
 
-Now `NODE_ENV` is `production` on the default branch but `development` on staging and each of its child environments. Note that build visible environment variables change the application's build configuration ID: value updates will trigger a rebuild of the application in the same way that a commit would. 
+Now `NODE_ENV` is `production` on the default branch but `development` on staging and each of its child environments.
+Note that build visible environment variables change the application's build configuration ID:
+value updates trigger a rebuild of the application in the same way that a commit would. 
 
 ### Use Platform.sh-provided variables
 
-Platform.sh also provides a series of variables by default that inform an application about its runtime configuration. They are always prefixed with `PLATFORM_*` to differentiate them from user-provided values and you can't set or update them directly.
+Platform.sh also provides a series of variables by default that inform an application about its runtime configuration.
+They're always prefixed with `PLATFORM_*` to differentiate them from user-provided values
+and you can't set or update them directly.
 
-The most important of these variables is relationship information, which tells the application how to connect to databases and other services defined in `services.yaml`. 
+The most important of these variables is relationship information,
+which tells the application how to connect to databases and other services defined in `services.yaml`. 
 
-The following table presents the available variables and whether they are available during builds and at runtime.
+The following table presents the available variables 
+and whether they're available during builds and at runtime.
 
 | Variable name             | Build | Runtime | Description |
 | ------------------------- | ----- | ------- | ----------- |
@@ -147,16 +158,20 @@ Dedicated instances also have the following variables available:
 | PLATFORM_PROJECT | No    | Yes     | The document root. Typically the same as your cluster name for the production environment, while staging environments have `_stg` or similar appended. |
 
 {{< note >}}
-The `PLATFORM_CLUSTER`, and `PLATFORM_PROJECT` environment variables are not yet available on [Dedicated Generation 3](/dedicated-gen-3/overview.md). If your application contains logic that depends on whether it is running on a Dedicated Generation 3 host, use `PLATFORM_MODE`.
+The `PLATFORM_CLUSTER`, and `PLATFORM_PROJECT` environment variables aren't yet available on [Dedicated Generation 3](/dedicated-gen-3/overview.md).
+If your application contains logic that depends on whether it is running on a Dedicated Generation 3 host, use `PLATFORM_MODE`.
 {{< /note >}}
 
 #### `PLATFORM_APPLICATION`
 
 `PLATFORM_APPLICATION` is a special case to keep in mind in how it differs between the build and runtime. Each environment's build is associated with a configuration ID that uniquely identifies it. This ID enables reusing builds on merges. The ID itself is a product of your application code and some of its configuration for Platform.sh in `.platform.app.yaml`. 
 
-Not every attribute in `.platform.app.yaml` is relevant to builds -- only some of these attributes result in a full app rebuild when they are updated. So not all of the attributes defined in your `.platform.app.yaml` file are accessible at build time from `PLATFORM_APPLICATION`, only those actually relevant to builds are.
+Not every attribute in `.platform.app.yaml` is relevant to builds --
+only some of these attributes result in a full app rebuild when they're updated.
+So not all of the attributes defined in your `.platform.app.yaml` file are accessible at build time from `PLATFORM_APPLICATION`,
+only those actually relevant to builds.
 
-Some attributes that are **not** available in `PLATFORM_APPLICATION` during builds are:
+Some attributes that are **not** available in `PLATFORM_APPLICATION` during builds:
 
 - everything under `resources`
 - `size`
@@ -169,7 +184,10 @@ Some attributes that are **not** available in `PLATFORM_APPLICATION` during buil
 - everything under  `web`, except `web.mounts`
 - everything under `workers`, except `workers.mounts`
 
-The above attributes are not visible during build because they are not included as a part of the configuration component of the build slug. So modifying any of these values in `.platform.app.yaml` does not trigger an app rebuild, only a redeploy. For more information, please read more about [how builds work](/bestpractices/environment-build.md#how-build-works) on Platform.sh.
+The above attributes aren't visible during build
+because they aren't included as a part of the configuration component of the build slug.
+So modifying any of these values in `.platform.app.yaml` doesn't trigger an app rebuild, only a redeploy.
+For more information, read more about [how builds work](/bestpractices/environment-build.md#how-build-works).
 
 ## Accessing variables
 

--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -133,6 +133,7 @@ The following table presents the available variables and whether they are availa
 | PLATFORM_BRANCH           | No    | Yes     | The name of the Git branch. |
 | PLATFORM_DOCUMENT_ROOT    | No    | Yes     | The absolute path to the web document root, if applicable. |
 | PLATFORM_ENVIRONMENT      | No    | Yes     | The name of the Platform.sh environment. |
+| PLATFORM_ENVIRONMENT_TYPE | No    | Yes     | The type of the Platform.sh environment (development, staging or production). |
 | PLATFORM_SMTP_HOST        | No    | Yes     | The SMTP host to send email messages through. Is empty when mail is disabled for the current environment. |
 | PLATFORM_RELATIONSHIPS    | No    | Yes     | A base64-encoded JSON object of relationships. The keys are the relationship name and the values are arrays of relationship endpoint definitions. The exact format is defined for each [service](/configuration/services/_index.md). |
 | PLATFORM_ROUTES           | No    | Yes     | A base64-encoded JSON object that describes the routes for the environment. It maps the content of the `.platform/routes.yaml` file. |
@@ -460,30 +461,16 @@ export PATH=/app/vendor/bin:$PATH
 
 Note that the file is sourced after all other environment variables above are defined, so they will be available to the script. That also means the `.environment` script has the "last word" on environment variable values and can override anything it wants to.
 
-## Make scripts behave differently on a dedicated cluster and development
+## Make scripts behave differently on production, staging and development
 
-The following sample shell script will output a different value on the Dedicated cluster than in a development environment.
-
-```bash
-if [ "$PLATFORM_MODE" = "enterprise" ] ; then
-    echo "Hello from the Enterprise"
-else
-    echo "We're on Development"
-fi
-```
-
-## Make scripts behave differently on production and staging
-
-While both production and staging Dedicated environments have `enterprise` for the `PLATFORM_MODE` variable, you can distinguish them by branch name. So assuming the production branch is named `production`, use a test like the following:
+While both production and staging Dedicated environments have `enterprise` for the `PLATFORM_MODE` variable, you can distinguish them by environment type. Make sure that the environment types are set correctly via the CLI or the Management Console.
 
 ```bash
-if [ "$PLATFORM_MODE" = "enterprise" ] ; then
-    if [ "$PLATFORM_BRANCH" = "production" ] ; then
-        echo "This is live on production"
-    else
-        echo "This is on staging"
-    fi
+if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ] ; then
+    echo "This is live on production"
+else if [ "$PLATFORM_ENVIRONMENT_TYPE" = staging ] ; then
+    echo "This is on staging"
 else
-    echo "We're on Development"
+    echo "We're on development"
 fi
 ```

--- a/docs/src/guides/wordpress/vanilla/customize.md
+++ b/docs/src/guides/wordpress/vanilla/customize.md
@@ -29,7 +29,7 @@ Platform.sh validates and retrieves submodules in the first stages of its build 
 
 ## `.environment`
 
-Platform.sh provides multiple *environments* for your projects, that can be customized (with different values for staging and development), but that inherit features from the (`master`) production environment. One clear case where this can be useful is environment variables. Each environment on Platform.sh comes with a set of [pre-defined variables](/development/variables.html#platformsh-provided-variables) that provide information about the branch you are working on, the application's configuration, and the credentials to connect to each service defined in `services.yaml`. 
+Platform.sh provides multiple *environments* for your projects, that can be customized (with different values for staging and development), but that inherit features from the production environment. One clear case where this can be useful is environment variables. Each environment on Platform.sh comes with a set of [pre-defined variables](/development/variables.html#platformsh-provided-variables) that provide information about the branch you are working on, the application's configuration, and the credentials to connect to each service defined in `services.yaml`. 
 
 Service credentials reside in a base64 encoded JSON object variable called `PLATFORM_RELATIONSHIPS`, and it is from this variable that you can define your database connection to the MariaDB container. To make each property (username, password, etc.) more easily accessible to `wp-config.php`, you can use the pre-installed `jq` package to clean the object into individual variables.
 
@@ -45,7 +45,7 @@ export DB_PASSWORD=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".da
 export WP_HOME=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key')
 export WP_SITEURL="${WP_HOME}wp"
 export WP_DEBUG_LOG=/var/log/app.log
-if [ "$PLATFORM_BRANCH" != "master" ] ; then
+if [ "$PLATFORM_ENVIRONMENT_TYPE" != production ] ; then
     export WP_ENV='development'
 else
     export WP_ENV='production'

--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -1,3 +1,4 @@
+accessor
 advancecomp
 allowlist
 asciinema


### PR DESCRIPTION
Using the environment type instead of relying on the branch name (it's not always `master`), is the correct way to identify wether an environment is the Production environment.