### PR TITLE
Correct PLATFORM_SOURCE_DIR info

### DIFF
--- a/docs/src/development/variables.md
+++ b/docs/src/development/variables.md
@@ -142,7 +142,7 @@ and whether they're available during builds and at runtime.
 | PLATFORM_TREE_ID          | Yes   | Yes     | The ID of the tree the application was built from, essentially the SHA hash of the tree in Git. Use when you need a unique ID for each build |
 | PLATFORM_PROJECT_ENTROPY  | Yes   | Yes     | A random, 56-character value created when the project is created and then stable throughout the project's life. Can be used for Drupal hash salts, Symfony secrets, and other similar values. |
 | PLATFORM_APP_DIR          | Yes   | Yes     | The absolute path to the application directory. |
-| PLATFORM_SOURCE_DIR       | No    | No      | Equivalent to `PLATFORM_APP_DIR` in the context of a running [source operation](../configuration/app/source-operations.md). The directory contains a writable copy of your repository that you can commit to during the operation. |
+| PLATFORM_SOURCE_DIR       | Yes    | No      | Equivalent to `PLATFORM_APP_DIR` in the context of a running [source operation](../configuration/app/source-operations.md). The directory contains a writable copy of your repository that you can commit to during the operation. |
 | PLATFORM_APPLICATION_NAME | Yes   | Yes     | The application name as set in the `.platform.app.yaml` file. |
 | PLATFORM_APPLICATION      | Yes   | Yes     | A base64-encoded JSON object that describes the application. It maps certain attributes from your `.platform.app.yaml` file, some with more structure. See [notes](#platform_application). |
 | PLATFORM_BRANCH           | No    | Yes     | The name of the Git branch. |


### PR DESCRIPTION
`PLATFORM_SOURCE_DIR` is available during build

## Why
Environmental variable `PLATFORM_SOURCE_DIR` is available during Build

[Additional context](https://github.com/orgs/platformsh/projects/3/views/1)

## What's changed

From: `PLATFORM_SOURCE_DIR` available during Build: `No`
To: &nbsp;&nbsp;&nbsp;&nbsp;`PLATFORM_SOURCE_DIR` available during Build: `Yes`