### PR TITLE
:art: Don't break code blocks in tables

### DIFF
--- a/docs/themes/avocadocs/static/styles/customizations.css
+++ b/docs/themes/avocadocs/static/styles/customizations.css
@@ -100,6 +100,10 @@ code {
   display: inline-block;
 }
 
+table code {
+  white-space: nowrap;
+}
+
 .chroma {
   background-color: var(--primary) !important;
   /* word-wrap: normal !important;


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Text inside code elements would break in tables in ways that normal words wouldn't, making it hard to read. It has parts on one line and parts on the other. This is intended to keep it all together.

An example of the problem can be seen at https://docs.platform.sh/configuration/services/vault.html#policies where we see
```
encryp
t
decryp
t
```

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changed the css for code elements inside table. It does push the lines on long blocks, such as the second column at https://pr-2014-6vbu2ei-652soceglkw4u.eu-3.platformsh.site/configuration/services/vault.html#policies, but I think that's not so bad and the other parts are much more readable.
