### PR TITLE
:bug: Fix region names for public IPs

### DIFF
--- a/docs/data/regions.yaml
+++ b/docs/data/regions.yaml
@@ -1,6 +1,6 @@
 europe:
     eu:
-        name: Dublin
+        name: Ireland
         label: eu.platform.sh
         outbound_ips: 
             - "54.72.94.105"
@@ -12,7 +12,7 @@ europe:
             - "54.76.137.151"
             - "54.76.136.188"
     eu-2:
-        name: Paris
+        name: Ireland 2
         label: eu-2.platform.sh
         outbound_ips: 
             - "52.208.123.9"
@@ -24,7 +24,7 @@ europe:
             - "34.241.191.143"
             - "52.210.208.94"
     eu-4:
-        name: Paris 2
+        name: Ireland 3
         label: eu-4.platform.sh
         outbound_ips: 
             - "18.200.158.188"
@@ -46,7 +46,7 @@ europe:
         inbound_ips:
             - "13.51.62.86"
     de-2:
-        name: Berlin
+        name: Germany
         label: de-2.platform.sh
         outbound_ips: 
             - "35.246.248.138"


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Some of the region names were incorrect (apparently based on the timezone rather than the location. See [additional context](https://github.com/orgs/platformsh/projects/3/views/1).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Since cities seemed to be possibly wrong, switched to countries, which should be enough detail.