### PR TITLE
Update redis.md

### DIFF
--- a/docs/src/guides/wordpress/redis.md
+++ b/docs/src/guides/wordpress/redis.md
@@ -6,66 +6,115 @@ description: |
     Configure Redis for your WordPress site.
 ---
 
-There are a number of Redis plugins for WordPress, only some of which are compatible with Platform.sh.  We have tested and recommend [WP Redis](https://wordpress.org/plugins/wp-redis/) or [Redis Object Cache](https://wordpress.org/plugins/redis-cache/), both of which require a minimal amount of configuration.
+There are a number of Redis plugins for WordPress, only some of which are compatible with Platform.sh.
+We've tested and recommend [WP Redis](https://wordpress.org/plugins/wp-redis/)
+and [Redis Object Cache](https://wordpress.org/plugins/redis-cache/),
+both of which require a minimal amount of configuration.
 
 ## Requirements
 
-### Add a Redis service
+### 1. Add a Redis service
 
-First you need to create a Redis service.  In your `.platform/services.yaml` file, add the following:
+To create a Redis service, add the following to your [services configuration](../../configuration/services/_index.md):
 
-```yaml
+```yaml {location=".platform/services.yaml"}
 rediscache:
     type: redis:6.0
 ```
 
-That will create a service named `rediscache`, of type `redis`, specifically version `6.0`.
+That creates a service named `rediscache` with the type `redis`, specifically version `6.0`.
 
-### Expose the Redis service to your application
+### 2. Expose the Redis service to your application
 
-In your `.platform.app.yaml` file, we now need to open a connection to the new Redis service.  Under the `relationships` section, add the following:
+Next open a connection to the new Redis service.
+In the `relationships` section of your [app configuration](../../configuration/app/_index.md),
+add the following:
 
-```yaml
+```yaml {location=".platform.app.yaml"}
 relationships:
     redis: "rediscache:redis"
 ```
 
-The key (left side) is the name that will be exposed to the application in the `PLATFORM_RELATIONSHIPS` [variable](/development/variables.md).  The right hand side is the name of the service we specified above (`rediscache`) and the endpoint (`redis`).  If you named the service something different above, change `rediscache` to that.
+The key (left side) is the name that's exposed to the application in the [`PLATFORM_RELATIONSHIPS` variable](../../development/variables.md).
+The value (right side) is the name of the service you specified in step 1 (`rediscache`) and the endpoint (`redis`).
+If you named the service something different in step 1, change `rediscache` to that.
 
-### Add the Redis PHP extension
+### 3. Add the Redis PHP extension
 
-Because the Redis extension for PHP has been known to have BC breaks at times, we do not bundle a specific verison by default.  Instead, we provide a script to allow you to build your desired version in the build hook.  See the [PHP-Redis page](/languages/php/redis.md) for a simple-to-install script and instructions.
+Add the Redis extension for PHP in one of two ways:
 
-### Add the Redis library
+* In your [app configuration](../../configuration/app/app-reference.md#extensions) (for extension versions tied to the PHP version)
+* Using a [builder script](../../languages/php/redis.md) (if you need more control over the extension version)
 
-If using Composer to build WordPress, you can install the your chosen Redis plugin with one of the following Composer commands, depending on which plugin you've chosen:
+### 4. Add the Redis library
 
-```bash
-composer require "wpackagist-plugin/wp-redis":"^1.1.4" 
-```
-or
-```bash
-composer require "wpackagist-plugin/redis-cache":"^2.0.23" 
-```
+If you're using Composer to build WordPress,
+install your chosen Redis plugin with a Composer command depending on the plugin:
+
+{{< codetabs >}}
+
+---
+title=WP Redis
+file=none
+highlight=bash
+---
+
+composer require "wpackagist-plugin/wp-redis":"^1.1.4"
+
+<--->
+
+---
+title=Redis Object Cache
+file=none
+highlight=bash
+---
+
+composer require "wpackagist-plugin/redis-cache":"^2.0.23"
+
+{{< /codetabs >}}
 
 Then commit the resulting changes to your `composer.json` and `composer.lock` files.
 
 ## Configuration
 
-To enable the Redis cache to work with WordPress, the `object-cache.php` file needs to be copied from the plugin's directory to the `wp-content` directory.  Add the following line to the bottom of your `build` hook, adjusting the paths based on where you have your plugins located, and which plugin you have selected:
+To enable the Redis cache to work with WordPress,
+the `object-cache.php` file needs to be copied from the plugin's directory to the `wp-content` directory.
+Add the following line to the bottom of your `build` hook in your [app configuration](../../configuration/app/app-reference.md#hooks),
+adjusting the paths based on where your plugins are located:
 
-WP-Redis
-```bash
+<!-- vale off -->
+{{< codetabs >}}
+
+---
+title=WP Redis
+file=none
+highlight=yaml
+---
+
+hooks:
+    build: |
+        ...
         if [ -f wordpress/wp-content/plugins/wp-redis/object-cache.php ]; then
             cp wordpress/wp-content/plugins/wp-redis/object-cache.php wordpress/wp-content/object-cache.php
         fi
-```
-Redis Object Cache
-```bash
+
+<--->
+
+---
+title=Redis Object Cache
+file=none
+highlight=yaml
+---
+
+hooks:
+    build: |
+        ...
         if [ -f wordpress/wp-content/plugins/redis-cache/includes/object-cache.php ]; then
             cp wordpress/wp-content/plugins/redis-cache/includes/object-cache.php wordpress/wp-content/object-cache.php
         fi
-```
+
+{{< /codetabs >}}
+<!-- vale on -->
 
 It should now look something like:
 
@@ -83,45 +132,65 @@ hooks:
         fi
 ```
 
-Both plugins require slightly different configurations. If you have chosen WP Redis, place the following code in the `wp-config.php` file, somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
+Each plugin requires slightly different configuration.
+Place the code for your chosen plugin in the `wp-config.php` file,
+somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
 
-```php
+{{< codetabs >}}
+
+---
+title=WP Redis
+file=none
+highlight=php
+---
+
 <?php
 
 if ($config->hasRelationship('redis') && extension_loaded('redis')) {
-		$credentials = $config->credentials('redis');
-		$redis_server = array(
-			'host'     => $credentials['host'],
-			'port'     => $credentials['port'],
-			'auth'     => $credentials['password'],
-		);
-	}
-```
+        $credentials = $config->credentials('redis');
+        $redis_server = array(
+            'host'     => $credentials['host'],
+            'port'     => $credentials['port'],
+            'auth'     => $credentials['password'],
+        );
+    }
 
-If you've decided to use the Redis Object Cache plugin, place the following code in the `wp-config.php` file, somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
+<--->
 
-```php
+---
+title=Redis Object Cache
+file=none
+highlight=php
+---
+
 <?php
 
 if ($config->hasRelationship('redis') && extension_loaded('redis')) {
-		$credentials = $config->credentials('redis');
+        $credentials = $config->credentials('redis');
 
-		define('WP_REDIS_CLIENT', 'phpredis');
-		define('WP_REDIS_HOST', $credentials['host']);
-		define('WP_REDIS_PORT', $credentials['port']);
-	}
-```
+        define('WP_REDIS_CLIENT', 'phpredis');
+        define('WP_REDIS_HOST', $credentials['host']);
+        define('WP_REDIS_PORT', $credentials['port']);
+    }
 
-These sections will set up the parameters the plugins will look for in order to connect to the Redis server.  If you used a different name for the relationship above, change it accordingly.  This code will have no impact when run on a local development environment.
+{{< /codetabs >}}
 
-Once you have commited the above changes and pushed, you will need to activate the plugins.
+These sections set up the parameters the plugins look for in order to connect to the Redis server. 
+If you used a different name for the relationship above, change it accordingly.
+This code has no impact when run on a local development environment.
+
+Once you have committed the above changes and pushed, you need to activate the plugins.
 
 ### Verifying Redis is running
 
-Run this command in a SSH session in your environment `redis-cli -h redis.internal info`. You should run it before you push all this new code to your repository.
+Run this command in a SSH session in your environment: `redis-cli -h redis.internal info`.
+You should run it before you push all this new code to your repository.
 
-This should give you a baseline of activity on your Redis installation. There should be very little memory allocated to the Redis cache.
+This should give you a baseline of activity on your Redis installation.
+There should be very little memory allocated to the Redis cache.
 
-After you push this code, you should run the command and notice that allocated memory will start jumping.
+After you push this code, you should run the command and notice that allocated memory starts jumping.
 
-To verify the plugins are working, both add a `redis` command to the wp cli tool. While in a SSH session in your environment, you can run `wp help redis` to see the available commands your chosen plugin has added.  
+To verify the plugins are working, add a `redis` command to the WP CLI tool.
+While in a SSH session in your environment,
+you can run `wp help redis` to see the available commands your chosen plugin has added.  

--- a/docs/src/guides/wordpress/redis.md
+++ b/docs/src/guides/wordpress/redis.md
@@ -6,7 +6,7 @@ description: |
     Configure Redis for your WordPress site.
 ---
 
-There are a number of Redis libraries for WordPress, only some of which are compatible with Platform.sh.  We have tested and recommend [devgeniem/wp-redis-object-cache-dropin](https://packagist.org/packages/devgeniem/wp-redis-object-cache-dropin), which requires extremely little configuration.
+There are a number of Redis plugins for WordPress, only some of which are compatible with Platform.sh.  We have tested and recommend [WP Redis](https://wordpress.org/plugins/wp-redis/) or [Redis Object Cache](https://wordpress.org/plugins/redis-cache/), both of which require a minimal amount of configuration.
 
 ## Requirements
 
@@ -16,10 +16,10 @@ First you need to create a Redis service.  In your `.platform/services.yaml` fil
 
 ```yaml
 rediscache:
-    type: redis:5.0
+    type: redis:6.0
 ```
 
-That will create a service named `rediscache`, of type `redis`, specifically version `5.0`.
+That will create a service named `rediscache`, of type `redis`, specifically version `6.0`.
 
 ### Expose the Redis service to your application
 
@@ -38,20 +38,33 @@ Because the Redis extension for PHP has been known to have BC breaks at times, w
 
 ### Add the Redis library
 
-If using Composer to build WordPress, you can install the WP-Redis library with the following Composer command:
+If using Composer to build WordPress, you can install the your chosen Redis plugin with one of the following Composer commands, depending on which plugin you've chosen:
 
 ```bash
-composer require devgeniem/wp-redis-object-cache-dropin
+composer require "wpackagist-plugin/wp-redis":"^1.1.4" 
+```
+or
+```bash
+composer require "wpackagist-plugin/redis-cache":"^2.0.23" 
 ```
 
 Then commit the resulting changes to your `composer.json` and `composer.lock` files.
 
 ## Configuration
 
-To enable the WP-Redis cache the `object-cache.php` file needs to be copied from the downloaded package to the `wp-content` directory.  Add the following line to the bottom of your `build` hook:
+To enable the Redis cache to work with WordPress, the `object-cache.php` file needs to be copied from the plugin's directory to the `wp-content` directory.  Add the following line to the bottom of your `build` hook, adjusting the paths based on where you have your plugins located, and which plugin you have selected:
 
+WP-Redis
 ```bash
-cp -r wp-content/wp-redis-object-cache-dropin/object-cache.php web/wp/wp-content/object-cache.php
+        if [ -f wordpress/wp-content/plugins/wp-redis/object-cache.php ]; then
+            cp wordpress/wp-content/plugins/wp-redis/object-cache.php wordpress/wp-content/object-cache.php
+        fi
+```
+Redis Object Cache
+```bash
+        if [ -f wordpress/wp-content/plugins/redis-cache/includes/object-cache.php ]; then
+            cp wordpress/wp-content/plugins/redis-cache/includes/object-cache.php wordpress/wp-content/object-cache.php
+        fi
 ```
 
 It should now look something like:
@@ -60,11 +73,32 @@ It should now look something like:
 hooks:
     build: |
         set -e
-        bash install-redis.sh 5.1.1
-        cp -r wp-content/wp-redis-object-cache-dropin/object-cache.php web/wp/wp-content/object-cache.php
+        bash .platform-scripts/install-redis.sh 6.0.12
+        # Copy manually-provided plugins into the plugins directory.
+        # This allows manually-provided and composer-provided plugins to coexist.
+        rsync -a plugins/* wordpress/wp-content/plugins/
+
+        if [ -f wordpress/wp-content/plugins/redis-cache/includes/object-cache.php ]; then
+            cp wordpress/wp-content/plugins/redis-cache/includes/object-cache.php wordpress/wp-content/object-cache.php
+        fi
 ```
 
-Next, place the following code in the `wp-config.php` file, somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
+Both plugins require slightly different configurations. If you have chosen WP Redis, place the following code in the `wp-config.php` file, somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
+
+```php
+<?php
+
+if ($config->hasRelationship('redis') && extension_loaded('redis')) {
+		$credentials = $config->credentials('redis');
+		$redis_server = array(
+			'host'     => $credentials['host'],
+			'port'     => $credentials['port'],
+			'auth'     => $credentials['password'],
+		);
+	}
+```
+
+If you've decided to use the Redis Object Cache plugin, place the following code in the `wp-config.php` file, somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
 
 ```php
 <?php
@@ -72,15 +106,15 @@ Next, place the following code in the `wp-config.php` file, somewhere before the
 if ($config->hasRelationship('redis') && extension_loaded('redis')) {
 		$credentials = $config->credentials('redis');
 
-		define('WP_REDIS_CLIENT', 'pecl');
+		define('WP_REDIS_CLIENT', 'phpredis');
 		define('WP_REDIS_HOST', $credentials['host']);
 		define('WP_REDIS_PORT', $credentials['port']);
 	}
 ```
 
-That will define 3 constants that the WP-Redis extension will look for in order to connect to the Redis server.  If you used a different name for the relationship above, change it accordingly.  This code will have no impact when run on a local development environment.
+These sections will set up the parameters the plugins will look for in order to connect to the Redis server.  If you used a different name for the relationship above, change it accordingly.  This code will have no impact when run on a local development environment.
 
-That's it.  There is no Plugin to enable through the WordPress administrative interface.  Commit the above changes and push.
+Once you have commited the above changes and pushed, you will need to activate the plugins.
 
 ### Verifying Redis is running
 
@@ -89,3 +123,5 @@ Run this command in a SSH session in your environment `redis-cli -h redis.intern
 This should give you a baseline of activity on your Redis installation. There should be very little memory allocated to the Redis cache.
 
 After you push this code, you should run the command and notice that allocated memory will start jumping.
+
+To verify the plugins are working, both add a `redis` command to the wp cli tool. While in a SSH session in your environment, you can run `wp help redis` to see the available commands your chosen plugin has added.  


### PR DESCRIPTION
Updates to add instructions for installing both available plugins

## Why

Closes #1841 

## What's changed

Added instructions on how to set up and configure the plugins WP-Redis and Redis Object Cache, updated version of redis from 5.0 to 6.0,
