### PR TITLE
:sparkles: Add PR comments with deployment links

### DIFF
--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -1,0 +1,129 @@
+name: Link to docs
+on: pull_request
+
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
+jobs:
+  get_url:
+    runs-on: ubuntu-latest
+    name: 'Get environment URL'
+    outputs:
+        commit_status: ${{ steps.get_env_url.outputs.env_status }}
+        env_url: ${{ steps.get_env_url.outputs.env_url }}  
+    steps: 
+        - uses: actions/checkout@v2
+        - name: Get environment URL
+          id: get_env_url
+          run: |
+            COMMIT_STATUS="pending"
+
+            # Make sure to give enough time for the initial status to be reported as pending 
+            sleep 120
+            STATUSES=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA  | jq -r 'length')
+            if [ $STATUSES == 0 ]; then
+              echo "No integration with Platform.sh reported. Skipping."
+            else
+              # Keep trying until deployment either succeeds or fails
+              until [ "$COMMIT_STATUS" == "success" ] || [ "$COMMIT_STATUS" == "failure" ]; do
+                ENV_URL=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA  | jq -r '.[0].target_url')
+                COMMIT_STATUS=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA  | jq -r '.[0].state')
+                
+                echo "The Platform.sh environment is: "
+                echo "$COMMIT_STATUS"
+                
+                if [ "$COMMIT_STATUS" == "pending" ]; then
+                  sleep 30
+                fi
+              done
+              if [ "$COMMIT_STATUS" == "success" ]; then
+                echo "Environment deployed to:"
+                echo "$ENV_URL"
+              fi
+
+              # Report the final statuses to be used in future jobs
+              echo "::set-output name=env_status::$COMMIT_STATUS"
+              echo "::set-output name=env_url::$ENV_URL"
+            fi
+
+  comment-failure:
+    runs-on: ubuntu-latest
+    name: Comment that deployment failed
+    needs: get_url
+    if: needs.get_url.outputs.commit_status == 'failure'
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `The environment on Platform.sh failed to deploy. :slightly_frowning_face:\n\nCheck the logs: https://console.platform.sh/projects/652soceglkw4u/pr-${process.env.PR_NUMBER}`
+            })
+
+  comment-with-links:
+    runs-on: ubuntu-latest
+    name: Comment with docs links
+    needs: get_url
+    if: needs.get_url.outputs.commit_status == 'success'
+    env:
+      ENV_URL: ${{ needs.get_url.outputs.env_url }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v14.5
+
+      - name: Get all changed files
+        id: get-files
+        run: |
+          files=()
+          for file in ${{ steps.changed-files.outputs.all_changed_and_modified_files }}; do
+
+            # Rewrite all Markdown files in the source to be links in the final environment
+            if [[ $file = "docs/src/"*".md" ]]; then
+
+              # Remove file extension
+              page=${file/.md/.html}
+
+              # Remove initial directory
+              page=${page/"docs/src/"/}
+
+              # Shift index pages up a level
+              page=${page/"/_index.html"/".html"}
+              
+              files+=("$ENV_URL$page")
+            fi
+          done
+          echo $(printf "%s||" "${files[@]}")
+          echo ::set-output name=changed_files::$(printf "%s||" "${files[@]}")
+      
+      - name: Comment with links
+        uses: actions/github-script@v5
+        if: steps.get-files.outputs.changed_files != ''
+        env:
+          PAGES: ${{ steps.get-files.outputs.changed_files }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Your Platform.sh environment has successfully deployed. :rocket:\n\nSee the changed pages:\n${process.env.PAGES.replace(/\|\|/g,"\n")}`
+            })
+
+      - name: Comment without links
+        uses: actions/github-script@v5
+        if: steps.get-files.outputs.changed_files == ''
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Your Platform.sh environment has successfully deployed. :rocket:\n\nSee the site: ${process.env.ENV_URL}`
+            })


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

We'd like to have direct links to pages changed in the PRs for speedy reviews.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added a workflow with:

* A comment on failure
* A general comment with a link to the site if no main docs pages are changed
* A comment with links to modified pages

It should run once for each PR. So subsequent pushes don't affect it.