### PR TITLE
:lipstick: Make ToC sticky on right

### DIFF
--- a/docs/themes/avocadocs/layouts/_default/list.html
+++ b/docs/themes/avocadocs/layouts/_default/list.html
@@ -14,16 +14,24 @@
 
           </div>
 
-          <!-- Table of contents -->
-          {{ if eq .Params.toc true }}
-            <div class="toc">
-              <h4>Contents:</h4>
-              {{ .TableOfContents }}
-            </div>
-          {{ end }}
+          <div class="content-grid">
 
-          <!-- Page content, anchorized -->
-          {{ partial "headline-hash.html" .Content }}
+            <!-- Table of contents -->
+            {{ if ne .Params.toc false }}
+              <div class="order-2">
+                <div class="toc">
+                  <h3>Contents:</h3>
+                  {{ .TableOfContents }}
+                </div>
+              </div>
+            {{ end }}
+
+            <div class="content-wrapper">
+              <!-- Page content, anchorized -->
+              {{ partial "headline-hash.html" .Content }}
+            </div>
+
+          </div>
 
           <!-- Section cards -->
           {{ range .Pages }}

--- a/docs/themes/avocadocs/layouts/_default/single.html
+++ b/docs/themes/avocadocs/layouts/_default/single.html
@@ -10,25 +10,29 @@
 
           {{ partial "editpagebutton.html" . }}
 
-          <div class="mb-7">
-              <!-- Page title -->
-              <div class="page-title">
-                <h1>{{ .Title }}</h1>
-              </div>
-
-              <!-- Table of contents -->
-              {{ if ne .Params.toc false }}
-                <div class="toc">
-                  <h4>Contents:</h4>
-                  {{ .TableOfContents }}
-                </div>
-              {{ end }}
-
-              <br>
+          <!-- Page title -->
+          <div class="page-title">
+            <h1>{{ .Title }}</h1>
           </div>
 
-          <!-- Page content, anchorized -->
-          {{ partial "headline-hash.html" .Content }}
+          <div class="content-grid">
+
+            <!-- Table of contents -->
+            {{ if ne .Params.toc false }}
+              <div class="order-2">
+                <div class="toc">
+                  <h3>Contents:</h3>
+                  {{ .TableOfContents }}
+                </div>
+              </div>
+            {{ end }}
+
+            <div class="content-wrapper">
+              <!-- Page content, anchorized -->
+              {{ partial "headline-hash.html" .Content }}
+            </div>
+
+          </div>
 
         </div>
       </div>

--- a/docs/themes/avocadocs/static/styles/customizations.css
+++ b/docs/themes/avocadocs/static/styles/customizations.css
@@ -348,7 +348,7 @@ MAIN
   text-align: right;
 }
 
-@media (min-width: 1030px) {
+@media (min-width: 992px) {
   .btn-edit-page {
     margin: 0rem 0rem .25rem 0rem;
   }
@@ -626,7 +626,7 @@ h6 {
 
 
 
-@media (min-width: 769px) {
+@media (min-width: 768px) {
     .mobile-only {
         display:none !important;
     }
@@ -658,19 +658,6 @@ body {
   color: var(--brand-font-color-black);
   text-align: left;
   background-color: #fff;
-}
-
-.toc {
-  padding: .25rem 2rem 1rem 2rem;
-  border: 1px solid var(--sidebar-bg-color);
-}
-
-.toc nav li {
-  list-style: none;
-}
-
-.toc nav a {
-  color: var(--brand-color-primary-blue);
 }
 
 .page-item {
@@ -725,7 +712,7 @@ body {
   border-bottom-right-radius: 0rem;
 }
 
-@media (min-width: 1030px) {
+@media (min-width: 992px) {
   .previous-page {
     display: inline;
   }
@@ -735,11 +722,11 @@ body {
 }
 
 
-@media (min-width: 825px) {
+@media (min-width: 768px) {
   .duik-content {
     min-height: calc(100vh - 5rem - 5.5rem);
     /* top | right | bottom | left */
-    padding: 3rem 3rem 3rem 9rem;
+    padding: 0rem 2rem 3rem 2rem;
   }
 /*
   .duik-sidebar {
@@ -747,11 +734,11 @@ body {
   } */
 }
 
-@media (min-width: 1030px) {
+@media (min-width: 992px) {
   .duik-content {
     min-height: calc(100vh - 5rem - 5.5rem);
     /* top | right | bottom | left */
-    padding: 0rem 7rem 3rem 7rem;
+    padding: 0rem 3rem 3rem 7rem;
   }
   /* .duik-sidebar {
     padding: 5rem 0 0 0;
@@ -762,7 +749,14 @@ body {
   } */
 }
 
-@media (max-width: 769px) {
+@media (min-width: 1200px) {
+  .duik-content {
+    /* top | right | bottom | left */
+    padding: 0rem 7rem 3rem 7rem;
+  }
+}
+
+@media (max-width: 768px) {
 
   .book-links {
     display: none !important;
@@ -775,7 +769,7 @@ body {
 
 }
 
-@media (min-width: 1185px) {
+@media (min-width: 1200px) {
 
   .book-links {
     /* display: none !important; */
@@ -783,7 +777,7 @@ body {
   }
 }
 
-@media (min-width: 1186px) {
+@media (min-width: 1200px) {
 
   .book-links {
     /* display: none !important; */
@@ -1160,7 +1154,7 @@ blockquote p {
   border-top: 2px solid #fff !important;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 992px) {
 
   .duik-sidebar {
     padding-top: 3rem !important;
@@ -1173,4 +1167,51 @@ blockquote p {
 
 .duik-sidebar-sticky {
   overflow: hidden !important;
+}
+
+/* Table of contents */
+.toc {
+  padding: .25rem 2rem 1rem 2rem;
+  border: 1px solid var(--sidebar-bg-color);
+  margin-bottom: 1rem;
+}
+
+.toc h3 {
+  padding-top: 1rem;
+  font-size: 18px;
+  font-weight: 300;
+  margin-bottom: 1rem;
+}
+
+.toc ul {
+  padding: 0;
+  margin: 0;
+}
+
+.toc ul ul {
+  padding-left: 1.5rem;
+}
+
+.toc nav li {
+  list-style: none;
+}
+
+.toc nav a {
+  color: var(--brand-color-primary-blue);
+}
+
+/* Sticky table of contents */
+@media (min-width: 768px) {
+  .content-grid {
+    display: grid;
+    grid-template-columns: minmax(20rem,80%) minmax(10rem,20%);
+  }
+
+  .toc {
+    position: sticky;
+    top: 84px;
+    padding: 0 1rem 0.5rem 1rem;
+    border: 1px solid var(--sidebar-bg-color);
+    margin-left: 1rem;
+  }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

To keep long tables of contents from pushing all actual content beneath the initial view.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
* Made the ToC sticky and placed on right for big enough screens.
* Standardized the breakpoints in `customizations.css` so there weren't different breaks at different points.


[Additional context](https://github.com/orgs/platformsh/projects/3)