### PR TITLE
:memo: Clarify when domains are challenged

### DIFF
--- a/docs/src/configuration/routes/https.md
+++ b/docs/src/configuration/routes/https.md
@@ -244,7 +244,8 @@ Let's Encrypt needs to make sure that the requester is entitled to receive the S
 This ownership verification is achieved through the so called _Challenge_ step,
 more background information can be found in the [Let's Encrypt Documentation](https://letsencrypt.org/docs/challenge-types/).
 
-By default, Platform.sh checks that both the `some-example.platform.sh` and `www.some-example.platform.sh` domains are pointing to your project.
+If you include them in your [routes definition](./_index.md),
+Platform.sh checks that both the `example.platform.sh` and `www.example.platform.sh` domains are pointing to your project.
 The certificate also encompasses both these domains.
 Make sure that both your apex domain and it's `www` subdomain are pointing to your project,
 more information can be found in out go live [step-by-step guide](gettingstarted/next-steps/going-live/configure-dns.md).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The docs said `www` routes were checked by default, but it's only if they're included

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Clarified the behavior and added a link to where routes can be defined.