### PR TITLE
Add PLATFORM_SOURCE_DIR var

### DIFF
--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -142,7 +142,7 @@ and whether they're available during builds and at runtime.
 | PLATFORM_TREE_ID          | Yes   | Yes     | The ID of the tree the application was built from, essentially the SHA hash of the tree in Git. Use when you need a unique ID for each build |
 | PLATFORM_PROJECT_ENTROPY  | Yes   | Yes     | A random, 56-character value created when the project is created and then stable throughout the project's life. Can be used for Drupal hash salts, Symfony secrets, and other similar values. |
 | PLATFORM_APP_DIR          | Yes   | Yes     | The absolute path to the application directory. |
-| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR`, but within the context of a running Source Operation. It will contain a writable copy of your repository that you can commmit to during the operation, located at `/mnt/source` |
+| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR`, but within the context of a running Source Operation. It will contain a writable copy of your repository that you can commit to during the operation, located at `/mnt/source` |
 | PLATFORM_APPLICATION_NAME | Yes   | Yes     | The application name as set in the `.platform.app.yaml` file. |
 | PLATFORM_APPLICATION      | Yes   | Yes     | A base64-encoded JSON object that describes the application. It maps certain attributes from your `.platform.app.yaml` file, some with more structure. See [notes](#platform_application). |
 | PLATFORM_BRANCH           | No    | Yes     | The name of the Git branch. |

--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -142,7 +142,7 @@ and whether they're available during builds and at runtime.
 | PLATFORM_TREE_ID          | Yes   | Yes     | The ID of the tree the application was built from, essentially the SHA hash of the tree in Git. Use when you need a unique ID for each build |
 | PLATFORM_PROJECT_ENTROPY  | Yes   | Yes     | A random, 56-character value created when the project is created and then stable throughout the project's life. Can be used for Drupal hash salts, Symfony secrets, and other similar values. |
 | PLATFORM_APP_DIR          | Yes   | Yes     | The absolute path to the application directory. |
-| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR`, but within the context of a running Source Operation. It will contain a writable copy of your repository that you can commit to during the operation, located at `/mnt/source` |
+| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR` in the context of a running [source operation](../configuration/app/source-operations.md). The directory contains a writable copy of your repository that you can commit to during the operation located at `/mnt/source`. |
 | PLATFORM_APPLICATION_NAME | Yes   | Yes     | The application name as set in the `.platform.app.yaml` file. |
 | PLATFORM_APPLICATION      | Yes   | Yes     | A base64-encoded JSON object that describes the application. It maps certain attributes from your `.platform.app.yaml` file, some with more structure. See [notes](#platform_application). |
 | PLATFORM_BRANCH           | No    | Yes     | The name of the Git branch. |

--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -142,7 +142,7 @@ and whether they're available during builds and at runtime.
 | PLATFORM_TREE_ID          | Yes   | Yes     | The ID of the tree the application was built from, essentially the SHA hash of the tree in Git. Use when you need a unique ID for each build |
 | PLATFORM_PROJECT_ENTROPY  | Yes   | Yes     | A random, 56-character value created when the project is created and then stable throughout the project's life. Can be used for Drupal hash salts, Symfony secrets, and other similar values. |
 | PLATFORM_APP_DIR          | Yes   | Yes     | The absolute path to the application directory. |
-| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR` in the context of a running [source operation](../configuration/app/source-operations.md). The directory contains a writable copy of your repository that you can commit to during the operation located at `/mnt/source`. |
+| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR` in the context of a running [source operation](../configuration/app/source-operations.md). The directory contains a writable copy of your repository that you can commit to during the operation. |
 | PLATFORM_APPLICATION_NAME | Yes   | Yes     | The application name as set in the `.platform.app.yaml` file. |
 | PLATFORM_APPLICATION      | Yes   | Yes     | A base64-encoded JSON object that describes the application. It maps certain attributes from your `.platform.app.yaml` file, some with more structure. See [notes](#platform_application). |
 | PLATFORM_BRANCH           | No    | Yes     | The name of the Git branch. |

--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -142,6 +142,7 @@ and whether they're available during builds and at runtime.
 | PLATFORM_TREE_ID          | Yes   | Yes     | The ID of the tree the application was built from, essentially the SHA hash of the tree in Git. Use when you need a unique ID for each build |
 | PLATFORM_PROJECT_ENTROPY  | Yes   | Yes     | A random, 56-character value created when the project is created and then stable throughout the project's life. Can be used for Drupal hash salts, Symfony secrets, and other similar values. |
 | PLATFORM_APP_DIR          | Yes   | Yes     | The absolute path to the application directory. |
+| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFRM_APP_DIR`, but within the context of a running Source Operation. It will contain a writable copy of your repository that you can commmit to during the operation, located at `/mnt/source` |
 | PLATFORM_APPLICATION_NAME | Yes   | Yes     | The application name as set in the `.platform.app.yaml` file. |
 | PLATFORM_APPLICATION      | Yes   | Yes     | A base64-encoded JSON object that describes the application. It maps certain attributes from your `.platform.app.yaml` file, some with more structure. See [notes](#platform_application). |
 | PLATFORM_BRANCH           | No    | Yes     | The name of the Git branch. |


### PR DESCRIPTION
## Why

Source operations run in a special kind of build container, within which certain variables are not accessible. One var that is needed (`PLATFORM_APP_DIR`) is only relevant within the S.O. from the `PLATFORM_SOURCE_DIR` variable, which was undocumented. 

## What's changed

Added the `PLATFORM_SOURCE_DIR` variable to the P.sh-provided variable list. 