### PR TITLE
:zap: Lower docs size so more resources for search

### DIFF
--- a/docs/.platform.app.yaml
+++ b/docs/.platform.app.yaml
@@ -45,8 +45,4 @@ web:
 
 disk: 1024
 
-mounts:
-  "public/scripts/xss/dist/config":
-      source: local
-      source_path: "config"
-
+size: S


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Search is hitting 300% or more of allocated RAM. This may cause problems.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Tried decreasing the size of the docs app.
