### PR TITLE
Postgres rm comment

### DIFF
--- a/docs/static/files/fetch/examples/php/mysql
+++ b/docs/static/files/fetch/examples/php/mysql
@@ -36,9 +36,9 @@ try {
     $conn->query($sql);
 
     // Insert data.
-    $sql = "INSERT INTO People (name, city) VALUES 
-        ('Neil Armstrong', 'Moon'), 
-        ('Buzz Aldrin', 'Glen Ridge'), 
+    $sql = "INSERT INTO People (name, city) VALUES
+        ('Neil Armstrong', 'Moon'),
+        ('Buzz Aldrin', 'Glen Ridge'),
         ('Sally Ride', 'La Jolla');";
     $conn->query($sql);
 

--- a/docs/static/files/fetch/examples/php/postgresql
+++ b/docs/static/files/fetch/examples/php/postgresql
@@ -19,7 +19,6 @@ try {
     $conn = new \PDO($dsn, $credentials['username'], $credentials['password'], [
         // Always use Exception error mode with PDO, as it's more reliable.
         \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-        // So we don't have to mess around with cursors and unbuffered queries by default.
     ]);
 
     $conn->query("DROP TABLE IF EXISTS People");


### PR DESCRIPTION
Remove comment from mysql option not present on postgres (PDO::MYSQL_ATTR_USE_BUFFERED_QUERY) cf https://github.com/platformsh/platformsh-docs/blob/7b3d6e09774e19fdb967d097e78dd97a600b4551/docs/static/files/fetch/examples/php/mysql#L23

Remove trailing on mysql file