### PR TITLE
:memo: Add note about /tmp disk usage

### DIFF
--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -49,6 +49,8 @@ Note that you do *not* need to add a relationship to point to the `files` servic
 
 The application container can now read from and write to the `my/files` path just as if it were a local writeable mount.
 
+User data that has been written to `/tmp` will not be automatically deleted. To avoid a full disk, regularly delete that data.
+
 {{< note >}}
 There is a small performance hit for using a network mount over a local mount.  In most cases it should not be noticeable.  However, high-volume sequential file creation (that is, creating a large number of small files in rapid succession) may see a more significant performance hit.  If that is something your application does regularly then a local mount will be more effective.
 {{< /note >}}

--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -49,7 +49,7 @@ Note that you do *not* need to add a relationship to point to the `files` servic
 
 The application container can now read from and write to the `my/files` path just as if it were a local writeable mount.
 
-User data that has been written to `/tmp` is not automatically deleted. To avoid a full disk, regularly delete that data.
+User data that has been written to `/tmp` isn't automatically deleted. To avoid a full disk, regularly delete that data.
 
 {{< note >}}
 There is a small performance hit for using a network mount over a local mount.  In most cases it should not be noticeable.  However, high-volume sequential file creation (that is, creating a large number of small files in rapid succession) may see a more significant performance hit.  If that is something your application does regularly then a local mount will be more effective.

--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -49,7 +49,7 @@ Note that you do *not* need to add a relationship to point to the `files` servic
 
 The application container can now read from and write to the `my/files` path just as if it were a local writeable mount.
 
-User data that has been written to `/tmp` will not be automatically deleted. To avoid a full disk, regularly delete that data.
+User data that has been written to `/tmp` is not automatically deleted. To avoid a full disk, regularly delete that data.
 
 {{< note >}}
 There is a small performance hit for using a network mount over a local mount.  In most cases it should not be noticeable.  However, high-volume sequential file creation (that is, creating a large number of small files in rapid succession) may see a more significant performance hit.  If that is something your application does regularly then a local mount will be more effective.

--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -49,7 +49,7 @@ Note that you do *not* need to add a relationship to point to the `files` servic
 
 The application container can now read from and write to the `my/files` path just as if it were a local writeable mount.
 
-User data that has been written to `/tmp` isn't automatically deleted. To avoid a full disk, regularly delete that data.
+User data that has been written to `/tmp` isn't automatically deleted. Delete your temporary data located in `/tmp` after usage to avoid a full disk.
 
 {{< note >}}
 There is a small performance hit for using a network mount over a local mount.  In most cases it should not be noticeable.  However, high-volume sequential file creation (that is, creating a large number of small files in rapid succession) may see a more significant performance hit.  If that is something your application does regularly then a local mount will be more effective.

--- a/docs/src/configuration/services/network-storage.md
+++ b/docs/src/configuration/services/network-storage.md
@@ -49,7 +49,8 @@ Note that you do *not* need to add a relationship to point to the `files` servic
 
 The application container can now read from and write to the `my/files` path just as if it were a local writeable mount.
 
-User data that has been written to `/tmp` isn't automatically deleted. Delete your temporary data located in `/tmp` after usage to avoid a full disk.
+User data that has been written to `/tmp` isn't automatically deleted. 
+To avoid a full disk, delete your temporary data located in `/tmp` after you've used it.
 
 {{< note >}}
 There is a small performance hit for using a network mount over a local mount.  In most cases it should not be noticeable.  However, high-volume sequential file creation (that is, creating a large number of small files in rapid succession) may see a more significant performance hit.  If that is something your application does regularly then a local mount will be more effective.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Disk space on `/tmp` reclaimed by an app or a user is not automatically deleted.
Additional context [can be found here](https://github.com/orgs/platformsh/projects/3/views/1)
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
