### PR TITLE
:lipstick: Change intent for level two in sidebar

### DIFF
--- a/docs/themes/avocadocs/layouts/partials/navigation/sidebar/books/main.html
+++ b/docs/themes/avocadocs/layouts/partials/navigation/sidebar/books/main.html
@@ -62,8 +62,8 @@
                 {{ if not ( isset .Params "sidebarIgnore" )}}
                   <!-- SECOND LEVEL ITEM -->
                   <li class="duik-sidebar__item">
-                    <a href="{{ .RelPermalink }}" class="duik-sidebar__link{{ if eq $currentPage . }} active{{ end }}">
-                        <span style="display:inline-block; width: {{ $levelTwoIndent }};"></span>{{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle }}{{ else }}{{ .Title }}{{ end }}
+                    <a href="{{ .RelPermalink }}" class="duik-sidebar__link{{ if eq $currentPage . }} active{{ end }}" style="padding-left:calc(2em + {{ $levelTwoIndent }})">
+                        {{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle }}{{ else }}{{ .Title }}{{ end }}
                     </a>
                   </li>
                 {{ end }}
@@ -75,8 +75,8 @@
                     {{ if not ( isset .Params "sidebarIgnore" )}}
                       <!-- THIRD LEVEL ITEM -->
                       <li class="duik-sidebar__item">
-                        <a href="{{ .RelPermalink }}" class="duik-sidebar__link{{ if eq $currentPage . }} active{{ end }}">
-                            <span style="display:inline-block; width: {{ $levelThreeIndent }};"></span>{{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle }}{{ else }}{{ .Title }}{{ end }}
+                        <a href="{{ .RelPermalink }}" class="duik-sidebar__link{{ if eq $currentPage . }} active{{ end }}" style="padding-left:calc(2em + {{ $levelThreeIndent }})">
+                            {{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle }}{{ else }}{{ .Title }}{{ end }}
                         </a>
                       </li>
                     {{ end }}
@@ -94,8 +94,8 @@
                 {{ if not ( isset .Params "sidebarIgnore" )}}
                   <!-- SECOND LEVEL ITEM -->
                   <li class="duik-sidebar__item">
-                    <a href="{{ .RelPermalink }}" class="duik-sidebar__link{{ if eq $currentPage . }} active{{ end }}">
-                        <span style="display:inline-block; width: {{ $levelTwoIndent }};"></span>{{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle }}{{ else }}{{ .Title }}{{ end }}
+                    <a href="{{ .RelPermalink }}" class="duik-sidebar__link{{ if eq $currentPage . }} active{{ end }}" style="padding-left:calc(2em + {{ $levelTwoIndent }})">
+                        {{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle }}{{ else }}{{ .Title }}{{ end }}
                     </a>
                   </li>
                   {{ end }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

So it doesn't look weird when it runs to two lines.
For example, Configuration > ROutes > Server Side Includes at a width of 1201.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Removed a span and hard-coded padding left.
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
