### PR TITLE
:memo: Update the getting help page

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -73,6 +73,10 @@ https://{default}/:
       "/integrations/profiling/new-relic/php.html": { "to": "/integrations/observability/new-relic/php.html", "code": 301, "prefix": false }
       "/integrations/profiling/tideways.html": { "to": "/integrations/observability/tideways.html", "code": 301, "prefix": false }
 
+      # PR 1963
+      "/overview/getting-help.html": { "to": "/overview/get-support.html", "code": 301, "prefix": false }
+
+
 "https://search.{default}/":
     type: upstream
     upstream: "search:http"

--- a/docs/src/domains/troubleshoot.md
+++ b/docs/src/domains/troubleshoot.md
@@ -44,6 +44,6 @@ Do the same with `platform logs error`
 
 ## Something still wrong?
 
-[Contact support](/overview/getting-help.md)
+[Contact support](/overview/contact-customer-support.md)
 
 We are here to help. Please include as much detail as possible (we will be able to provide quicker help).

--- a/docs/src/domains/troubleshoot.md
+++ b/docs/src/domains/troubleshoot.md
@@ -44,6 +44,6 @@ Do the same with `platform logs error`
 
 ## Something still wrong?
 
-[Contact support](/overview/contact-customer-support.md)
+[Contact support](/overview/get-support.md)
 
 We are here to help. Please include as much detail as possible (we will be able to provide quicker help).

--- a/docs/src/overview/contact-customer-support.md
+++ b/docs/src/overview/contact-customer-support.md
@@ -3,7 +3,7 @@ title: "Contact Customer Support"
 weight: 4
 toc: false
 description: |
-  If you're experiencing a problem with Platform.sh, you can submit a ticket to Customer Support.
+  If you're experiencing a problem with Platform.sh, you can submit a ticket to our Customer Support team.
 ---
 
 {{< description >}}
@@ -11,7 +11,7 @@ description: |
 
 ## Create a Customer Support ticket
 
-To create a support ticket from the console, follow these steps:
+To create a ticket from the console, follow these steps:
 
 Before you begin
 
@@ -22,28 +22,27 @@ Steps
 
 1. Log into Platform.sh.
 2. In the console, click your **user profile** > **Support**.
-Now you are on the **Support tickets** page.
-Here you can see the list of issues created over time by users in your organization.
-![List of support tickets](/images/management-console/support-tickets-new.png "0.5")
 
-If the page shows no tickets, it means you're the first user in your organization creating a ticket.
-![List of support tickets](/images/management-console/support-tickets-new.png "0.5")
+Now you are on the **Support tickets** page.
+Here you can see the list of tickets created by users in your organization over time.
+If the page has no tickets, it means you're the first user in your organization creating one.
 
 3. Click **+ New ticket**.
 4. Fill in the ticket fields and click **Submit**.
 
 Note that once you submit the ticket you won't be able to modify or delete the submission.
+If you have any additional information you can add it to the ticket as a reply.
 
 ## Other ways to get support
 
 ### Slack
 
 Our customers and engineers hang out on our [public Slack channel](https://chat.platform.sh/) where you can get tips on using Platform.sh.
-Mention `@platform. to grab our team's attention.
+Mention `@platform` to grab our team's attention.
 
 ### Community
 
-The [Platform.sh Community Site](https://community.platform.sh/) contains plenty of how-to guides.
+The [Platform.sh Community Site](https://community.platform.sh/) contains plenty of how-to guides and a Q&A section.
 
 ### Contact us
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -18,7 +18,7 @@ description: |
 
 In the future, you can [access the ticket list](https://console.platform.sh/-/users/~/tickets) or [open a ticket directly](https://console.platform.sh/-/users/~/tickets/open) using the shortcuts.
 
-Once you submit a ticket you can see it on the ticket list alongside tickets created by users in your organization over time.
+Once you submit a ticket, you can see it on the list alongside tickets created by users in your organization over time.
 Note that once you submit the ticket you won't be able to modify or delete the submission.
 If you have any additional information, you can select the submitted ticket and write a message.
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -30,7 +30,7 @@ If you want to chat with engineers and other customers you can join the [public 
 
 ## Community
 
-In the [Platform.sh Community Site](https://community.platform.sh/) you can find plenty of how-to guides that contains suggestions on how to make the most out of Platform.
+The [Platform.sh Community site](https://community.platform.sh/) has how-to guides with suggestions on how to get the most out of Platform.sh.
 
 
 ## Contact Sales

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -19,7 +19,7 @@ description: |
 Or use these shortcuts to [access all support tickets](https://console.platform.sh/-/users/~/tickets) or [open a new ticket](https://console.platform.sh/-/users/~/tickets/open).
 
 Once you submit a ticket, you can see it on the list alongside tickets created by users in your organization over time.
-Note that once you submit the ticket you won't be able to modify or delete the submission.
+Note that once you submit the ticket, you won't be able to modify or delete the submission.
 If you have any additional information, you can select the submitted ticket and write a message.
 
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -28,7 +28,7 @@ If you have any additional information, you can select the submitted ticket and 
 
 ## Slack
 
-To talk with engineers and other customers, join the [public Slack channel](https://chat.platform.sh/).
+To talk about app development or framework-related questions, join other customers and engineers in the  [public Slack channel](https://chat.platform.sh/).
 
 ## Community
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -1,15 +1,15 @@
 ---
-title: "Contact Customer Support"
+title: " Get support"
 weight: 4
 toc: false
 description: |
-  If you're experiencing a problem with Platform.sh, you can submit a ticket to our Customer Support team.
+  If you're experiencing a problem with Platform.sh, you can submit a support ticket, join the Slack channel, or checkout the Platform.sh Community.
 ---
 
 {{< description >}}
 
 
-## Create a Customer Support ticket
+## Create a support ticket
 
 To create a ticket from the console, follow these steps:
 
@@ -20,7 +20,7 @@ Before you begin
 
 Steps
 
-1. Log into Platform.sh.
+1. [Log in to Platform.sh](https://auth.api.platform.sh/)
 2. In the console, click your **user profile** > **Support**.
 
 Now you are on the **Support tickets** page.
@@ -37,8 +37,8 @@ If you have any additional information you can add it to the ticket as a reply.
 
 ### Slack
 
-Our customers and engineers hang out on our [public Slack channel](https://chat.platform.sh/) where you can get tips on using Platform.sh.
-Mention `@platform` to grab our team's attention.
+Hang out with customers and engineers on the [public Slack channel](https://chat.platform.sh/)
+Mention `@platform` to get the team attention.
 
 ### Community
 
@@ -46,6 +46,6 @@ The [Platform.sh Community Site](https://community.platform.sh/) contains plenty
 
 ### Contact us
 
-Get in touch with our [Sales and Support teams](https://platform.sh/contact/).
+Get in touch with the [Sales and Support teams](https://platform.sh/contact/).
 
 ---

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -28,7 +28,7 @@ If you have any additional information, you can select the submitted ticket and 
 
 ## Slack
 
-If you want to talk to with engineers and other customers you can join the [public Slack channel](https://chat.platform.sh/).
+To talk with engineers and other customers, join the [public Slack channel](https://chat.platform.sh/).
 
 ## Community
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -11,7 +11,7 @@ description: |
 
 ## Create a support ticket
 
-Create a support ticket when you're experiencing issues related to the proper functioning of the Platform.sh infrastructure, application container software, build processes, possible bugs and general questions.
+Create a support ticket when you're experiencing issues related to the proper functioning of the Platform.sh infrastructure, application container software, build processes, possible bugs or if you have general questions.
 
 1. [Open the Management Console](https://console.platform.sh/)
 2. Select **User menu** (your name) > **Support**.

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -18,7 +18,7 @@ description: |
 
 Or use these shortcuts to [access all support tickets](https://console.platform.sh/-/users/~/tickets) or [open a new ticket](https://console.platform.sh/-/users/~/tickets/open).
 
-Once you submit a ticket, you can see it on the list alongside tickets created by users in your organization over time.
+Once you submit a ticket, you see it in a list of all tickets created within your organization.
 Note that once you submit the ticket, you won't be able to modify or delete the submission.
 If you have any additional information, you can select the submitted ticket and write a message.
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -11,7 +11,7 @@ description: |
 
 ## Create a support ticket
 
-Create a support ticket when you're experiencing issues related to the proper functioning of the Platform.sh infrastructure, application container software, build processes, possible bugs or if you have general questions.
+If you're experiencing issues related to the proper functioning of the Platform.sh infrastructure, application container software, or build processes; have found possible bugs; or have general questions, open a support ticket:
 
 1. [Open the Management Console](https://console.platform.sh/)
 2. Select **User menu** (your name) > **Support**.

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -37,4 +37,3 @@ In the [Platform.sh Community Site](https://community.platform.sh/) you can find
 
 If you have questions about pricing or need help figuring out if Platform.sh is the right solution for your team, get in touch with [Sales](https://platform.sh/contact/).
 
----

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -8,33 +8,36 @@ description: |
 
 {{< description >}}
 
-
 ## Create a support ticket
 
-If you're experiencing issues related to the proper functioning of the Platform.sh infrastructure, application container software, or build processes; have found possible bugs; or have general questions, open a support ticket:
+If you're experiencing issues related to
+the proper functioning of the Platform.sh infrastructure, application container software, or build processes;
+have found possible bugs; or have general questions,
+open a support ticket:
 
 1. [Open the Management Console](https://console.platform.sh/)
 2. Select **User menu** (your name) > **Support**.
 3. Click **+ New ticket**.
 4. Fill in the ticket fields and click **Submit**.
 
-Or use these shortcuts to [access all support tickets](https://console.platform.sh/-/users/~/tickets) or [open a new ticket](https://console.platform.sh/-/users/~/tickets/open).
+Or use these shortcuts to [access all support tickets](https://console.platform.sh/-/users/~/tickets)
+or [open a new ticket](https://console.platform.sh/-/users/~/tickets/open).
 
 Once you submit a ticket, you see it in a list of all tickets created within your organization.
-Note that once you submit the ticket, you won't be able to modify or delete the submission.
+Note that once you submit the ticket, you can't modify or delete the submission.
 If you have any additional information, you can select the submitted ticket and write a message.
-
-
 
 ## Slack
 
-To talk about app development or framework-related questions, join other customers and engineers in the  [public Slack channel](https://chat.platform.sh/).
+To talk about app development or framework-related questions,
+join other customers and engineers in the [public Slack channel](https://chat.platform.sh/).
 
 ## Community
 
-The [Platform.sh Community site](https://community.platform.sh/) has how-to guides with suggestions on how to get the most out of Platform.sh.
-
+The [Platform.sh Community site](https://community.platform.sh/) has how-to guides with suggestions
+on how to get the most out of Platform.sh.
 
 ## Contact Sales
 
-If you have questions about pricing or need help figuring out if Platform.sh is the right solution for your team, get in touch with [Sales](https://platform.sh/contact/).
+If you have questions about pricing or need help figuring out if Platform.sh is the right solution for your team,
+get in touch with [Sales](https://platform.sh/contact/).

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -16,7 +16,7 @@ description: |
 3. Click **+ New ticket**.
 4. Fill in the ticket fields and click **Submit**.
 
-In the future, you can [access the ticket list](https://console.platform.sh/-/users/~/tickets) or [open a ticket directly](https://console.platform.sh/-/users/~/tickets/open) using the shortcuts.
+Or use these shortcuts to [access all support tickets](https://console.platform.sh/-/users/~/tickets) or [open a new ticket](https://console.platform.sh/-/users/~/tickets/open).
 
 Once you submit a ticket, you can see it on the list alongside tickets created by users in your organization over time.
 Note that once you submit the ticket you won't be able to modify or delete the submission.

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -35,6 +35,6 @@ In the [Platform.sh Community Site](https://community.platform.sh/) you can find
 
 ## Contact Sales
 
-If you have questions with regards pricing or if you need help figuring out if Platform.sh is the right solution for your team, get in touch with [Sales](https://platform.sh/contact/).
+If you have questions about pricing or need help figuring out if Platform.sh is the right solution for your team, get in touch with [Sales](https://platform.sh/contact/).
 
 ---

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -11,6 +11,8 @@ description: |
 
 ## Create a support ticket
 
+Create a support ticket when you're experiencing issues related to the proper functioning of the Platform.sh infrastructure, application container software, build processes, possible bugs and general questions.
+
 1. [Open the Management Console](https://console.platform.sh/)
 2. Select **User menu** (your name) > **Support**.
 3. Click **+ New ticket**.
@@ -26,7 +28,7 @@ If you have any additional information, you can select the submitted ticket and 
 
 ## Slack
 
-If you want to chat with engineers and other customers you can join the [public Slack channel](https://chat.platform.sh/).
+If you want to talk to with engineers and other customers you can join the [public Slack channel](https://chat.platform.sh/).
 
 ## Community
 
@@ -36,4 +38,3 @@ The [Platform.sh Community site](https://community.platform.sh/) has how-to guid
 ## Contact Sales
 
 If you have questions about pricing or need help figuring out if Platform.sh is the right solution for your team, get in touch with [Sales](https://platform.sh/contact/).
-

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -3,7 +3,7 @@ title: " Get support"
 weight: 4
 toc: false
 description: |
-  Find out how to get help If you're experiencing an issue with Platform.sh.
+  Find out how to get help if you're experiencing issues with Platform.sh.
 ---
 
 {{< description >}}

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -16,9 +16,13 @@ description: |
 3. Click **+ New ticket**.
 4. Fill in the ticket fields and click **Submit**.
 
+In the future, you can [access the ticket list](https://console.platform.sh/-/users/~/tickets) or [open a ticket directly](https://console.platform.sh/-/users/~/tickets/open) using the shortcuts.
+
 Once you submit a ticket you can see it on the ticket list alongside tickets created by users in your organization over time.
 Note that once you submit the ticket you won't be able to modify or delete the submission.
 If you have any additional information, you can select the submitted ticket and write a message.
+
+
 
 ## Slack
 

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -3,7 +3,7 @@ title: " Get support"
 weight: 4
 toc: false
 description: |
-  If you're experiencing a problem with Platform.sh, you can submit a support ticket, join the Slack channel, or checkout the Platform.sh Community.
+  Find out how to get help If you're experiencing an issue with Platform.sh.
 ---
 
 {{< description >}}
@@ -11,41 +11,26 @@ description: |
 
 ## Create a support ticket
 
-To create a ticket from the console, follow these steps:
-
-Before you begin
-
-* You need to have a Platform.sh account.
-* You must be logged into your account.
-
-Steps
-
-1. [Log in to Platform.sh](https://auth.api.platform.sh/)
-2. In the console, click your **user profile** > **Support**.
-
-Now you are on the **Support tickets** page.
-Here you can see the list of tickets created by users in your organization over time.
-If the page has no tickets, it means you're the first user in your organization creating one.
-
+1. [Open the Management Console](https://console.platform.sh/)
+2. Select **User menu** (your name) > **Support**.
 3. Click **+ New ticket**.
 4. Fill in the ticket fields and click **Submit**.
 
+Once you submit a ticket you can see it on the ticket list alongside tickets created by users in your organization over time.
 Note that once you submit the ticket you won't be able to modify or delete the submission.
-If you have any additional information you can add it to the ticket as a reply.
+If you have any additional information, you can select the submitted ticket and write a message.
 
-## Other ways to get support
+## Slack
 
-### Slack
+If you want to chat with engineers and other customers you can join the [public Slack channel](https://chat.platform.sh/).
 
-Hang out with customers and engineers on the [public Slack channel](https://chat.platform.sh/)
-Mention `@platform` to get the team attention.
+## Community
 
-### Community
+In the [Platform.sh Community Site](https://community.platform.sh/) you can find plenty of how-to guides that contains suggestions on how to make the most out of Platform.
 
-The [Platform.sh Community Site](https://community.platform.sh/) contains plenty of how-to guides and a Q&A section.
 
-### Contact us
+## Contact Sales
 
-Get in touch with the [Sales and Support teams](https://platform.sh/contact/).
+If you have questions with regards pricing or if you need help figuring out if Platform.sh is the right solution for your team, get in touch with [Sales](https://platform.sh/contact/).
 
 ---

--- a/docs/src/overview/getting-help.md
+++ b/docs/src/overview/getting-help.md
@@ -1,25 +1,52 @@
 ---
-title: "Getting help"
+title: "Contact Customer Support"
 weight: 4
 toc: false
 description: |
-  If you're facing any issue with Platform.sh, you can submit a support ticket from the Platform.sh management console.
+  If you're experiencing a problem with Platform.sh, you can submit a ticket to Customer Support.
 ---
 
 {{< description >}}
 
-![Support Ticket](/images/management-console/support-ticket-pulldown.png "0.15")
 
-You will be redirected to a list of your support tickets, and you can click to open a 'New ticket' at the top of the page.
+## Create a Customer Support ticket
 
-![Empty Support Ticket](/images/management-console/support-empty.png "0.5")
+To create a support ticket from the console, follow these steps:
 
-File your issues in the fields for the new ticket and Submit.
+Before you begin
 
-![New Support Ticket](/images/management-console/support-tickets-new.png "0.5")
+* You need to have a Platform.sh account.
+* You must be logged into your account.
 
-You can also open a support ticket directly from your [user account](https://accounts.platform.sh/support).
+Steps
 
-You are more than welcome to hop-on to our [public Slack chat channel](https://chat.platform.sh/).
+1. Log into Platform.sh.
+2. In the console, click your **user profile** > **Support**.
+Now you are on the **Support tickets** page.
+Here you can see the list of issues created over time by users in your organization.
+![List of support tickets](/images/management-console/support-tickets-new.png "0.5")
 
-And you are [always invited to drop us a line at our contact form](https://platform.sh/contact).
+If the page shows no tickets, it means you're the first user in your organization creating a ticket.
+![List of support tickets](/images/management-console/support-tickets-new.png "0.5")
+
+3. Click **+ New ticket**.
+4. Fill in the ticket fields and click **Submit**.
+
+Note that once you submit the ticket you won't be able to modify or delete the submission.
+
+## Other ways to get support
+
+### Slack
+
+Our customers and engineers hang out on our [public Slack channel](https://chat.platform.sh/) where you can get tips on using Platform.sh.
+Mention `@platform. to grab our team's attention.
+
+### Community
+
+The [Platform.sh Community Site](https://community.platform.sh/) contains plenty of how-to guides.
+
+### Contact us
+
+Get in touch with our [Sales and Support teams](https://platform.sh/contact/).
+
+---

--- a/docs/src/security/encryption.md
+++ b/docs/src/security/encryption.md
@@ -15,4 +15,4 @@ Data in transit on Platform.sh controlled networks (for example, between the app
 
 All application data is encrypted at rest by default using encrypted ephemeral storage (typically using an AES-256 block cipher). Some Enterprise-Dedicated clusters do not have full encryption at rest.
 
-If you have specific audit requirements surrounding data at rest encryption please [contact Customer Support](/overview/contact-customer-support.md).
+If you have specific audit requirements surrounding data at rest encryption please [contact Customer Support](/overview/get-support.md).

--- a/docs/src/security/encryption.md
+++ b/docs/src/security/encryption.md
@@ -15,4 +15,4 @@ Data in transit on Platform.sh controlled networks (for example, between the app
 
 All application data is encrypted at rest by default using encrypted ephemeral storage (typically using an AES-256 block cipher). Some Enterprise-Dedicated clusters do not have full encryption at rest.
 
-If you have specific audit requirements surrounding data at rest encryption please [contact us](/overview/getting-help.md).
+If you have specific audit requirements surrounding data at rest encryption please [contact Customer Support](/overview/contact-customer-support.md).

--- a/docs/src/security/pen-test.md
+++ b/docs/src/security/pen-test.md
@@ -34,4 +34,4 @@ On Platform.sh's side, there is no automatic ip or range blocking. Blocking IP's
 
 ## Troubleshooting
 
-If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please ensure your container is [updated](/security/updates.md) and retest. If the problem remains, please [contact support](/overview/getting-help.md).
+If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please ensure your container is [updated](/security/updates.md) and retest. If the problem remains, please [contact Customer Support](/overview/contact-customer-support.md).).

--- a/docs/src/security/pen-test.md
+++ b/docs/src/security/pen-test.md
@@ -34,4 +34,4 @@ On Platform.sh's side, there is no automatic ip or range blocking. Blocking IP's
 
 ## Troubleshooting
 
-If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please ensure your container is [updated](/security/updates.md) and retest. If the problem remains, please [contact Customer Support](/overview/contact-customer-support.md).).
+If your vulnerability scanning suggests there may be an issue with Platform.sh's service, please ensure your container is [updated](/security/updates.md) and retest. If the problem remains, please [contact Customer Support](/overview/get-support.md).


### PR DESCRIPTION
## Why

Closes #1958

## What's changed

- Changed the page name.
- Updated the description.
- Updated links in pages pointing to **Get support**.
- Added how-to structure.
- The page was approved by Support. 
- Removed unnecessary images since they didn't provide additional information and the paths are clear.
- Reorganized **Slack**, **Community** and **Contact us** sections.
- Added a redirection from old getting-help to new get-support. You can [test it here](https://update-getting-help-avvv26q-652soceglkw4u.eu-3.platformsh.site/overview/getting-help.html).
 
