### PR TITLE
:memo: Clarify restriction on root location

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -252,7 +252,7 @@ The following table presents possible properties for each location:
 
 | Name                | Type                                                 | Default   | Description |
 | ------------------- | ---------------------------------------------------- | --------- | ----------- |
-| `root`              | `string`                                             |           | The directory to serve static assets for this location relative to the app root. Must be an actual directory and not just the app root. |
+| `root`              | `string`                                             |           | The directory to serve static assets for this location relative to the app's root directory. Must be an actual directory inside the root directory. |
 | `passthru`          | `boolean` or  `string`                               | `false`   | Whether to forward disallowed and missing resources from this location to the app. A string is a path with a leading `/` to the controller, such as `/index.php`. |
 | `index`             | Array of `string`s or `null`                         |           | Files to consider when serving a request for a directory. When set, requires access to the files through the `allow` or `rules` keys. |
 | `expires`           | `string`                                             | `-1`      | How long static assets are cached. The default means no caching. Setting it to a value enables the `Cache-Control` and `Expires` headers. Times can be suffixed with `ms` = milliseconds, `s` = seconds, `m` = minutes, `h` = hours, `d` = days, `w` = weeks, `M` = months/30d, or `y` = years/365d. |

--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -252,7 +252,7 @@ The following table presents possible properties for each location:
 
 | Name                | Type                                                 | Default   | Description |
 | ------------------- | ---------------------------------------------------- | --------- | ----------- |
-| `root`              | `string`                                             |           | The directory to serve static assets for this location relative to the app root. |
+| `root`              | `string`                                             |           | The directory to serve static assets for this location relative to the app root. Must be an actual directory and not just the app root. |
 | `passthru`          | `boolean` or  `string`                               | `false`   | Whether to forward disallowed and missing resources from this location to the app. A string is a path with a leading `/` to the controller, such as `/index.php`. |
 | `index`             | Array of `string`s or `null`                         |           | Files to consider when serving a request for a directory. When set, requires access to the files through the `allow` or `rules` keys. |
 | `expires`           | `string`                                             | `-1`      | How long static assets are cached. The default means no caching. Setting it to a value enables the `Cache-Control` and `Expires` headers. Times can be suffixed with `ms` = milliseconds, `s` = seconds, `m` = minutes, `h` = hours, `d` = days, `w` = weeks, `M` = months/30d, or `y` = years/365d. |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Make it clear that the `root` can't be set to the app root to avoid conflicts with dot files and the like.
[Additional context](https://github.com/orgs/platformsh/projects/3)

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added a sentence of explanation, though left out the reason as it seemed maybe extraneous and the space in the table is small.