### PR TITLE
Document SECRET_KEY_BASE for Ruby/Elixir generation

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -40,11 +40,13 @@ If you are using Hex to manage your dependencies, it is necessary to specify a s
 ```yaml
 variables:
     env:
-        SECRET_KEY_BASE: $PLATFORM_PROJECT_ENTROPY
         MIX_ENV: 'prod'
 ```
 
 Include in your build hook the steps to retrieve a local Hex and `rebar`, and then run `mix do deps.get, deps.compile, compile` on your application to build a binary.
+
+Environment variable `SECRET_KEY_BASE` will be generated based on the
+`PLATFORM_PROJECT_ENTROPY` and can be still changed.
 
 {{< readFile file="src/registry/images/examples/full/elixir.hooks.app.yaml" highlight="yaml" location=".platform.app.yaml" >}}
 
@@ -71,7 +73,6 @@ type: elixir:1.9
 variables:
     env:
         MIX_ENV: 'prod'
-        SECRET_KEY_BASE: $PLATFORM_PROJECT_ENTROPY
 
 hooks:
     build: |

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -35,24 +35,24 @@ Remember `config/prod.exs` is evaluated at **build time** and has no access to r
 
 ## Building and running the application
 
-If you are using Hex to manage your dependencies, it is necessary to specify a set of environment variables in your `.platform.app.yaml` file that define the `MIX_ENV` and `SECRET_KEY_BASE`, which can be set to the Platform.sh-provided `PLATFORM_PROJECT_ENTROPY` environment variable:
+If you are using Hex to manage your dependencies, you need to specify the `MIX_ENV` environment variable:
 
-```yaml
+```yaml {location=".platform.app.yaml"}
 variables:
     env:
         MIX_ENV: 'prod'
 ```
 
-Include in your build hook the steps to retrieve a local Hex and `rebar`, and then run `mix do deps.get, deps.compile, compile` on your application to build a binary.
+The `SECRET_KEY_BASE` variable is generated automatically based on the [`PLATFORM_PROJECT_ENTROPY` variable](../development/variables/use-variables.md#use-platformsh-provided-variables).
+You can change it.
 
-Environment variable `SECRET_KEY_BASE` will be generated based on the
-`PLATFORM_PROJECT_ENTROPY` and can be still changed.
+Include in your build hook the steps to retrieve a local Hex and `rebar`, and then run `mix do deps.get, deps.compile, compile` on your application to build a binary.
 
 {{< readFile file="src/registry/images/examples/full/elixir.hooks.app.yaml" highlight="yaml" location=".platform.app.yaml" >}}
 
 {{< note >}}
 
-The above build hook works for most cases and assumes that your `mix.exs` file is located at [your app root](../create-apps/app-reference.md#root-directory).
+That build hook works for most cases and assumes that your `mix.exs` file is located at [your app root](../create-apps/app-reference.md#root-directory).
 
 {{< /note >}}
 
@@ -63,9 +63,9 @@ you can then start it from the `web.commands.start` directive.
 The start command _must_ run in the foreground, so you should set the `--no-halt` flag when calling `mix run`.
 {{< /note >}}
 
-The following basic `.platform.app.yaml` file is sufficient to run most Elixir applications.
+The following basic app configuration is sufficient to run most Elixir applications.
 
-```yaml
+```yaml {location=".platform.app.yaml"}
 name: app
 
 type: elixir:1.9

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -36,14 +36,11 @@ A complete example is included at the end of this section.
    You can change the Rails/Bundler via those environment variables,
    some of which are defaults on Platform.sh.
 
-    Environment variable `SECRET_KEY_BASE` will be generated based on the
-    `PLATFORM_PROJECT_ENTROPY` and can be still changed.
-
     ```yaml
     variables:
         env:
             BUNDLE_CACHE_ALL: '1' # default
-            BUNDLE_CLEAN: '1' # /!\ if you are working with Ruby<2.7 this does not work well
+            BUNDLE_CLEAN: '1' # /!\ if you are working with Ruby <2.7, this doesn't work well
             BUNDLE_DEPLOYMENT: '1' # default
             BUNDLE_ERROR_ON_STDERR: '1' # default
             BUNDLE_WITHOUT: 'development:test'
@@ -57,6 +54,9 @@ A complete example is included at the end of this section.
             RAILS_LOG_TO_STDOUT: '1' # default (log to /var/log/app.log)
             RAILS_TMP: '/tmp' # default
     ```
+
+    The `SECRET_KEY_BASE` variable is generated automatically based on the [`PLATFORM_PROJECT_ENTROPY` variable](../development/variables/use-variables.md#use-platformsh-provided-variables).
+    You can change it.
 
 3. Build your application with the build hook.
 

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -36,6 +36,9 @@ A complete example is included at the end of this section.
    You can change the Rails/Bundler via those environment variables,
    some of which are defaults on Platform.sh.
 
+    Environment variable `SECRET_KEY_BASE` will be generated based on the
+    `PLATFORM_PROJECT_ENTROPY` and can be still changed.
+
     ```yaml
     variables:
         env:


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Platform.sh issue "SECRET_KEY_BASE need to be 64-byte size but currently PLATFORM_ENTROPY is too short"

## What's changed

Document how we are generating the secret for users
