### PR TITLE
:bug: Fix incorrect filename for relationships key in service docs

### DIFF
--- a/docs/src/configuration/services/_index.md
+++ b/docs/src/configuration/services/_index.md
@@ -89,14 +89,14 @@ This is done in your [app configuration for relationships](../app/app-reference.
 
 The relationship follows this pattern:
 
-```yaml {location=".platform/services.yaml"}
+```yaml {location=".platform.app.yaml"}
 relationships:
     <RELATIONSHIP_NAME>: "<SERVICE_NAME>:<ENDPOINT>"
 ```
 
 An example relationship to connect to the databases given in the [example in step 1](#1-configure-the-service):
 
-```yaml {location=".platform/services.yaml"}
+```yaml {location=".platform.app.yaml"}
 relationships:
     mysql_database: "database1:mysql"
     postgresql_database: "database2:postgresql"


### PR DESCRIPTION
## What's changed

The services documentation incorrectly indicates that the `relationships` key should be present in the `.platform/services.yaml` file, when it should be present in the `.platform.app.yaml` file instead. This PR fixes that.

A correct example of using the `relationships` key can be found [here](https://docs.platform.sh/configuration/app.html#comprehensive-example).