### PR TITLE
:memo: Clarify start commands

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -187,6 +187,14 @@ web:
 This command runs every time your app is restarted, regardless of whether or not new code is deployed.
 So it can be useful for things like clearing ephemeral cache.
 
+```yaml {location=".platform.app.yaml"}
+web:
+    commands:
+        start: 'redis-cli -h redis.internal flushall; sleep infinity'
+        # For a Dedicated environment use:
+        # start: 'redis-cli flushall ; sleep infinity'
+```
+
 {{< note >}}
 
 Never "background" a start process using `&`.

--- a/docs/src/configuration/app/web.md
+++ b/docs/src/configuration/app/web.md
@@ -46,12 +46,22 @@ Although most websites today have some dynamic component, static site generators
 This documentation is built using a tool called Hugo, and served by Platform.sh as a static site.
 You can see the [entire repository](https://github.com/platformsh/platformsh-docs) on GitHub.
 The `.platform.app.yaml` file it uses is listed below.
-Note in particular the `web.commands.start` directive. There needs to be some background process so it's set to the `sleep` shell command, which blocks forever (or some really long time, as computers don't know about forever) and restart if needed.
-The file also runs the Hugo build process, and then specifies the files that are allowed to serve.
-
-If you do no require any additional service, you can leave the `.platform/services.yaml` file empty. The file itself is required, but its contents are optional.
 
 {{< readFile file="static/files/fetch/docsappyaml/platformsh-docs" highlight="yaml" >}}
+
+It does use one dynamic script in the `web.commands.start` directive for detecting and handling 404 errors.
+If you don't need this, set a background process using the `sleep` command:
+
+```yaml {location=".platform.app.yaml"}
+web:
+    commands:
+        # Run a no-op process that uses no CPU resources since this is a static site.
+        start: sleep infinity
+```
+
+This blocks as long as necessary and restarts if needed.
+If you don't require any additional services, leave your `.platform/services.yaml` file empty.
+The file itself is required, but its contents are optional.
 
 ## How can I control the headers sent with my files?
 

--- a/docs/src/guides/drupal9/redis.md
+++ b/docs/src/guides/drupal9/redis.md
@@ -6,9 +6,13 @@ description: |
 weight: -70
 ---
 
-If you are using the Platform.sh-provided Drupal template, most of this work is already done for you.  Redis is already configured and will be enabled after the installation is complete.
+If you are using the Platform.sh-provided Drupal template, most of this work is already done for you.
+Redis is already configured and is enabled after the installation is complete.
 
-Note that this Redis service is ephemeral, meaning it does not persist if the container moves or is shut down. Your app must treat it as ephemeral and not rely on it being there. One way to do this is regenerating cache in the `start` key in [your web configuration](/configuration/app/app-reference.md#commands) so the cache is regenerated each time your app starts.
+Note that this Redis service is ephemeral, meaning it doesn't persist if the container moves or is shut down.
+Your app must treat it as ephemeral and not rely on it being there.
+One way to do this is emptying cache in the `start` key in [your web configuration](../../configuration/app/app-reference.md#commands)
+so the cache is clean each time your app starts.
 
 If you are working from an older repository or migrating a pre-built site to Platform.sh, see the instructions below.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The docs for `web.commands.start` were misleading and lacking an example.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added an example for sleeping and clarified the example for the docs website.

[Additional context[(https://github.com/orgs/platformsh/projects/3/views/1)