### PR TITLE
Update backup-and-restore.md

### DIFF
--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -147,6 +147,20 @@ In most cases when creating regular backups the list should match up as expected
 but depending on their age some backups may no longer be available as per the [data retention policy](https://docs.platform.sh/administration/backup-and-restore.html#restore).
 As a rule, backup often and use the most recent in your restores.
 
+Using the Platform.sh CLI and [`jq`](https://stedolan.github.io/jq/manual/), you can filter the list of backups returned for a particular environment for those that are actually `restorable`.
+
+```bash
+$ platform project:curl -p PROJECT_ID /environments/ENVIRONMENT/backups | jq '.[] | select(.restorable=true) | {id, created_at}'
+{
+  "id": "mmzqoffpcpxnmy6zas55jjjdaq",
+  "created_at": "2021-11-12T19:30:07.680746+00:00"
+}
+{
+  "id": "pkxj46necupbzw627bmoeciz4q",
+  "created_at": "2021-11-12T19:25:39.895401+00:00"
+}
+```
+
 {{< /note >}}
 
 You can then restore a specific backup with the CLI as follows:

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -147,10 +147,11 @@ In most cases when creating regular backups the list should match up as expected
 but depending on their age some backups may no longer be available as per the [data retention policy](https://docs.platform.sh/administration/backup-and-restore.html#restore).
 As a rule, backup often and use the most recent in your restores.
 
-Using the Platform.sh CLI and [`jq`](https://stedolan.github.io/jq/manual/), you can filter the list of backups returned for a particular environment for those that are actually `restorable`.
+Using the Platform.sh CLI and [`jq`](https://stedolan.github.io/jq/manual/),
+you can filter the list of backups returned for a particular environment to those that are actually `restorable`.
 
 ```bash
-platform project:curl -p PROJECT_ID /environments/ENVIRONMENT/backups | jq '.[] | select((.restorable=true) and (.safe=true) and (.status="CREATED")) | {id, created_at}'
+platform project:curl -p <PROJECT_ID> /environments/<ENVIRONMENT_ID>/backups | jq '.[] | select((.restorable=true) and (.safe=true) and (.status="CREATED")) | {id, created_at}'
 {
   "id": "mmzqoffpcpxnmy6zas55jjjdaq",
   "created_at": "2021-11-12T19:30:07.680746+00:00"

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -150,7 +150,7 @@ As a rule, backup often and use the most recent in your restores.
 Using the Platform.sh CLI and [`jq`](https://stedolan.github.io/jq/manual/), you can filter the list of backups returned for a particular environment for those that are actually `restorable`.
 
 ```bash
-$ platform project:curl -p PROJECT_ID /environments/ENVIRONMENT/backups | jq '.[] | select(.restorable=true) | {id, created_at}'
+platform project:curl -p PROJECT_ID /environments/ENVIRONMENT/backups | jq '.[] | select((.restorable=true) and (.safe=true) and (.status="CREATED")) | {id, created_at}'
 {
   "id": "mmzqoffpcpxnmy6zas55jjjdaq",
   "created_at": "2021-11-12T19:30:07.680746+00:00"


### PR DESCRIPTION
## Why

Listed backups are a list of activities, rather than backups that can actually be restored to an environment. There is a `restorable` attribute on the `/environments/ENV/backups` endpoint that we can use with `jq` to filter out available backups. [Slack thread](https://platformsh.slack.com/archives/C0JHEUHQD/p1636738196443800)

## What's changed

Expanded the note on *Restore* with a jq tip. 
