### PR TITLE
:memo: Clarify Let's Encrypt limits per env

### DIFF
--- a/docs/src/configuration/routes/https.md
+++ b/docs/src/configuration/routes/https.md
@@ -81,11 +81,15 @@ The use cases for this configuration are few.
 More complex routing logic is also possible if the situation calls for it.
 
 {{< note >}}
-Let's Encrypt has a limit of 100 TLS certificates per environment.
-If you define both a `{default}` and `www.{default}` route for each domain you use, that will give you a limit of 50 domains.
-Adding more than that will result in a warning on deploy and some domains will not be issued a TLS certificate.
-If you need more than that, we recommend obtaining additional certificates or a wildcard certificate from another TLS provider.
-Alternatively, consider splitting your project up into multiple discrete Platform.sh projects.
+
+Let's Encrypt has a limit of 100 hostnames per certificate.
+Each of your environments has 1 certificate.
+If you define both a `{default}` and `www.{default}` route for each domain you use, you have a limit of 50 hostnames.
+Adding more than that results in a warning on deploy and no new TLS certificates are issued.
+
+If you need more hostnames than that, obtain additional certificates or a wildcard certificate from another TLS provider.
+Alternatively, consider splitting your project up into multiple Platform.sh projects.
+
 {{< /note >}}
 
 ## TLS configuration

--- a/docs/src/configuration/routes/https.md
+++ b/docs/src/configuration/routes/https.md
@@ -83,7 +83,7 @@ More complex routing logic is also possible if the situation calls for it.
 {{< note >}}
 
 Let's Encrypt has a limit of 100 hostnames per certificate.
-Each of your environments has 1 certificate.
+Each of your environments can have 1 Let's Encrypt certificate.
 If you define both a `{default}` and `www.{default}` route for each domain you use, you have a limit of 50 hostnames.
 Adding more than that results in a warning on deploy and no new TLS certificates are issued.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Docs said that Let's Encrypt limited environments by domain and that exceeding the limits meant some domains would succeed and some fail. This isn't correct
[Additional context](https://github.com/orgs/platformsh/projects/3/views/1)

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Clarified that the limit regards hostnames.
