### PR TITLE
:memo: Clarify cron pausing during backups

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -549,6 +549,8 @@ For each app container, only one cron job can run at a time.
 If a new job is triggered while another is running, the new job is paused until the other completes.
 To minimize conflicts, a random offset is applied to all triggers.
 The offset is a random number of seconds up to 5 minutes or the cron frequency, whichever is smaller.
+Crons are also paused while activities such as [backups](../../dedicated/overview/backups.md) are running.
+The crons are queued to run after the other activity finishes.
 
 If an application defines both a `web` instance and `worker` instances, cron jobs run only on the `web` instance.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

People were surprised that crons were paused. [Additional context](https://github.com/orgs/platformsh/projects/3).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added a note about cron jobs being paused.