### PR TITLE
:bug: Render text in shortcodes with render hooks

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,6 +6,6 @@ MinAlertLevel = suggestion # suggestion, warning, or error
 
 [*.md]
 BasedOnStyles = Platform,Vale
-TokenIgnores = {{< .* >}}, \
+TokenIgnores = {{ .* }}, \
 file\=.*, \
 highlight\=.*

--- a/docs/layouts/shortcodes/guides/config-app.html
+++ b/docs/layouts/shortcodes/guides/config-app.html
@@ -1,7 +1,7 @@
 
 <p>The <code>.platform.app.yaml</code> file is the heart of your application. It has an <a href="{{ relref . "/configuration/app/_index.md" }}">extensive set of options</a> that allow you to configure nearly any aspect of your application. Most of it is explained with comments inline. You can and likely will evolve this file over time as you build out your site.</p>
 
-<p>{{ .Inner | markdownify }}</p>
+<p>{{ .Inner | .Page.RenderString }}</p>
 
 {{ $file := printf "static/files/fetch/appyaml/%s" (.Get "template" ) }}
 {{ highlight ( readFile $file ) "yaml" ""}}

--- a/docs/layouts/shortcodes/guides/config-service.md
+++ b/docs/layouts/shortcodes/guides/config-service.md
@@ -2,7 +2,7 @@ The `services.yaml` file lists the pre-packaged services you need for your appli
 You pick the major version of the service and Platform.sh updates the patch version periodically
 so that you always get the newest version when you deploy.
 
-{{ .Inner }}
+{{ .Inner | .Page.RenderString }}
 
 You can add [other services](/configuration/services/_index.md) if desired,
 such as [Solr](/configuration/services/solr.md) or [Elasticsearch](/configuration/services/elasticsearch.md).

--- a/docs/layouts/shortcodes/guides/data-migration.md
+++ b/docs/layouts/shortcodes/guides/data-migration.md
@@ -10,7 +10,7 @@ If you are using MySQL/MariaDB, then the [`mysqldump` command](https://mariadb.c
 Save your dump file as `database.sql`.
 (Or any name, really, as long as it's the same as you use below.)
 
-{{ .Inner }}
+{{ .Inner | .Page.RenderString }}
 
 Next, import the database into your Platform.sh site.
 The easiest way to do so is with the Platform.sh CLI.

--- a/docs/layouts/shortcodes/guides/signup.html
+++ b/docs/layouts/shortcodes/guides/signup.html
@@ -20,7 +20,7 @@
 
 <p>After creating an account, you will be prompted to create your first project.  Since you'll be providing your own code, use the "Blank project" option.  You will be able to give the project a title and choose a region closest to the visitors of your site. You also have the option to select more resources for your project, although the <code>development</code> plan should be enough for you to get started.</p>
 
-{{ .Inner | markdownify }}
+{{ .Inner | .Page.RenderString }}
 
 <p>Then, add a Git remote for the Platform.sh project you just created.  The easiest way to get the ID of the project is to run just <code>plaform</code> on its own, which lists all of your projects.  As you have only one project, you can copy its ID.  Then in your Git repository run</p>
 

--- a/docs/themes/avocadocs/layouts/shortcodes/centerContent.html
+++ b/docs/themes/avocadocs/layouts/shortcodes/centerContent.html
@@ -1,5 +1,5 @@
 <!-- Helper shortcode to center body content -->
 
 <p class="text-center mb-5">
- {{ .Inner | markdownify }}
+ {{ .Inner | .Page.RenderString }}
 </p>


### PR DESCRIPTION


<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

To make sure links and such get transformed.

https://docs.platform.sh/guides/wordpress/deploy/configure.html#application-container-platformappyaml The link on `mounts` went to the `.md` file rather than the built page.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Switched from `Markdownify` to `.Page.RenderString`. These hooks aren't available in `Markdownify`

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
