### PR TITLE
fix: remove smart quotes

### DIFF
--- a/docs/layouts/partials/examples/relationship.html
+++ b/docs/layouts/partials/examples/relationship.html
@@ -4,6 +4,6 @@
  -->
 {{ $comment := "# .platform.app.yaml"}}
 {{ $l1 := "relationships:" }}
-{{ $l2 := printf "    relationship_name: “service_name:%s”" .endpoint}}
+{{ $l2 := printf "    relationship_name: \"service_name:%s\"" .endpoint}}
 
 {{ return (highlight (printf "%s\n%s\n%s" $comment $l1 $l2) "yaml" "") }}

--- a/docs/src/dedicated/overview/upgrading.md
+++ b/docs/src/dedicated/overview/upgrading.md
@@ -8,11 +8,16 @@ description: |
 
 {{< description >}}
 
-These older projects can be upgraded to the new Integrated UI, which eliminates the extra Git repositories, many "must be a ticket" configuration changes, and makes the Production and Staging environments available in the UI.
+These older projects can be upgraded to the new Integrated UI,
+which eliminates the extra Git repositories, many "must be a ticket" configuration changes,
+and makes the Production and Staging environments available in the UI.
 
-To add these environments to the Project Web Interface, review this entire document, complete a few preparatory steps, and submit a ticket. Your ticket is added to a queue for updating existing Dedicated projects.  The process may take time to complete, so check your ticket for details, timing, and other important information.
+To add these environments to the Project Web Interface,
+review this entire document, complete a few preparatory steps, and submit a ticket.
+Your ticket is added to a queue for updating existing Dedicated projects.
+The process may take time to complete, so check your ticket for details, timing, and other important information.
 
-We recommend this upgrade for all users.
+This upgrade is recommended for all users.
 
 ## New Features
 
@@ -35,7 +40,7 @@ You must still submit a support ticket to update and modify the following in the
 * Managing PHP extensions
 * Managing mounts
 
-You cannot perform the following:
+You can't perform the following:
 
 * Branch from the Staging and Production environments
 * Synchronize data from the Staging and Production environments
@@ -43,15 +48,18 @@ You cannot perform the following:
 
 ### Branching hierarchy
 
-Before converting your project, the branches include a repository for Development, Staging, and Production. Each repository has a master branch with deployment targets configured for Staging and Production.
+Before converting your project, the branches include a repository for Development, Staging, and Production.
+Each repository has a master branch with deployment targets configured for Staging and Production.
 
-After converting your project, the hierarchical relationships appear in your Project Web Interface with two, main environment branches for Staging and Production:
+After converting your project, the hierarchical relationships appear in your Project Web Interface
+with two main environment branches for Staging and Production:
 
 ![Production and Staging are special children of master](/images/dedicated/wings-branches.png "0.3")
 
 ## Before you upgrade
 
-When we add Staging and Production access to the Project Web Interface, we use the user accounts, branch user permissions, and environment variables from your Development master environment.
+When we add Staging and Production access to the Project Web Interface,
+we use the user accounts, branch user permissions, and environment variables from your Development master environment.
 
 To prepare, verify that your settings and environment variables are correct.
 
@@ -61,13 +69,20 @@ To prepare, verify that your settings and environment variables are correct.
 
 ### Verify code
 
-We strongly recommend working in your local development environment, deploying to Development, deploying to Staging, and, finally, deploying to Production. All code should match 100% across each of these environments. Before submitting a ticket, make sure you sync your code. This process creates a new branch of code for Staging and Production environments.
+We strongly recommend working in your local development environment,
+deploying to Development, deploying to Staging, and, finally, deploying to Production.
+All code should match 100% across each of these environments.
+Before submitting a ticket, make sure you sync your code.
+This process creates a new branch of code for Staging and Production environments.
 
-If you have additional code, such as new extensions in your Production environment without following this workflow, then deployments from Integration or Staging overwrite your Production code.
+If you have additional code, such as new extensions in your Production environment without following this workflow,
+then deployments from Integration or Staging overwrite your Production code.
 
 ### Verify user account access
 
-We recommend verifying your user account access and permissions set in the Integration environment. When adding Staging and Production to the Project Web Interface, the process includes all user accounts and settings. You can modify the settings and values for these environments after they are added.
+We recommend verifying your user account access and permissions set in the Integration environment.
+When adding Staging and Production to the Project Web Interface, the process includes all user accounts and settings.
+You can modify the settings and values for these environments after they're added.
 
 1. Log in to your Platform.sh account.
 2. From your project, click Master to view the environment information and settings.
@@ -77,7 +92,9 @@ We recommend verifying your user account access and permissions set in the Integ
 
 ### Prepare variables
 
-When we convert your project to the new Project Web Interface, we add variables from Development environment to the Staging and Production environments. You can review, modify, and add variables through the current Project Web Interface prior to conversion.
+When we convert your project to the new Project Web Interface,
+we add variables from Development environment to the Staging and Production environments.
+You can review, modify, and add variables through the current Project Web Interface prior to conversion.
 
 1. Log in to your Platform.sh account.
 2. From your project, click the master branch to view the environment information and settings.
@@ -86,15 +103,22 @@ When we convert your project to the new Project Web Interface, we add variables 
 5. To create a new variable, click Add Variable.
 6. To update an existing variable, click Edit next to the variable.
 
-For environment-specific variables, including sensitive data and values, you can add those variables after we update your Project Web Interface. Environment variables defined in `.platform.app.yaml` or a `.environment` file will continue to work. You can add and manage these variables via SSH and CLI commands directly into the Staging and Production environments.
+For environment-specific variables, including sensitive data and values,
+you can add those variables after we update your Project Web Interface.
+Environment variables defined in `.platform.app.yaml` or a `.environment` file continue to work.
+You can add and manage these variables via SSH and CLI commands directly into the Staging and Production environments.
 
 ## Enter a ticket for updating the Project Web Interface
 
-Enter a Support ticket with the suggested title “Connect Stg / Prod to Project’s UI”. In the ticket, request to have your project enabled with Staging and Production in the UI and confirm that you've taken the steps above to prepare your project.
+Enter a Support ticket with the suggested title "Connect Stg / Prod to Project’s UI".
+In the ticket, request to have your project enabled with Staging and Production in the UI
+and confirm that you've taken the steps above to prepare your project.
 
-We will review the infrastructure and settings, create user and environment variables for Staging and Production environments, and update the ticket with results.
+We will review the infrastructure and settings, create user and environment variables for Staging and Production environments,
+and update the ticket with results.
 
-Once started the process usually takes less than an hour.  There should be no downtime on your production site, although you should not push any code to Git while the upgrade is in progress.
+Once started the process usually takes less than an hour.
+There should be no downtime on your production site, although you shouldn't push any code to Git while the upgrade is in progress.
 
 When done, you can access review your project through the Project Web Interface.
 

--- a/docs/src/development/faq.md
+++ b/docs/src/development/faq.md
@@ -9,55 +9,88 @@ sidebarTitle: "FAQ"
 
 Platform or Platform.sh is the infrastructure which is running all your projects.
 
-A project is the site that you're working on.  Each project corresponds to one Git repository.  A project may contain multiple applications that will run in their own isolated containers.  Each branch of a project may be deployed in its own environment.
+A project is the site that you're working on.
+Each project corresponds to one Git repository.
+A project may contain multiple applications that run in their own isolated containers.
+Each branch of a project may be deployed in its own environment.
 
-An environment is a standalone copy of your site, complete with code, data, and running services.  The `master` branch is the production environment, while any other branch can be setup as an otherwise identical testing environment.
+An environment is a standalone copy of your site, complete with code, data, and running services.
+The `master` branch is the production environment,
+while any other branch can be setup as an otherwise identical testing environment.
 
 ## How can I cancel my subscription?
 
-If you want to delete your project and cancel your subscription, simply go to your user profile and click on "Edit plan" on the project you want to delete. Then you can click on the link: "delete your Platform.sh plan".
+If you want to delete your project and cancel your subscription,
+go to your user profile and click on **Edit plan** on the project you want to delete.
+Then click **Delete project**.
 
-This will delete your project and stop invoicing for this project. If you have multiple projects, your subscription will continue until you don't have any projects left.
+This delete your project and stops invoicing for this project.
+If you have multiple projects, your subscription continues until you don't have any projects left.
 
 ## How do I delete my Platform.sh account?
 
-If you would like to delete your Platform.sh account, log in and select "Support" from the dropdown options when you click on your avatar in the top right hand corner of the management console. Create a new ticket, and request for your account to be deleted in the form provided there. A support agent will receive your request and delete your account shortly thereafter. 
+If you would like to delete your Platform.sh account,
+log in and select "Support" from the dropdown options when you click on your avatar in the management console.
+Create a new ticket and request for your account to be deleted in the form provided there.
+A support agent will receive your request and delete your account shortly thereafter. 
 
 ## Does branching an environment duplicate services?
 
-Yes! Branching an environment creates an exact copy (snapshot) of the parent environment, containing the files, the database, and code.  Each environment runs independently of every other, so if you have four active environments then you have four copies of your application, four copies of your database, four copies of your files, etc.
+Yes! Branching an environment creates an exact copy (snapshot) of the parent environment, containing the files, the database, and code.
+Each environment runs independently of every other,
+so if you have four active environments then you have four copies of your application,
+four copies of your database, four copies of your files, and so on.
 
 ## Do you have a local writable file-system?
 
-Yes!  Platform.sh supports non-ephemeral storage.  When you configure your application you can tell it what directories you want to be read/write. (These are called [mounts](/configuration/app/storage.md).) These will be mounted on a distributed file system (which is transparent for you).  When you backup your environment they will be backed up as well.  When you create a new staging environment, these mounts will be cloned with the rest of your data.
+Yes! Platform.sh supports non-ephemeral storage.
+When you configure your application you can tell it what directories you want to be read/write.
+(These are called [mounts](/configuration/app/storage.md).)
+These are mounted on a distributed file system (which is transparent for you).
+When you backup your environment they will be backed up as well.
+When you create a new staging environment, these mounts are cloned with the rest of your data.
 
 ## What happens if I push a local branch to my project?
 
-If you push a local branch that you created with Git, you create what is called an `inactive environment`, that is, an environment that is not deployed.
+If you push a local branch that you created with Git,
+you create what's called an `inactive environment`, an environment that isn't deployed.
 
-This means there won't be any services attached to this branch.
+This means there aren't any services attached to this branch.
 
 You are able to convert an `inactive environment` into an `active environment` and vice versa back from the environment configuration page or using the CLI with `platform environment:activate`.
 
 ## How does Master (the live site) scale?
 
-The `master` environment gets a pool of resources based on your plan size, which is then split up between the applications and services you have defined.  (For example, PHP 40%, MySQL 30%, Redis 10%, Solr 20%, etc).  Increasing your plan size will increase the pool of CPU and RAM that gets split between each container.
+The `master` environment gets a pool of resources based on your plan size,
+which is then split up between the applications and services you have defined.
+(For example, PHP 40%, MySQL 30%, Redis 10%, Solr 20%, etc).
+Increasing your plan size will increase the pool of CPU and RAM that gets split between each container.
 
-All containers on development plans are "small" containers.  See the [sizing configuration page](/configuration/app/size.md) for more details.
+All containers on development plans are "small" containers.
+See the [sizing configuration page](/configuration/app/size.md) for more details.
 
 ## What exactly am I SSHing into?
 
-The `platform ssh` command allows you to log into your application container (where your PHP app or Node app or Java app is running).  It is a fully running Linux environment, but almost all of the disk will be read-only, with the exception of mounts you have defined.
+The `platform ssh` command allows you to log into your application container (where your PHP app or Node app or Java app is running).
+It's a fully running Linux environment,
+but almost all of the disk is read-only, with the exception of mounts you have defined.
 
 ## Can I edit a quick fix on a Platform environment without triggering a rebuild?
 
-No.  Changes to the code can only be made through deploying new Git commits.  That ensures that "hot patches" don't get lost in the net update, that all changes are auditable, and that if a security break-in happens the attacker still cannot modify your application code.
+No. Changes to the code can only be made through deploying new Git commits.
+That ensures that "hot patches" don't get lost in the net update, that all changes can be audited,
+and that if a security break-in happens the attacker still cannot modify your application code.
 
 ## What do I see when I push code?
 
-When you `git push` new code, Platform.sh rebuilds and redeploys the application.  What shows on the command line is the output of your build process (composer, pip, bundler, etc. plus your own build hook) followed by the deploy process.  It ends with a description of what was just deployed and the URLs that are now active.
+When you `git push` new code, Platform.sh rebuilds and redeploys the application.
+What shows on the command line is the output of your build process
+(such as Composer, pip, or Bundler plus your own build hook) followed by the deploy process.
+It ends with a description of what was just deployed and the URLs that are now active.
 
-To suppress the output, run `platform push -W`.  The `-W` means `--no-wait`, and will disconnect the connection once the commits are pushed so that you can continue to use your local terminal.  The exact same output is also available in the Web Management Console.
+To suppress the output, run `platform push -W`.
+The `-W` means `--no-wait` and disconnects the connection once the commits are pushed so that you can continue to use your local terminal.
+The exact same output is also available in the Web Management Console.
 
 ## What Linux distribution is Platform.sh using?
 
@@ -65,17 +98,25 @@ Platform.sh is built on Debian.
 
 ## If I choose the Development plan, can I use that plan for production?
 
-No.  The Development plan provides all the tools to build your website. You can create as many development profiles as you wish for yourself and for your team.  However, it does not allow for full production-level resources on the `master` branch and does not allow you to configure a custom domain name.
+No. The Development plan provides all the tools to build your website.
+You can create as many development profiles as you wish for yourself and for your team. 
+However, it doesn't allow for full production-level resources on the `master` branch
+and doesn't allow you to configure a custom domain name.
 
-Once your project is complete and ready for production, you can choose another plan to go live. These plans are available on the [pricing page](https://platform.sh/pricing).
+Once your project is complete and ready for production, you can choose another plan to go live.
+These plans are available on the [pricing page](https://platform.sh/pricing).
 
-## I am getting weird errors when I push (something with paramiko..)
+## I am getting weird errors when I push (something with `paramiko`)
 
-Please validate the syntax of your YAML file. Don't use tabs. If all fails, contact support.
+Please validate the syntax of your YAML file.
+Don't use tabs. If all fails, contact support.
 
 ## Which geographic zones does Platform.sh cover?
 
-Platform.sh works with multiple cloud infrastructure providers, including Amazon Web Services, Microsoft Azure, Google Cloud, OVHcloud and Orange.  We offer public Grid regions in several parts of the world: USA (East Coast), USA (West Coast), Canada (East Coast), Europe (Dublin), Europe (Germany), United Kingdom (London), and Australia (Sydney).
+Platform.sh works with multiple cloud infrastructure providers,
+including Amazon Web Services, Microsoft Azure, Google Cloud, OVHcloud, and Orange.
+We offer public Grid regions in several parts of the world:
+USA (East Coast), USA (West Coast), Canada (East Coast), Europe (Dublin), Europe (Germany), United Kingdom (London), and Australia (Sydney).
 
 Dedicated projects can deploy production to any public AWS or Azure region.
 
@@ -83,15 +124,22 @@ Dedicated projects can deploy production to any public AWS or Azure region.
 
 'sh' is the short version of shell.
 
-According to Wikipedia™, in computing, a [shell](https://en.wikipedia.org/wiki/Shell_(computing)) is a user interface for access to an operating system's services. Generally, operating system shells use either a [command-line interface ](https://en.wikipedia.org/wiki/Command-line_interface) (CLI) or [graphical user interface](https://en.wikipedia.org/wiki/Graphical_user_interface) (GUI).  This is exactly what Platform.sh is about: Giving developers tools to build, test, deploy, and run great websites!
+According to Wikipedia™, in computing, a [shell](https://en.wikipedia.org/wiki/Shell_(computing)) is a user interface for access to an operating system's services.
+Generally, operating system shells use either a [command-line interface ](https://en.wikipedia.org/wiki/Command-line_interface) (CLI)
+or [graphical user interface](https://en.wikipedia.org/wiki/Graphical_user_interface) (GUI).
+This is exactly what Platform.sh is about:
+Giving developers tools to build, test, deploy, and run great websites!
 
-".sh" is also the TLD for Saint Helena that looks like a lovely island, and whose motto is: "Loyal and Unshakeable" which we also strive to be.
+".sh" is also the TLD for Saint Helena that looks like a lovely island,
+and whose motto is: "Loyal and Unshakeable", which we also strive to be.
 
 ## IDE Specific Tips
 
 MAMP pro:
 
-In order for MAMP to work well with the symlinks created by the [Platform.sh CLI](https://github.com/platformsh/platformsh-cli), add the following to the section under Hosts \> Advanced called “Customized virtual host general settings.” For more details visit [MAMP Pro documentation page](https://documentation.mamp.info/).
+In order for MAMP to work well with the symlinks created by the [Platform.sh CLI](https://github.com/platformsh/platformsh-cli),
+add the following to the section under Hosts \> Advanced called "Customized virtual host general settings".
+For more details visit [MAMP Pro documentation page](https://documentation.mamp.info/).
 
 ```bash
 <Directory>
@@ -101,9 +149,13 @@ In order for MAMP to work well with the symlinks created by the [Platform.sh CLI
 ```
 
 {{< note >}}
-When you specify your document root, MAMP will follow the symlink and substitute the actual build folder path. This means that when you rebuild your project locally, you will need to repoint the docroot to the symlink again so that it will refresh the build path.
+When you specify your document root, MAMP will follow the symlink and substitute the actual build folder path.
+This means that when you rebuild your project locally,
+you need to repoint the docroot to the symlink again so that it will refresh the build path.
 {{< /note >}}
 
 ## Do you support MFA/2FA/TFA authentication?
 
-Yes. We support Multi-Factor Authentication, and encourage its use. To do so please go to your **Account Settings** on our [Account site](https://accounts.platform.sh/). Then click on the left tab called **Security** which will let you enable an **MFA Application**.
+Yes. We support multi-factor authentication (MFA), and encourage its use.
+To do so, in the management console, go to **My profile** under your name.
+Then click **Security**, where you can set up an **MFA Application**.

--- a/docs/src/overview/build-deploy.md
+++ b/docs/src/overview/build-deploy.md
@@ -3,8 +3,9 @@ title: "Build & Deploy"
 weight: 2
 ---
 
-Every time you push to a live branch (a git branch with an active environment attached to it) or activate an
-[environment](/administration/web/environments.md) for a branch, there are two main processes that happen: **Build** and **Deploy**.
+Every time you push to a live branch (a git branch with an active environment attached to it)
+or activate an [environment](/administration/web/environments.md) for a branch,
+there are two main processes that happen: **Build** and **Deploy**.
 
 1. The build process looks through the configuration files in your repository and assembles the necessary containers.  
 2. The deploy process makes those containers live, replacing the previous versions, with virtually no interruption in service.
@@ -13,38 +14,75 @@ Every time you push to a live branch (a git branch with an active environment at
 
 ## Always Be Compiling
 
-Interpreted languages like PHP or Node.js may not seem like they have to be compiled, but with modern package management tools like Composer or npm, as well as the growing use of CSS preprocessors such as Sass, most modern web applications need a "build" step between their source code and their production execution code.  At Platform.sh, we aim to make that easy.  The build step includes the entire application container&mdash;from language version to build tools to your code&mdash;rebuilt every time.
+Interpreted languages like PHP or Node.js may not seem like they have to be compiled,
+but with modern package management tools like Composer and npm as well as the growing use of CSS preprocessors such as Sass,
+most modern web applications need a "build" step between their source code and their production execution code.
+The Platform.sh build step includes the entire application container
+(from language version to build tools to your code), rebuilt every time.
 
-That build process is under your control and runs on every Git push.  Every Git push is a validation not only of your code, but of your build process.  Whether that's installing packages using Composer or Bundler, compiling TypeScript or Sass, or building your application code in Go or Java, your build process is vetted every time you push.
+That build process is under your control and runs on every Git push.
+Every Git push is a validation not only of your code, but of your build process.
+Whether that's installing packages using Composer or Bundler, compiling TypeScript or Sass,
+or building your application code in Go or Java,
+your build process is vetted every time you push.
 
-Whenever possible, you should avoid committing build assets to your repository that can be regenerated at build time.  Depending on your application, that may include 3rd party libraries and frameworks, generated and optimized CSS and JS files, generated source code, etc.
+Whenever possible, you should avoid committing build assets to your repository that can be regenerated at build time.
+Depending on your application,
+that may include third-party libraries and frameworks, generated and optimized CSS and JS files, and generated source code.
 
 The following two constraints make sure you have fast, repeatable builds:
 
-1. **The build step should be environment-independent.** This is paramount to ensure development environments are truly perfect copies of production. This means you can not connect to services (like the database) during the build.
-2. **The final built application must be read-only.** If your application requires writing to the filesystem, you can specify the directories that require Read/Write access. These should not be directories that have code, because that would be a security risk.
+1. **The build step should be environment-independent.**
+   This is paramount to ensure development environments are truly perfect copies of production.
+   This means you can not connect to services (like the database) during the build.
+2. **The final built application must be read-only.**
+   If your application requires writing to the filesystem, you can specify the directories that require Read/Write access.
+   These shouldn't be directories that have code, because that would be a security risk.
 
 ## Building the application
 
-After you push your code, the first build step is to validate your configuration files (i.e. `.platform.app.yaml`, `.platform/services.yaml`, and `.platform/routes.yaml`). The Git server will issue an error if validation fails, and nothing will happen on the server.
+After you push your code, the first build step is to validate your configuration files
+(`.platform.app.yaml`, `.platform/services.yaml`, and `.platform/routes.yaml`).
+The Git server issues an error if validation fails, and nothing happens on the server.
 
 {{< note >}}
-While most projects have a single `.platform.app.yaml` file, Platform.sh supports multiple applications in a single project.  It will scan the repository for `.platform.app.yaml` files in subdirectories and each directory containing one will be built as an independent application. A built application will not contain any directories above the one in which it is found. The system is smart enough not to rebuild applications that have already been built, so if you have multiple applications, only changed applications will be rebuilt and redeployed.
+
+While most projects have a single `.platform.app.yaml` file,
+Platform.sh supports multiple applications in a single project.
+It scans the repository for `.platform.app.yaml` files in subdirectories
+and each directory containing one is built as an independent application.
+A built application doesn't contain any directories above the one in which it's found.
+The system is smart enough not to rebuild applications that have already been built,
+so if you have multiple applications, only changed applications are rebuilt and redeployed.
+
 {{< /note >}}
 
-The live environment is composed of multiple containers&mdash;both for your application(s) and for the services it depends on. It also has a virtual network connecting them, as well as a router to route incoming requests to the appropriate application.
+The live environment is composed of multiple containers&mdash;both for your applications and for the services it depends on.
+It also has a virtual network connecting them as well as a router to route incoming requests to the appropriate application.
 
-Based on your application type the system will select one of our pre-built container images and run the following:
+Based on your application type, the system selects one of the pre-built container images and runs the following:
 
-1. First, any dependencies specified in the `.platform.app.yaml` file are installed. Those include tools like Sass, Webpack, Drupal Console, or any others that you may need.
+1. First, any dependencies specified in the `.platform.app.yaml` file are installed.
+   Those include tools like Sass, webpack, and Drupal Console.
+2. Then, depending on the build flavor specified in the configuration file, a series of standard commands is run.
+   The default for PHP containers, for example, is running `composer install`.
 
-2. Then, depending on the “build flavor” specified in the configuration file, we run a series of standard commands. The default for PHP containers, for example, is simply to run `composer install`.
+3. Finally, the build hook from the configuration file is run.
+   The build hook comprises one or more shell commands that you write to finish creating your production code base.
+   That could be compiling Sass files, running a bundler, rearranging files on disk,
+   compiling an application in a compiled language, or whatever else you want.
+   Note that, at this point, all you are able to access is the file system; there are no services or other databases available.
 
-3. Finally, we run the “build hook” from the configuration file.  The build hook comprises one or more shell commands that you write to finish creating your production code base.  That could be compiling Sass files, running a bundler, rearranging files on disk, compiling an application in a compiled language, or whatever else you want.  Note that, at this point, all you are able to access is the file system; there are no services or other databases available.
+Once all of that is completed, we freeze the file system and produce a read-only container image.
+That image is the final build artifact:
+a reliable, repeatable snapshot of your application, built the way you want, with the environment you want.
 
-Once all of that is completed, we freeze the file system and produce a read-only container image.  That image is the final build artifact: a reliable, repeatable snapshot of your application, built the way you want, with the environment you want.
-
-Because  container configuration (both for your application and its underlying services) is exclusively based on your configuration files, and your configuration files are managed through Git, we know that a given container has a 1:1 relationship with a Git commit.  That means builds are always repeatable.  It also means that if we detect that there are no changes that would affect a given container, we can skip the build step entirely and reuse the existing container image, saving a great deal of time.
+Because container configuration (for both your application and its underlying services) is exclusively based on your configuration files
+and your configuration files are managed through Git,
+we know that a given container has a 1:1 relationship with a Git commit.
+That means builds are always repeatable.
+It also means that if we detect that there are no changes that would affect a given container,
+we can skip the build step entirely and reuse the existing container image, saving a great deal of time.
 
 In practice, the entire build process usually takes less than a minute.
 
@@ -52,14 +90,29 @@ In practice, the entire build process usually takes less than a minute.
 
 Deploying the application also has several steps, although they're much quicker.
 
-First, we pause all incoming requests and hold them so that there's no interruption of service.  Then we disconnect the current containers from their file system mounts, if any, and connect the file systems to the new containers instead.  If it's a new branch and there is no existing file system, we clone it from the parent branch.
+First, we pause all incoming requests and hold them so that there's no interruption of service.
+Then we disconnect the current containers from their file system mounts, if any,
+and connect the file systems to the new containers instead.
+If it's a new branch and there is no existing file system, we clone it from the parent branch.
 
-We then open networking connections between the various containers, but only those that were specified in the configuration files (using the `relationships` key).  No configuration, no connection. That helps with security, as only those connections that are actually needed even exist.  The connection information for each service is available in an application as environment variables.
+We then open networking connections between the various containers,
+but only those that were specified in the configuration files (using the `relationships` key).
+No configuration, no connection.
+That helps with security, as only those connections that are actually needed even exist.
+The connection information for each service is available in an application as environment variables.
 
-Now that we have working, running containers there are two more steps to run.  First, if there is a “start” command specified in your `.platform.app.yaml` file to start the application, we run that. (With PHP, this is optional.)
+Now that we have working, running containers there are two more steps to run.
+First, if there is a `start` command specified in your `.platform.app.yaml` file to start the application, we run that.
+(With PHP, this is optional.)
 
-Then we run your deploy hook.  Just like the build hook, the deploy hook is any number of shell commands you need to prepare your application.  Usually this includes clearing caches, running database migrations, and so on.  You have complete access to all services here as your application is up and running, but the file system where your code lives will now be read-only.
+Then we run your deploy hook.
+Just like the build hook, the deploy hook is any number of shell commands you need to prepare your application.
+Usually this includes clearing caches, running database migrations, and so on.
+You have complete access to all services here as your application is up and running,
+but the file system where your code lives is now read-only.
 
-Finally, once the deploy hooks are done, we open the floodgates and let incoming requests through to your newly deployed application.  You're done!
+Finally, once the deploy hooks are done,
+we open the floodgates and let incoming requests through to your newly deployed application.
+You're done!
 
 In practice, the deploy process takes only a few seconds, plus whatever time is required for your deploy hook, if any.

--- a/docs/src/overview/structure.md
+++ b/docs/src/overview/structure.md
@@ -3,7 +3,9 @@ title: "Structure"
 weight: 1
 ---
 
-Every application you deploy on Platform.sh is built as a **virtual cluster**, containing a set of containers.  The master branch of your Git repository is always deployed as the production cluster.  Any other branch can be deployed as a development cluster.
+Every application you deploy on Platform.sh is built as a **virtual cluster**, containing a set of containers.
+The default branch of your Git repository is always deployed as the production cluster.
+Any other branch can be deployed as a development cluster.
 
 By default, you can have up to three live development clusters at once, but you can buy more on a per-project basis.
 
@@ -19,7 +21,7 @@ All of those containers are managed by three special files in your Git repositor
 * `.platform/services.yaml`
 * `.platform.app.yaml`
 
-In most cases, that means your repository will look like this:
+In most cases, that means your repository looks like this:
 
 ```text
 yourproject/
@@ -35,18 +37,29 @@ yourproject/
 
 There is always exactly one Router per cluster.
 
-The Router of a cluster is a single nginx process.  It is configured by the `routes.yaml` file.  It maps incoming requests to the appropriate Application container and provides basic caching of responses, if so configured. It has no persistent storage.
+The Router of a cluster is a single nginx process.
+It's configured by the `routes.yaml` file.
+It maps incoming requests to the appropriate Application container and provides basic caching of responses, if so configured.
+It has no persistent storage.
 
 ## Service
 
 Service containers are configured by the `services.yaml` file.
 
-There may be zero or more Service containers in a cluster, depending on the `services.yaml` file.  The code for a Service is provided by Platform.sh in a pre-built container image, along with a default configuration.  Depending on the service it may also include user-provided configuration in the `services.yaml` file.  Examples of services include MySQL/MariaDB, Elasticsearch, Redis, and RabbitMQ.
+There may be zero or more Service containers in a cluster, depending on the `services.yaml` file.
+The code for a Service is provided by Platform.sh in a pre-built container image, along with a default configuration.
+Depending on the service it may also include user-provided configuration in the `services.yaml` file.
+Examples of services include MySQL/MariaDB, Elasticsearch, Redis, and RabbitMQ.
 
 ## Application
 
-There always must be one Application container in a cluster, but there may be more.
+There always must be one application container in a cluster, but there may be more.
 
-Each Application container corresponds to a `.platform.app.yaml` file in the repository.  If there are 3 `.platform.app.yaml` files, there will be three Application containers.  Application containers hold the code you provide via your Git repository.  Application containers are always built off of one of the Platform.sh-provided language-specific images, such as “PHP 7.4”, “Node.js 14”, or “Python 3.7”. It is also possible to have multiple Application containers running different languages or versions.
+Each application container corresponds to a `.platform.app.yaml` file in the repository.
+If there are 3 `.platform.app.yaml` files, there are 3 application containers.
+Application containers hold the code you provide via your Git repository.
+Application containers are always built off of one of the Platform.sh-provided language-specific images,
+such as `PHP 7.4`, `Node.js 14`, or `Python 3.7`.
+It's also possible to have multiple application containers running different languages or versions.
 
 For typical applications, there is only one `.platform.app.yaml` file, which is generally placed at the repository root.

--- a/docs/src/security/compliance-guidance.md
+++ b/docs/src/security/compliance-guidance.md
@@ -1,53 +1,67 @@
 ---
 title: "Compliance guidance"
 weight: 11
-
-description: |
-
 ---
-
-{{< description >}}
 
 ## Overview
 
-Platform.sh provides a Platform as a Service (PaaS) solution and has many customers that require us to maintain various certifications. These certifications contain requirements to ensure certain measures are implemented to meet industry standards. Some requirements are the responsibility of the host, some are the responsibility of the application developer, and others are a shared responsibility.
+Platform.sh provides a Platform as a Service (PaaS) solution and has many customers that require us to maintain various certifications.
+These certifications contain requirements to ensure certain measures are implemented to meet industry standards.
+Some requirements are the responsibility of the host, some are the responsibility of the application developer,
+and others are a shared responsibility.
 
-Basic compliance questions can be handled by our support team via a ticket. For more advanced questions, including help with an audit, please contact your Platform.sh Account Manager.
+Basic compliance questions can be handled by our support team via a ticket.
+For more advanced questions, including help with an audit, please contact your Platform.sh Account Manager.
 
 
 ## Security & Compensating Controls
 
 * For a list of security measures, please see our [Security page](https://platform.sh/security).
-
-* Customer environments are deployed in a read-only instance, segregated with GRE tunnels and encrypted using TLS, which often permits compensating controls to be claimed for several PCI requirements.
-
-* Because customers can use our PaaS in a variety of ways, the best approach with auditors is to focus on “What do I (the customer) control/configure, and how is it managed in a compliant manner?”
-
+* Customer environments are deployed in a read-only instance, segregated with GRE tunnels and encrypted using TLS,
+  which often permits compensating controls to be claimed for several PCI requirements.
+* Because customers can use our PaaS in a variety of ways,
+  the best approach with auditors is to focus on "What do I (the customer) control/configure, and how is it managed in a compliant manner?"
 * The `FR-1` and `FR-3` regions are excluded from our PCI and SOC2 certifications.
-
 * HIPAA workloads are strictly run on our US-4 region.
 
 ## Responsibility
 
-Platform.sh and customers often have shared responsibility for ensuring an up-to-date and secure environment. The customer is responsible for achieving and maintaining their own certifications and compliance.
+Platform.sh and customers often have shared responsibility for ensuring an up-to-date and secure environment.
+The customer is responsible for achieving and maintaining their own certifications and compliance.
 
-The following is a general allocation of responsibilities between Platform.sh and the customer. For more guidance on responsibility for specific certification requirements, please refer to our relevant documentation (e.g. PCI Compliance) to access the relevant shared responsibility matrix.
+The following is a general allocation of responsibilities between Platform.sh and the customer.
+For more guidance on responsibility for specific certification requirements,
+refer to the relevant documentation (such as PCI Compliance) to access the relevant shared responsibility matrix.
 
 Platform.sh is responsible for:
 
-* **Physical and Environmental controls** - We use third-party hosting and thus these requirements are passed through to those providers (e.g. AWS).
-* **Patch Management** - Platform.sh is responsible for patching and fixing underlying system software, management software, and environment images.
-* **Configuration Management** - Platform.sh maintains the configuration of its infrastructure and devices.
-* **Awareness and Training** - Platform.sh trains its own employees in secure software development and management.
-* **Capacity Management** - Platform.sh is responsible for capacity management of the infrastructure, such as server allocation and bandwidth management.
-* **Access Control** - Platform.sh is responsible for providing access control mechanisms to customers and for vetting all Platform.sh personnel access.
-* **Backups** - Platform.sh is responsible for backing up the infrastructure and management components of the system.  On Platform.sh Dedicated Enterprise (only), Platform.sh will also backup application code and databases on behalf of customers.
+* **Physical and Environmental controls**:
+  We use third-party hosting and thus these requirements are passed through to those providers (such as AWS).
+* **Patch Management**:
+  Platform.sh is responsible for patching and fixing underlying system software, management software, and environment images.
+* **Configuration Management**:
+  Platform.sh maintains the configuration of its infrastructure and devices.
+* **Awareness and Training**:
+  Platform.sh trains its own employees in secure software development and management.
+* **Capacity Management**:
+  Platform.sh is responsible for capacity management of the infrastructure, such as server allocation and bandwidth management.
+* **Access Control**:
+  Platform.sh is responsible for providing access control mechanisms to customers and for vetting all Platform.sh personnel access.
+* **Backups**:
+  Platform.sh is responsible for backing up the infrastructure and management components of the system.
+  On Platform.sh Dedicated Enterprise (only), Platform.sh also backs up application code and databases on behalf of customers.
 
 Customers are responsible for:
 
-* **Patch Management** - Customers are responsible for maintaining and patching application code uploaded to Platform.sh, either written by them or by a third-party.
-* **Configuration Management** - Customers are responsible for the secure configuration of their application, including Platform.sh configuration and routes managed through YAML files.
-* **Awareness and Training** - Customers are responsible for training their own employees and users on secure software practices.
-* **Capacity Management** - Customers are responsible for ensuring their application containers have sufficient resources for their selected tasks.
-* **Access Control** - Customers are responsible for effectively leveraging available access control mechanisms, including proper access control settings, secrets management, SSH key management, and the use of two-factor authentication.
-* **Backups** - On Platform.sh, Professional customers are responsible for all application and database backups.
+* **Patch Management**:
+  Customers are responsible for maintaining and patching application code uploaded to Platform.sh, either written by them or by a third-party.
+* **Configuration Management**:
+  Customers are responsible for the secure configuration of their application, including Platform.sh configuration and routes managed through YAML files.
+* **Awareness and Training**:
+  Customers are responsible for training their own employees and users on secure software practices.
+* **Capacity Management**:
+  Customers are responsible for ensuring their application containers have sufficient resources for their selected tasks.
+* **Access Control**:
+  Customers are responsible for effectively leveraging available access control mechanisms, including proper access control settings, secrets management, SSH key management, and the use of two-factor authentication.
+* **Backups**:
+  On Platform.sh, Professional customers are responsible for all application and database backups.

--- a/docs/src/security/pci.md
+++ b/docs/src/security/pci.md
@@ -6,20 +6,32 @@ description: |
     Platform.sh is PCI DSS certified.
 ---
 
-Please refer to our [Compliance Guidance](https://docs.platform.sh/security/compliance-guidance.html) page for an overview of our compliance program, including security & compensating controls, and a general allocation of responsibility.
+Refer to our [Compliance Guidance](https://docs.platform.sh/security/compliance-guidance.html)
+for an overview of our compliance program, including security & compensating controls, and a general allocation of responsibility.
 
 ## Overview
 
-Payment Card Industry (PCI) Data Security Standards (DSS) is a set of network security and business best practice guidelines that establish a “minimum security standard” to protect payment card information. While Platform.sh does not handle credit cards, many of our customers do.
+Payment Card Industry (PCI) Data Security Standards (DSS) is a set of network security and business best practice guidelines
+that establish a "minimum security standard" to protect payment card information.
+While Platform.sh doesn't handle credit cards, many of our customers do.
 
-Platform.sh undergoes an annual third-party audit to maintain PCI DSS recertification. Please note, however, that the FR-1 and FR-3 regions are excluded from our PCI certification.
+Platform.sh undergoes an annual third-party audit to maintain PCI DSS recertification.
+Note that the FR-1 and FR-3 regions are excluded from our PCI certification.
 
 {{< note >}}
-Cardholder processing activity is discouraged. Please use a third-party processor.
+
+Cardholder processing activity is discouraged.
+Please use a third-party processor.
+
 {{< /note >}}
 
 ## Responsibility
 
-Customers who want to run PCI workloads on Platform.sh must agree to and implement the measures contained in the [Platform.sh PCI Responsibility Matrix](https://docs.google.com/spreadsheets/d/1zLkHpdUoX1VNC3wTipl3g-Z4eHjou-57IrQxE8GH6oA/edit#gid=238986323) (Excel). This document provides guidance on shared responsibilities to achieve PCI DSS compliance using PCI DSS 3.2 as a reference.
+Customers who want to run PCI workloads on Platform.sh must agree to and implement
+the measures contained in the [Platform.sh PCI Responsibility Matrix](https://docs.google.com/spreadsheets/d/1zLkHpdUoX1VNC3wTipl3g-Z4eHjou-57IrQxE8GH6oA/edit#gid=238986323) (Excel).
+This document provides guidance on shared responsibilities to achieve PCI DSS compliance using PCI DSS 3.2 as a reference.
 
-While Platform.sh provides a secure and PCI compliant infrastructure, the customer is responsible for ensuring that the environment and applications that they host on Platform.sh are properly configured and secured according to PCI requirements. Failure to do so will result in a non-compliant customer environment.
+While Platform.sh provides a secure and PCI compliant infrastructure,
+the customer is responsible for ensuring that the environment and applications that they host on Platform.sh
+are properly configured and secured according to PCI requirements.
+Failure to do so will result in a non-compliant customer environment.

--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -5,6 +5,7 @@ asciinema
 async
 Blackfire
 blockquote
+[Bb]undler
 Cloudwatt
 [Cc]onfig
 [Cc]ron
@@ -27,11 +28,14 @@ multifactor
 multithread[ed|ing]
 namespace
 [Nn]ginx
+npm
 optipng
 pngcrush
+preprocessor
 progs
 Pthreads
 plaintext
+recertification
 [Rr]sync
 runtimes
 shortcode


### PR DESCRIPTION
Copying smart quotes from a code sample created an error,
so I decided to get rid of them everywhere.

The platform transforms regular quotes to smart quotes automatically.﻿
