### PR TITLE
:children_crossing: Remove title from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/improvements.yml
+++ b/.github/ISSUE_TEMPLATE/improvements.yml
@@ -1,6 +1,5 @@
 name: Improvements
 description: For changes to improve existing content.
-title: ":bug: "
 labels:
   - ungroomed
 body:

--- a/.github/ISSUE_TEMPLATE/new_docs.yml
+++ b/.github/ISSUE_TEMPLATE/new_docs.yml
@@ -1,6 +1,5 @@
 name: New docs
 description: For adding documentation that doesn't yet exist, such as for a new feature.
-title: ":sparkles: "
 labels:
   - ungroomed
 body:


### PR DESCRIPTION


<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

To make it more clear the title should be filled out. It doesn't show up as a placeholder, but as if the field is filled in, making it unclear that users should actually do something with that field. So as nice as it was to have the gitmoji there to start with, I think leaving it blank is probably for the best (at least until the feature is improved).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Issue templates no longer have default titles.
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
