### PR TITLE
:memo: Update PHP documentation with Composer 2

### DIFF
--- a/docs/src/languages/php/_index.md
+++ b/docs/src/languages/php/_index.md
@@ -117,19 +117,7 @@ That allows you to install a forked version of a global dependency from a custom
 PHP images use the `composer` build flavor by default,
 which runs `composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader` if a `composer.json` file is detected.
 
-Note that by default, all PHP containers include the latest Composer 1.x release. If you wish to use Composer 2.x, add it as a `dependency` (see the section below).
-
-```yaml
-dependencies:
-    php:
-        composer/composer: '^2'
-```
-
-You still see a message in the build output warning you about the availability of a new Composer version;
-that is the pre-packaged Composer 1 running to download Composer 2.
-You can safely ignore it.
-As Composer 2 performs considerably better than Composer 1,
-you should really upgrade unless your application has a Composer plugin dependency that hasn't yet been updated.
+Note that by default, all PHP containers include the latest Composer 1.x release. If you wish to use Composer 2.x, then you can use `composer2`.
 
 `drupal` runs `drush make` automatically in one of a few different ways.
 See the [Drupal 7](/frameworks/drupal7/_index.md) documentation for more details.


### PR DESCRIPTION
Change the way to use Composer 2, use it with the PHAR available.

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2001

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Change the way the user uses Composer 2 in PHP images

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
