### PR TITLE
Devrel 1140 add a new troubleshooting section under source integration

### DIFF
--- a/docs/src/integrations/source/troubleshooting.md
+++ b/docs/src/integrations/source/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting"
 description: |
-  Source integration troubleshooting
+  In the following section you'll find troubleshooting guidance on source integration.
 ---
 
 {{< description >}}

--- a/docs/src/integrations/source/troubleshooting.md
+++ b/docs/src/integrations/source/troubleshooting.md
@@ -6,11 +6,12 @@ description: |
 
 {{< description >}}
 
-##Troubleshooting while cloning the repository
+## Troubleshooting while cloning the repository
 
-When you set up an `[external integration](https://docs.platform.sh/integrations/source.html)` to GitHub, GitLab, or Bitbucket, an additional layer of access control gets added.
+When you set up an [external integration](https://docs.platform.sh/integrations/source.html) to GitHub, GitLab, or Bitbucket, an additional layer of access control gets added.
 
-###Example
+### Example
+
 If you invite a user with Project Administrator role to a project on Platform.sh, but you haven’t invited them to the remote repository on GitHub/ GitLab/Bitbucket, they won't be able to clone the project locally.
 
 In the following example, using either platform get with the CLI:
@@ -20,11 +21,13 @@ or the git clone command visible from the “Git” dropdown in the management c
 both would error with
 ``Failed to connect to the Git repository: git@github.com:user/github-repo.git``
 
-###Solution 1 (Recommended)
+### Solution 1 (Recommended)
+
 Ensure you have the correct access rights for the external integration repository.
 
 
-###Solution 2
+### Solution 2
+
 Clone the repository from Platform.sh, which is a repository is an read-only mirror of the external integration repository.
 
 ```bash

--- a/docs/src/integrations/source/troubleshooting.md
+++ b/docs/src/integrations/source/troubleshooting.md
@@ -1,0 +1,38 @@
+---
+title: "Troubleshooting"
+description: |
+  Source integration troubleshooting
+---
+
+{{< description >}}
+
+##Troubleshooting while cloning the repository
+
+When you set up an `[external integration](https://docs.platform.sh/integrations/source.html)` to GitHub, GitLab, or Bitbucket, an additional layer of access control gets added.
+
+###Example
+If you invite a user with Project Administrator role to a project on Platform.sh, but you haven’t invited them to the remote repository on GitHub/ GitLab/Bitbucket, they won't be able to clone the project locally.
+
+In the following example, using either platform get with the CLI:
+``$ platform get <projectID>``
+or the git clone command visible from the “Git” dropdown in the management console
+``$ git clone git@github.com:user/github-repo.git Project Name``
+both would error with
+``Failed to connect to the Git repository: git@github.com:user/github-repo.git``
+
+###Solution 1 (Recommended)
+Ensure you have the correct access rights for the external integration repository.
+
+
+###Solution 2
+Clone the repository from Platform.sh, which is a repository is an read-only mirror of the external integration repository.
+
+```bash
+$ git clone <project>@git.<region>.platform.sh:<project>.git
+```
+
+{{< note theme="warning" title="Warning" >}}
+
+Changes pushed to the Platform.sh mirror repository will be overwritten when other changes are pushed to the external integration repository.
+
+{{< /note >}}

--- a/docs/src/integrations/source/troubleshooting.md
+++ b/docs/src/integrations/source/troubleshooting.md
@@ -14,17 +14,25 @@ When you set up an [external integration](https://docs.platform.sh/integrations/
 
 If you invite a user with Project Administrator role to a project on Platform.sh, but you haven’t invited them to the remote repository on GitHub/ GitLab/Bitbucket, they won't be able to clone the project locally.
 
-In the following example, using either platform get with the CLI:
-``$ platform get <projectID>``
-or the git clone command visible from the “Git” dropdown in the management console
-``$ git clone git@github.com:user/github-repo.git Project Name``
+In the following example, using either `platform get` with the CLI:
+```
+$ platform get <projectID>
+```
+or the `git clone` command visible from the **Git** dropdown in the management console
+
+```
+$ git clone git@github.com:user/github-repo.git Project Name
+```
+
 both would error with
-``Failed to connect to the Git repository: git@github.com:user/github-repo.git``
+
+```
+Failed to connect to the Git repository: git@github.com:user/github-repo.git
+```
 
 ### Solution 1 (Recommended)
 
 Ensure you have the correct access rights for the external integration repository.
-
 
 ### Solution 2
 
@@ -36,6 +44,6 @@ $ git clone <project>@git.<region>.platform.sh:<project>.git
 
 {{< note theme="warning" title="Warning" >}}
 
-Changes pushed to the Platform.sh mirror repository will be overwritten when other changes are pushed to the external integration repository.
+Changes pushed to the Platform.sh mirror repository are overwritten when other changes are pushed to the external integration repository.
 
 {{< /note >}}


### PR DESCRIPTION
This section was originally placed under user administration. After a chat with María we established the section should live under source integration as a troubleshooting page/container.