### PR TITLE
:bug: Improve search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ If you would like to test the search server, follow these steps:
    npm run dev
    npm run build-searchapp
    hugo
+   # Export master key again in this terminal.
+   export MEILI_MASTER_KEY=test
    ./deploy.sh
    ```
 
@@ -94,8 +96,6 @@ If you would like to test the search server, follow these steps:
 
    ```bash
    cd ../search
-   # Export again in this terminal window.
-   export MEILI_MASTER_KEY=test
    # Update the index
    ./post_deploy.sh
    ```

--- a/search/main.py
+++ b/search/main.py
@@ -28,6 +28,8 @@ class Search:
         # Show results for one query with the listed pages, when they by default would not show up as best results.
         # Note: these aren't automatically two-way, which is why they're all defined twice.
         self.synonyms = {
+            "cron": ["crons"],
+            "crons": ["cron"],
             "routes.yaml": ["routes"],
             "routes": ["routes.yaml"],
             "services": ["services.yaml"],

--- a/search/main.py
+++ b/search/main.py
@@ -29,7 +29,6 @@ class Search:
         # Note: these aren't automatically two-way, which is why they're all defined twice.
         self.synonyms = {
             "cron": ["crons"],
-            "crons": ["cron"],
             "routes.yaml": ["routes"],
             "routes": ["routes.yaml"],
             "services": ["services.yaml"],

--- a/search/main.py
+++ b/search/main.py
@@ -23,7 +23,7 @@ class Search:
         # Data available to the dropdown React app in docs, used to fill out autocomplete results.
         self.displayed_attributes = ['title', 'text', 'url', 'site', 'section']
         # Data actually searchable by our queries.
-        self.searchable_attributes = ['title', 'pageUrl', 'text', 'url', 'section']
+        self.searchable_attributes = ['title', 'pageUrl', 'section', 'url', 'text']
 
         # Show results for one query with the listed pages, when they by default would not show up as best results.
         # Note: these aren't automatically two-way, which is why they're all defined twice.
@@ -48,17 +48,17 @@ class Search:
 
         # Ranking rules:
         #
-        #   - Default order: ["typo", "words", "proximity", "attribute", "wordsPosition", "exactness"]
+        #   - Default order: ["words", "typo", "proximity", "attribute", "sort", "exactness"]
         #
-        #   - typo: fewer typos > more typos
         #   - words: number of times query is in document (greater number gets priority)
+        #   - typo: fewer typos > more typos
         #   - proximity: smaller distance between multiple occurences of query in same document > larger distances
         #   - attribute: sorted according to order of importance of attributes (searchable_attributes). terms in
         #       more important attributes first.
-        #   - wordsPosition: query terms earlier in document > later in document
+        #   - sort: queries are sorted at query time
         #   - exactness: similarity of matched words in document with query
 
-        self.ranking_rules = ["asc(rank)", "attribute", "typo", "words", "proximity", "wordsPosition", "exactness"]
+        self.ranking_rules = ["rank:asc", "attribute", "typo", "words", "proximity", "exactness"]
 
         self.updated_settings = {
             "rankingRules": self.ranking_rules,

--- a/search/main.py
+++ b/search/main.py
@@ -29,6 +29,8 @@ class Search:
         # Note: these aren't automatically two-way, which is why they're all defined twice.
         self.synonyms = {
             "cron": ["crons"],
+            "crons": ["cron tasks", "cron jobs"],
+            "e-mail": ["email"],
             "routes.yaml": ["routes"],
             "routes": ["routes.yaml"],
             "services": ["services.yaml"],


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Search results for "cron" aren't as helpful as those for "crons". Other searches not returning relevant results (Such as one for "firewall" returning [multiple rules]() above [firewall[()

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
* Made "crons" a synonym for "cron" in the search.
* Also "email" for "e-mail"
* Focused search on section title and URL over the text.
* Updated instructions for using search locally (exporting key in new terminal)

[Additional context](https://github.com/orgs/platformsh/projects/3)
