### PR TITLE
:bug: Fix search query on search page

### DIFF
--- a/docs/static/scripts/xss/src/containers/Search.js
+++ b/docs/static/scripts/xss/src/containers/Search.js
@@ -50,16 +50,19 @@ const Search = ({ fullPage }) => {
   }
 
   useEffect(() => {
-    if (!query) setQuery(urlQuery);
     getConfig().then((value) => {
       setConfig(value)
-      getInfo(value, query)
+      if (!query) {
+        setQuery(urlQuery)
+        getInfo(value, urlQuery)
+      } else {
+        getInfo(value, query)
+      }
     })
   }, [maxResults, urlQuery])
 
   const clearInputFunc = () => {
     setQuery('')
-    URLSearchParams.set('search', '')
   }
 
   const handleInputChange = (event) => {


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Search page was loading results for an empty string even when the URL had a query.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Change the useEffect hook to not rely on useState hook and just use the URL query directly.
