### PR TITLE
Remove note about rebuilding after enabling outgoing email

### DIFF
--- a/docs/src/development/email.md
+++ b/docs/src/development/email.md
@@ -56,14 +56,6 @@ the environment variable `PLATFORM_SMTP_HOST` will be populated with the address
 When SMTP support is disabled,
 that environment variable will be empty.
 
-{{< note >}}
-
-Changing the SMTP status will not take effect immediately.
-You will need to issue a new *build*, not just a new deploy, for the changes to take effect.
-That means making a trivial change to some file in Git for the application.
-
-{{< /note >}}
-
 ## Ports
 
 - Port 465 and 587 should be used to send email to your own external email server.


### PR DESCRIPTION
## Why

This process is now automatic and the rebuild is no longer required after enabling outgoing email on a grid environment, This paragraph can be removed from the docs.

## What's changed

Remove unnecessary step from the process to enable outgoing e-mail on a grid environment. Ticking the checkbox alone is now all that is needed.
