### PR TITLE
:bug: Change hardcoded framework name for variable

### DIFF
--- a/docs/layouts/shortcodes/guides/config-service.md
+++ b/docs/layouts/shortcodes/guides/config-service.md
@@ -6,7 +6,7 @@ so that you always get the newest version when you deploy.
 
 You can add [other services](/configuration/services/_index.md) if desired,
 such as [Solr](/configuration/services/solr.md) or [Elasticsearch](/configuration/services/elasticsearch.md).
-You need to configure Drupal to use those services as well once the service is enabled.
+You need to configure {{ .Get "framework" }} to use those services as well once the service is enabled.
 
 Each service entry has a name (`db` {{if not (.Get "WordPress") }}and `cache`{{ end }} in the example below)
 as well as a `type` that specifies the service and version to use.

--- a/docs/src/guides/drupal9/deploy/configure.md
+++ b/docs/src/guides/drupal9/deploy/configure.md
@@ -15,7 +15,7 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service %}}
+{{% guides/config-service framework=Drupal %}}
 
 We recommend the latest [MariaDB](/configuration/services/mysql.md) version for Drupal,
 although you can also use Oracle MySQL or [PostgreSQL](/configuration/services/postgresql.md) if you prefer.

--- a/docs/src/guides/micronaut/deploy/configure.md
+++ b/docs/src/guides/micronaut/deploy/configure.md
@@ -15,12 +15,12 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service %}}
+{{% guides/config-service framework=Micronaut %}}
 
 Deploying Micronaut does not in itself require you to configure a database or another service,
 but in all likelihood you will want to add one at some point.
 
-{{% /guides/config-service %}}
+{{% /guides/config-service%}}
 
 {{< readFile file="static/files/fetch/servicesyaml/drupal9" highlight="yaml" >}}
 

--- a/docs/src/guides/quarkus/deploy/configure.md
+++ b/docs/src/guides/quarkus/deploy/configure.md
@@ -15,7 +15,7 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service %}}
+{{% guides/config-service framework=Quarkus %}}
 
 Deploying Quarkus doesn't in itself require you to configure a database or another service,
 but in all likelihood you will want to add one at some point.

--- a/docs/src/guides/spring/deploy/configure.md
+++ b/docs/src/guides/spring/deploy/configure.md
@@ -15,7 +15,7 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service %}}
+{{% guides/config-service framework=Spring %}}
 
 Deploying Spring does not in itself require you to configure a database or another service,
 but in all likelihood you will want to add one at some point.

--- a/docs/src/guides/typo3/deploy/configure.md
+++ b/docs/src/guides/typo3/deploy/configure.md
@@ -15,7 +15,7 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service %}}
+{{% guides/config-service framework=TYPO3 %}}
 
 We recommend the latest [MariaDB](/configuration/services/mysql.md) version for TYPO3,
 although you can also use Oracle MySQL or [PostgreSQL](/configuration/services/postgresql.md) if you prefer.

--- a/docs/src/guides/wordpress/deploy/configure.md
+++ b/docs/src/guides/wordpress/deploy/configure.md
@@ -15,7 +15,7 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service WordPress=true %}}
+{{% guides/config-service WordPress=true framework=WordPress %}}
 
 We recommend the latest [MariaDB](/configuration/services/mysql.md) version for WordPress.
 

--- a/docs/src/guides/wordpress/vanilla/configure.md
+++ b/docs/src/guides/wordpress/vanilla/configure.md
@@ -15,7 +15,7 @@ description: |
 
 ## Service configuration: `services.yaml`
 
-{{% guides/config-service WordPress=true %}}
+{{% guides/config-service WordPress=true framework=WordPress %}}
 
 We recommend the latest [MariaDB](/configuration/services/mysql.md) version for WordPress.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Because "Drupal" was hardcoded in a shortcode, it ended up in docs for other frameworks, like [Spring](https://docs.platform.sh/guides/spring/deploy/configure.html#service-configuration-servicesyaml). 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Changed the hardcoded value for a variable that should change for each framework. So the text still gets reused but with the proper value.
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

