### PR TITLE
Include OVH in data deletion policy

### DIFF
--- a/docs/src/security/data-deletion.md
+++ b/docs/src/security/data-deletion.md
@@ -8,7 +8,7 @@ description: |
 
 {{< description >}}
 
-All projects, except those hosted on Orange Cloud for Business, utilize encrypted volumes. The encryption key is destroyed when we release the volume back to the provider, adding another layer of protection.
+All projects, except those hosted on OVH or Orange Cloud for Business, utilize encrypted volumes. The encryption key is destroyed when we release the volume back to the provider, adding another layer of protection.
 
 ## Media destruction
 


### PR DESCRIPTION
## Why

Security team is updating data deletion policy around encryption at rest. This includes OVH as well as Orange Cloud for Business.

## What's changed

OVH is added to the relevant line. 
