### PR TITLE
Context for Composer + wp-cli

### DIFF
--- a/docs/src/guides/wordpress/deploy/customize.md
+++ b/docs/src/guides/wordpress/deploy/customize.md
@@ -79,4 +79,12 @@ Finally, install `wp-cli` and `psy/psych` using Composer. With these packages in
 $ composer require wp-cli/wp-cli-bundle psy/psysh --ignore-platform-reqs
 ```
 
+Once you've pushed that commit, you will be able to use the CLI within an application container from the `vendor` directory:
+
+```bash
+$ ./vendor/bin/wp plugin list
+```
+
+If receive an error of the type `This does not seem to be a WordPress installation.`, you may still need to provide the `--path` flag that points to your WordPress install path. 
+
 {{< guide-buttons next="Deploy WordPress" >}}

--- a/docs/src/guides/wordpress/deploy/customize.md
+++ b/docs/src/guides/wordpress/deploy/customize.md
@@ -82,6 +82,8 @@ composer require wp-cli/wp-cli-bundle psy/psysh --ignore-platform-reqs
 
 If you've installed the WordPress CLI as a dependency as in the [previous step](./configure.md#application-container-platformappyaml),
 you can use it directly.
+(As long as you have only `wp-cli/wp-cli-bundle` as a dependency and not `wp-cli/wp-cli`.)
+
 Otherwise, commit the changes from composer and push.
 Then you can use the WordPress CLI within an application container from the `vendor` directory:
 

--- a/docs/src/guides/wordpress/deploy/customize.md
+++ b/docs/src/guides/wordpress/deploy/customize.md
@@ -73,18 +73,23 @@ Lastly, to prevent committing WordPress Core when it is installed via Composer, 
 
 ## Additional packages
 
-Finally, install `wp-cli` and `psy/psych` using Composer. With these packages included, the WordPress CLI will be available to you when you SSH into the application container. 
+Finally, install `wp-cli` and `psy/psych` using Composer.
+With these packages included, the WordPress CLI is available when you SSH into the application container.
 
 ```bash
-$ composer require wp-cli/wp-cli-bundle psy/psysh --ignore-platform-reqs
+composer require wp-cli/wp-cli-bundle psy/psysh --ignore-platform-reqs
 ```
 
-Once you've pushed that commit, you will be able to use the CLI within an application container from the `vendor` directory:
+If you've installed the WordPress CLI as a dependency as in the [previous step](./configure.md#application-container-platformappyaml),
+you can use it directly.
+Otherwise, commit the changes from composer and push.
+Then you can use the WordPress CLI within an application container from the `vendor` directory:
 
 ```bash
-$ ./vendor/bin/wp plugin list
+./vendor/bin/wp plugin list
 ```
 
-If receive an error of the type `This does not seem to be a WordPress installation.`, you may still need to provide the `--path` flag that points to your WordPress install path. 
+If receive an error stating `This does not seem to be a WordPress installation.`,
+try providing the `--path` flag and point to your WordPress install path.
 
 {{< guide-buttons next="Deploy WordPress" >}}


### PR DESCRIPTION
## Why

Clarification over how to use `wp-cli` when installed via composer.

## What's changed

Added some more information for post-installation. 

[Additional context (30)](https://github.com/orgs/platformsh/projects/3/views/1)