### PR TITLE
:bug: Fix typo

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -256,7 +256,7 @@ The following table presents possible properties for each location:
 | `passthru`          | `boolean` or  `string`                               | `false`   | Whether to forward disallowed and missing resources from this location to the app. A string is a path with a leading `/` to the controller, such as `/index.php`. |
 | `index`             | Array of `string`s or `null`                         |           | Files to consider when serving a request for a directory. When set, requires access to the files through the `allow` or `rules` keys. |
 | `expires`           | `string`                                             | `-1`      | How long static assets are cached. The default means no caching. Setting it to a value enables the `Cache-Control` and `Expires` headers. Times can be suffixed with `ms` = milliseconds, `s` = seconds, `m` = minutes, `h` = hours, `d` = days, `w` = weeks, `M` = months/30d, or `y` = years/365d. |
-| `allows`            | `boolean`                                            | `true`    | Whether to allow serving files which don't match a rule. |
+| `allow`             | `boolean`                                            | `true`    | Whether to allow serving files which don't match a rule. |
 | `scripts`           | `string`                                             |           | Whether to allow loading scripts in that location. Meaningful only on PHP containers. |
 | `headers`           | A headers dictionary                                 |           | Any additional headers to apply to static assets, mapping header names to values. Responses from the app aren't affected. |
 | `request_buffering` | A [request buffering dictionary](#request-buffering) | See below | Handling for chunked requests. |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

There was `allows` instead of `allow` as a key for the location.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changed to `allow`