### PR TITLE
Fix typo in Wordpress composer migrate doc file

### DIFF
--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -140,10 +140,10 @@ Like WordPress core itself, themes and plugins can be installed as dependencies 
     Search for your existing themes and plugins [WPackagist](https://wpackagist) and install them through Composer with `composer require`:
 
     ```bash
-    # Theme
+    # Plugin
     composer require wpackagist-plugin/wordpress-seo
 
-    # Plugin
+    # Theme
     composer require wpackagist-theme/hueman
     ```
 


### PR DESCRIPTION
Small typo where Plugin and Theme were inverted

cf https://twitter.com/Stargayte/status/1491215111746244611
