### PR TITLE
:lipstick: Small improvements to styling

### DIFF
--- a/docs/themes/avocadocs/static/styles/customizations.css
+++ b/docs/themes/avocadocs/static/styles/customizations.css
@@ -1083,6 +1083,12 @@ td, th {
   padding: 8px;
 }
 
+th {
+  position: sticky;
+  top: calc(1.5rem * 3);
+  background-color: var(--primary);
+}
+
 blockquote {
   color: #333;
   border: none;

--- a/docs/themes/avocadocs/static/styles/customizations.css
+++ b/docs/themes/avocadocs/static/styles/customizations.css
@@ -1219,5 +1219,7 @@ blockquote p {
     padding: 0 1rem 0.5rem 1rem;
     border: 1px solid var(--sidebar-bg-color);
     margin-left: 1rem;
+    max-height: 100vh;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

* In long tables (like for [PHP extensions](https://docs.platform.sh/languages%2Fphp%2Fextensions.html)), it could be hard to see what column lined up with what heading.
* When a table of contents was long or the window not tall enough, a lot of the ToC was hidden and inaccessible.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
* Made the headings sticky so they're still shown when scrolling down. Should be a progressive enhancement (just not appear if the browser doesn't support it) rather than a breaking change. [Example](https://pr-2058-csuicfi-652soceglkw4u.eu-3.platformsh.site/languages/php/extensions.html)
* Made long ToCs scrollable