### PR TITLE
:bug: Exclude registry pages from search index

### DIFF
--- a/docs/layouts/_default/index.json.json
+++ b/docs/layouts/_default/index.json.json
@@ -2,7 +2,9 @@
 {{- range .Site.Pages -}}
   {{- $pageDocuments := partial "meilindex/page" . | transform.Unmarshal -}}
   {{- range $index, $document := $pageDocuments -}}
-    {{- $allDocuments = $allDocuments | append $document -}}
+    {{- if not (hasPrefix $document.pageUrl "/registry") -}}
+      {{- $allDocuments = $allDocuments | append $document -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- $allDocuments | jsonify -}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2115

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
All docs starting with "/registry" should be skipped in search indexing now. Hope it doesn't exlude anything we want.
