### PR TITLE
Update registry.json

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -805,7 +805,7 @@
           "socket_family": "unix"
         },
         "commands": {
-          "start": "\"unicorn -l $SOCKET -E production config.ru\""
+          "start": "unicorn -l $SOCKET -E production config.ru"
         },
         "locations": {
           "/": {


### PR DESCRIPTION
## Why

Some example snippets are generated in docs, which then get reused in console within the Project Setup Wizard. For Ruby, there was some escaped double-quotes that were causing issues when a user copy-pastes the resulting `.platform.app.yaml` snippet. 

The same is happening for `root: "public"`, so these escape quotes aren't being seen on the console side.

## What's changed

Removed double quotes to give a workable config file. 
