### PR TITLE
:pencil2: Fix a typo in NodeJS doc

### DIFF
--- a/docs/src/languages/nodejs/_index.md
+++ b/docs/src/languages/nodejs/_index.md
@@ -78,7 +78,7 @@ as described here (a complete example is included at the end).
    ```
 
    {{< note >}}
-  If using the `pm2` process manager to start your application, it is recommended that you do so directly in `web.commands.start` as described above, rather than by calling a separate script the contains that command. Calling `pm2 start` at `web.commands.start` from within a script, even with the `--no-daemon` flag, has been found to daemonize itself and block other processes (such as backups) with continuous respawns.
+  If using the `pm2` process manager to start your application, it is recommended that you do so directly in `web.commands.start` as described above, rather than by calling a separate script that contains the command. Calling `pm2 start` at `web.commands.start` from within a script, even with the `--no-daemon` flag, has been found to daemonize itself and block other processes (such as backups) with continuous respawns.
    {{< /note >}}
 
 4. Create any Read/Write mounts. The root file system is read only. You must explicitly describe writable mounts. In (3) we set the home of the process manager to `/app/run` so this needs to be writable.


### PR DESCRIPTION
## Why

Found a typo

## What's changed

> rather than by calling a separate script the contains that command.

to 

> rather than by calling a separate script that contains the command.

:bow: 