### PR TITLE
Switch the Edit Page link to the new default branch name.

### DIFF
--- a/docs/themes/avocadocs/layouts/_default/list.html
+++ b/docs/themes/avocadocs/layouts/_default/list.html
@@ -7,7 +7,7 @@
 
           <div class="mb-7">
             <div class="edit-page">
-              {{ $editLocation := printf "%sedit/master/docs/src/%s" .Site.Params.repo .File.Path}}
+              {{ $editLocation := printf "%sedit/main/docs/src/%s" .Site.Params.repo .File.Path}}
               <button onclick="window.location.href = '{{ $editLocation }}';" type="button" class="btn2 btn-primary2 btn-edit-page">
                 <span class="text-button-">Edit page</span>
                 <span class="icon"><img class="chevron-next2" aria-hidden="true" src="/images/icons/chevrons.svg" /></span>

--- a/docs/themes/avocadocs/layouts/_default/single.html
+++ b/docs/themes/avocadocs/layouts/_default/single.html
@@ -10,7 +10,7 @@
 
           <div class="mb-7">
             <div class="edit-page">
-              {{ $editLocation := printf "%sedit/master/docs/src/%s" .Site.Params.repo .File.Path}}
+              {{ $editLocation := printf "%sedit/main/docs/src/%s" .Site.Params.repo .File.Path}}
               <button onclick="window.location.href = '{{ $editLocation }}';" type="button" class="btn2 btn-primary2 btn-edit-page">
                 <span class="text-button-">Edit page</span>
                 <span class="icon"><img class="chevron-next2" aria-hidden="true" src="/images/icons/chevrons.svg" /></span>

--- a/docs/themes/avocadocs/layouts/index.html
+++ b/docs/themes/avocadocs/layouts/index.html
@@ -8,7 +8,7 @@
 
           <div class="mb-7">
             <div class="edit-page">
-              {{ $editLocation := printf "%sedit/master/docs/src/%s" .Site.Params.repo .File.Path}}
+              {{ $editLocation := printf "%sedit/main/docs/src/%s" .Site.Params.repo .File.Path}}
               <button onclick="window.location.href = '{{ $editLocation }}';" type="button" class="btn2 btn-primary2 btn-edit-page">
                 <span class="text-button-">Edit page</span>
                 <span class="icon"><img class="chevron-next2" aria-hidden="true" src="/images/icons/chevrons.svg" /></span>


### PR DESCRIPTION
## Why

This Pull Request fixes the `Edit Page` link to GitHub.

## What's changed

Since we renamed the default branch name, the `Edit Page` link to GitHub is broken.