### PR TITLE
:bug: Limit region table CSS to that table

### DIFF
--- a/docs/static/styles/user-customizations.css
+++ b/docs/static/styles/user-customizations.css
@@ -302,7 +302,7 @@
   border-spacing: 2px;
 }
 
-.region-table > tr, td, th {
+.region-table tr, .region-table td, .region-table th {
   border: none;
   text-align: center;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

In #2007, I unfortunately entered the CSS for region tables too broad so they applied everywhere. See the table here for an example:
https://docs.platform.sh/configuration%2Fservices.html#type

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Made the CSS for the region table only apply to that table and not cells everywhere.
