### PR TITLE
:bug: Fix description of disk property for apps

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -25,7 +25,7 @@ To override any part of a property, you have to provide the entire property.
 | `type`          | A [type](#types)                                | Yes      | No               | The base image to use with a specific app language. Format: `runtime:version`. |
 | `size`          | A [size](#sizes)                                |          | Yes              | How much resources to devote to the app. Defaults to `AUTO` in production environments. |
 | `relationships` | A dictionary of [relationships](#relationships) |          | Yes              | Connections to other services and apps. |
-| `disk`          | `integer` or `boolean`                          |          | Yes              | The size of the disk space for the app in MB. Minimum value is `128`. Defaults to `false`, meaning no disk is available. See [note on available space](#available-disk-space) |
+| `disk`          | `integer` or `null`                          |          | Yes              | The size of the disk space for the app in MB. Minimum value is `128`. Defaults to `null`, meaning no disk is available. See [note on available space](#available-disk-space) |
 | `mounts`        | A dictionary of [mounts](#mounts)               |          | Yes              | Directories that are writable even after the app is built. If set as a local source, `disk` is required. |
 | `web`           | A [web instance](#web)                          |          | N/A              | How the web application is served. |
 | `workers`       | A [worker instance](#workers)                   |          | N/A              | Alternate copies of the application to run as background processes. |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Docs said the `disk` property could be a boolean, but it defaults to `null`, not `false`.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changed it to `null`.
