### PR TITLE
:bug: Update available and default PHP extensions

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -146,8 +146,9 @@ There are also built-in modules that are always on:
 
 To see a complete list of extensions in your environment:
 
-1. [SSH](../) into the environment.
-2. Run the command `php -m`.
+```bash
+platform ssh -p <PROJECT_ID> -e <ENVIRONMENT_ID> 'php -m'
+```
 
 ## Custom PHP extensions
 

--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -17,175 +17,152 @@ runtime:
         - sqlite3
 ```
 
-The following extensions are enabled by default:
+The following table shows all extensions that are available (Avail) and on by default (Def).
+You can turn on the available ones with the `extensions` key
+and turn off those on by default with the `disabled_extensions` key.
+(Extensions marked with `*` are built in and can't be turned off.)
 
-* `bcmath`
-* `bz2` (7.1 and later)
-* `common` (7.1 and later)
-* `curl`
-* `dba` (7.1 and later)
-* `enchant` (7.1 and later)
-* `gd`
-* `interbase` (7.1 and later)
-* `intl`
-* `json` (5.6 and later)
-* `mbstring` (7.1 and later)
-* `mcrypt` (5.6 and earlier)
-* `mysql`
-* `mysqli` (not in 7.1)
-* `mysqlnd` (not in 7.1)
-* `odbc` (7.1 and later)
-* `openssl`
-* `pdo` (not in 7.1)
-* `pdo_mysql` (not in 7.1)
-* `pdo_sqlite` (not in 7.1)
-* `pgsql` (7.1 and later)
-* `pspell` (7.1 and later)
-* `readline` (7.1 and later)
-* `recode` (7.1 and later)
-* `snmp` (7.1 and later)
-* `soap` (7.1 and later)
-* `sqlite3`
-* `sockets` (7.0 and later)
-* `sybase` (7.1 and later)
-* `tidy` (7.1 and later)
-* `xml` (7.1 and later)
-* `xmlrpc` (7.1 and later, not in 8.0)
-* `zendopcache` (5.4 only) / `opcache` (5.5 and later)
-* `zip` (7.1 and later)
+| Extension         | 5.4   | 5.5   | 5.6   | 7.0   | 7.1   | 7.2   | 7.3   | 7.4   | 8.0   |
+| ----------------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| `amqp`            |       |       |       | Avail | Avail | Avail | Avail | Avail |       |
+| `apc`             | Avail | Avail |       |       |       |       |       |       |       |
+| `apcu`            | Avail |       | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `apcu_bc`         |       |       |       | Avail | Avail | Avail | Avail | Avail |       |
+| `applepay`        |       |       |       | Avail | Avail |       |       | Avail |       |
+| `bcmath`          |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `blackfire`       | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `bz2`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `calendar`        |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `ctype`           |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `curl`            | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `dba`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `dom`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `enchant`         | Avail | Avail | Avail | Def   | Def   | Def   | Def   | Def   | Def   |
+| `event`           |       |       |       |       | Avail | Avail | Avail | Avail | Avail |
+| `exif`            |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `ffi`             |       |       |       |       |       |       |       | Avail | Avail |
+| `fileinfo`        |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `ftp`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `gd`              | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `gearman`         | Avail | Avail | Avail |       |       |       |       |       |       |
+| `geoip`           | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `gettext`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `gmp`             | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `http`            | Avail | Avail |       |       |       |       | Avail | Avail | Avail |
+| `iconv`           |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `igbinary`        |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |
+| `imagick`         | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |       |
+| `imap`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `interbase`       | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `intl`            | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `ioncube`         |       |       |       | Avail | Avail | Avail |       |       |       |
+| `json`            |       |       | Def   | Def   | Def   | Def   | Def   | Def   | *     |
+| `ldap`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `mailparse`       |       |       |       | Avail | Avail | Avail |       | Avail | Avail |
+| `mbstring`        |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `mcrypt`          | Avail | Avail | Avail | Avail | Avail |       |       |       |       |
+| `memcache`        | Avail | Avail | Avail |       |       |       |       |       |       |
+| `memcached`       | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `mongo`           | Avail | Avail | Avail |       |       |       |       |       |       |
+| `mongodb`         |       |       |       | Avail | Avail | Avail | Avail | Avail |       |
+| `msgpack`         |       |       | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `mssql`           | Avail | Avail | Avail |       |       |       |       |       |       |
+| `mysql`           | Def   | Def   | Def   |       |       |       |       |       |       |
+| `mysqli`          | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `mysqlnd`         | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `newrelic`        |       |       | Avail | Avail | Avail | Avail | Avail | Avail |       |
+| `oauth`           |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |
+| `odbc`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `opcache`         |       | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `PDO`             | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `pdo_dblib`       | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `pdo_firebird`    | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |       |
+| `pdo_mysql`       | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `pdo_odbc`        | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `pdo_pgsql`       | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `pdo_sqlite`      | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `pdo_sqlsrv`      |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |
+| `pgsql`           | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `Phar`            |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `pinba`           | Avail | Avail | Avail |       |       |       |       |       |       |
+| `posix`           |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `propro`          |       |       | Avail |       |       |       |       |       |       |
+| `pspell`          | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `pthreads`        |       |       |       |       | Avail |       |       |       |       |
+| `raphf`           |       |       | Avail |       |       |       |       | Avail | Avail |
+| `readline`        | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `recode`          | Avail | Avail | Avail | Avail | Avail | Avail | Avail |       |       |
+| `redis`           | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `shmop`           |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |
+| `SimpleXML`       |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `snmp`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `soap`            |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `sockets`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `sodium`          |       |       |       |       |       | Avail | Avail | Avail | Avail |
+| `sourceguardian`  |       |       |       | Avail | Avail |       |       |       |       |
+| `spplus`          | Avail | Avail |       |       |       |       |       |       |       |
+| `sqlite3`         | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
+| `sqlsrv`          |       |       |       | Avail | Avail | Avail | Avail | Avail |       |
+| `ssh2`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |       |
+| `sybase`          |       |       |       |       | Avail | Avail | Avail | Avail | Avail |
+| `sysvmsg`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `sysvsem`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `sysvshm`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `tideways`        |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |
+| `tideways-xhprof` |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |
+| `tidy`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `tokenizer`       |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `uuid`            |       |       |       |       | Avail | Avail | Avail | Avail | Avail |
+| `wddx`            |       |       |       | Avail | Avail | Avail | Avail | Avail |       |
+| `xdebug`          |       |       |       |       | Avail | Avail | Avail | Avail | Avail |
+| `xcache`          | Avail | Avail |       |       |       |       |       |       |       |
+| `xhprof`          | Avail | Avail | Avail |       |       |       |       |       |       |
+| `xml`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `xmlreader`       |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `xmlrpc`          | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |       |
+| `xmlwriter`       |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
+| `xsl`             | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
+| `yaml`            |       |       |       |       | Avail | Avail | Avail | Avail | Avail |
+| `zbarcode`        |       |       |       | Avail | Avail | Avail | Avail |       |       |
+| `zendopcache`     | Def   | *     | *     | *     | *     | *     | *     | *     | *     |
+| `zip`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   |
 
+There are also built-in modules that are always on:
 
-You can disable those by adding them to the `disabled_extensions` list.
+- `date`
+- `filter`
+- `hash`
+- `json` (from 8.0)
+- `libxml`
+- `openssl`
+- `pcntl`
+- `pcre`
+- `Reflection`
+- `session`
+- `SPL`
+- `standard`
+- `Zend OPcache` (from 5.5)
+- `zlib`
 
-This is the complete list of extensions that can be enabled:
+To see a complete list of extensions in your environment:
 
-| Extension        | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 | 7.4 | 8.0 |
-|------------------|-----|-----|-----|-----|-----|-----|-----|-----|-----|
-| `amqp`           |     |     |     | *   | *   | *   | *   | *   |     |
-| `apc`            | *   | *   |     |     |     |     |     |     |     |
-| `apcu`           | *   |     | *   | *   | *   | *   | *   | *   | *   |
-| `apcu_bc`        |     |     |     | *   | *   | *   | *   | *   |     |
-| `applepay`       |     |     |     | *   | *   |     |     | *   |     |
-| `bcmath`         |     |     |     | *   | *   | *   | *   | *   | *   |
-| `blackfire`      | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `bz2`            |     |     |     | *   | *   | *   | *   | *   | *   |
-| `calendar`       |     |     |     | *   | *   | *   | *   | *   | *   |
-| `ctype`          |     |     |     | *   | *   | *   | *   | *   | *   |
-| `curl`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `dba`            |     |     |     | *   | *   | *   | *   | *   | *   |
-| `dom`            |     |     |     | *   | *   | *   | *   | *   | *   |
-| `enchant`        | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `event`          |     |     |     |     | *   | *   | *   | *   | *   |
-| `exif`           |     |     |     | *   | *   | *   | *   | *   | *   |
-| `ffi`            |     |     |     |     |     |     |     | *   | *   |
-| `fileinfo`       |     |     |     | *   | *   | *   | *   | *   | *   |
-| `ftp`            |     |     |     | *   | *   | *   | *   | *   | *   |
-| `gd`             | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `gearman`        | *   | *   | *   |     |     |     |     |     |     |
-| `geoip`          | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `gettext`        |     |     |     | *   | *   | *   | *   | *   | *   |
-| `gmp`            | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `http`           | *   | *   |     |     |     |     | *   | *   | *   |
-| `iconv`          |     |     |     | *   | *   | *   | *   | *   | *   |
-| `igbinary`       |     |     |     | *   | *   | *   | *   | *   | *   |
-| `imagick`        | *   | *   | *   | *   | *   | *   | *   | *   |     |
-| `imap`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `interbase`      | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `intl`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `ioncube`        |     |     |     | *   | *   | *   |     |     |     |
-| `json`           |     |     | *   | *   | *   | *   | *   | *   | *   |
-| `ldap`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `mailparse`      |     |     |     | *   | *   | *   |     | *   | *   |
-| `mbstring`       |     |     |     | *   | *   | *   | *   | *   | *   |
-| `mcrypt`         | *   | *   | *   | *   | *   |     |     |     |     |
-| `memcache`       | *   | *   | *   |     |     |     |     |     |     |
-| `memcached`      | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `mongo`          | *   | *   | *   |     |     |     |     |     |     |
-| `mongodb`        |     |     |     | *   | *   | *   | *   | *   |     |
-| `msgpack`        |     |     | *   | *   | *   | *   | *   | *   | *   |
-| `mssql`          | *   | *   | *   |     |     |     |     |     |     |
-| `mysql`          | *   | *   | *   |     |     |     |     |     |     |
-| `mysqli`         | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `mysqlnd`        | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `newrelic`       |     |     | *   | *   | *   | *   | *   | *   |     |
-| `oauth`          |     |     |     | *   | *   | *   | *   | *   | *   |
-| `odbc`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `opcache`        |     | *   | *   | *   | *   | *   | *   | *   | *   |
-| `openssl`        |     |     |     |     |     |     |     |     |     |
-| `pdo`            | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pdo_dblib`      | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pdo_firebird`   | *   | *   | *   | *   | *   | *   | *   | *   |     |
-| `pdo_mysql`      | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pdo_odbc`       | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pdo_pgsql`      | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pdo_sqlite`     | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pdo_sqlsrv`     |     |     |     | *   | *   | *   | *   | *   | *   |
-| `pgsql`          | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `phar`           |     |     |     | *   | *   | *   | *   | *   | *   |
-| `pinba`          | *   | *   | *   |     |     |     |     |     |     |
-| `posix`          |     |     |     | *   | *   | *   | *   | *   | *   |
-| `propro`         |     |     | *   |     |     |     |     |     |     |
-| `pspell`         | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `pthreads`       |     |     |     |     | *   |     |     |     |     |
-| `raphf`          |     |     | *   |     |     |     |     | *   | *   |
-| `readline`       | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `recode`         | *   | *   | *   | *   | *   | *   | *   |     |     |
-| `redis`          | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `shmop`          |     |     |     | *   | *   | *   | *   | *   | *   |
-| `simplexml`      |     |     |     | *   | *   | *   | *   | *   | *   |
-| `snmp`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `soap`           |     |     |     | *   | *   | *   | *   | *   | *   |
-| `sockets`        |     |     |     | *   | *   | *   | *   | *   | *   |
-| `sodium`         |     |     |     |     |     | *   | *   | *   | *   |
-| `sourceguardian` |     |     |     | *   | *   |     |     |     |     |
-| `spplus`         | *   | *   |     |     |     |     |     |     |     |
-| `sqlite3`        | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `sqlsrv`         |     |     |     | *   | *   | *   | *   | *   |     |
-| `ssh2`           | *   | *   | *   | *   | *   | *   | *   | *   |     |
-| `sybase`         |     |     |     |     | *   | *   | *   | *   | *   |
-| `sysvmsg`        |     |     |     | *   | *   | *   | *   | *   | *   |
-| `sysvsem`        |     |     |     | *   | *   | *   | *   | *   | *   |
-| `sysvshm`        |     |     |     | *   | *   | *   | *   | *   | *   |
-| `tideways`       |     |     |     | *   | *   | *   | *   | *   | *   |
-| `tideways-xhprof`|     |     |     | *   | *   | *   | *   | *   | *   |
-| `tidy`           | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `tokenizer`      |     |     |     | *   | *   | *   | *   | *   | *   |
-| `uuid`           |     |     |     |     | *   | *   | *   | *   | *   |
-| `wddx`           |     |     |     | *   | *   | *   | *   | *   |     |
-| `xdebug`         |     |     |     |     | *   | *   | *   | *   | *   |
-| `xcache`         | *   | *   |     |     |     |     |     |     |     |
-| `xhprof`         | *   | *   | *   |     |     |     |     |     |     |
-| `xml`            |     |     |     | *   | *   | *   | *   | *   | *   |
-| `xmlreader`      |     |     |     | *   | *   | *   | *   | *   | *   |
-| `xmlrpc`         | *   | *   | *   | *   | *   | *   | *   | *   |     |
-| `xmlwriter`      |     |     |     | *   | *   | *   | *   | *   | *   |
-| `xsl`            | *   | *   | *   | *   | *   | *   | *   | *   | *   |
-| `yaml`           |     |     |     |     | *   | *   | *   | *   | *   |
-| `zbarcode`       |     |     |     | *   | *   | *   | *   |     |     |
-| `zendopcache`    | *   |     |     |     |     |     |     |     |     |
-| `zip`            |     |     |     | *   | *   | *   | *   | *   | *   |
-
-{{< note >}}
-
-You can check out the output of `ls /etc/php5/mods-available`
-to see the up-to-date complete list of extensions after you SSH into your environment.
-For PHP7 and above, use `ls /etc/php/*/mods-available`.
-
-{{< /note >}}
+1. [SSH](../) into the environment.
+2. Run the command `php -m`.
 
 ## Custom PHP extensions
 
-It's possible to use an extension not listed here but it takes slightly more work:
+It's possible to use an extension not listed here but it takes slightly more
+work:
 
 1. Download the .so file for the extension as part of your build hook using `curl` or similar.
-   It can also be added to your Git repository if the file is not publicly downloadable,
+   It can also be added to your Git repository if the file isn't publicly downloadable,
    although committing large binary blobs to Git is generally not recommended.
 
 2. Provide a custom `php.ini` file in the application root (as a sibling of your `.platform.app.yaml` file)
    that loads the extension using an absolute path.
    For example, if the extension is named `spiffy.so` and is in the root of your application,
-   you would have a `php.ini` file that reads:
+   your `php.ini` file includes:
 
-    ```ini
-    extension=/app/spiffy.so
-    ```
+   ```ini
+   extension=/app/spiffy.so
+   ```


### PR DESCRIPTION


<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Updated PHP extensions to match what is available and on by default.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Moved the list of defaults into the table for better readability.

Also added list of built in modules that are on, but can't be turned off and updated the way to list extensions.
