### PR TITLE
remove MASTER_USE_GTID from start command example

### DIFF
--- a/docs/src/guides/general/mysql-replication.md
+++ b/docs/src/guides/general/mysql-replication.md
@@ -140,8 +140,7 @@ mysql> CHANGE MASTER TO
   MASTER_PORT=3306,
   MASTER_LOG_FILE='binlogs.000002',
   MASTER_LOG_POS=1036,
-  MASTER_CONNECT_RETRY=10,
-  MASTER_USE_GTID = slave_pos;
+  MASTER_CONNECT_RETRY=10;
 ```
 
 Where `<the.host>` will vary depending on the SSH tunneling configuration you have, and the `<your_replicator_password>` can be obtained by running `platform relationships`.


### PR DESCRIPTION
With the setup provide by this guide, the "slave_pos" is an empty string when starting the replication database. This causes an error in the reading of the bin logs, as it can not find the '' location in the log. Removing this line from the slave definition allows the database to start and copy as expected.