### PR TITLE
:bug: Get PR comments with links working

### DIFF
--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -17,24 +17,30 @@ jobs:
           id: get_env_url
           run: |
             COMMIT_STATUS="pending"
+            COMMIT_SHA=${{ github.event.pull_request.head.sha }}
 
-            # Make sure to give enough time for the initial status to be reported as pending 
-            sleep 120
-            STATUSES=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA  | jq -r 'length')
+            # Wait for the initial status to be reported as pending or 10 minutes has passed
+            STATUSES=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA  | jq -r 'length')
+            STATUS_TRY=0
+            until [ $STATUSES != 0 ] || [ $STATUS_TRY == 20 ]; do
+              sleep 30
+              STATUSES=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA  | jq -r 'length')
+              ((STATUS_TRY+=1))
+            done
+            
             if [ $STATUSES == 0 ]; then
               echo "No integration with Platform.sh reported. Skipping."
+              exit 1
             else
               # Keep trying until deployment either succeeds or fails
               until [ "$COMMIT_STATUS" == "success" ] || [ "$COMMIT_STATUS" == "failure" ]; do
-                ENV_URL=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA  | jq -r '.[0].target_url')
-                COMMIT_STATUS=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA  | jq -r '.[0].state')
+                sleep 30
+
+                ENV_URL=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA  | jq -r '.[0].target_url')
+                COMMIT_STATUS=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA  | jq -r '.[0].state')
                 
-                echo "The Platform.sh environment is: "
+                echo "The Platform.sh environment is:"
                 echo "$COMMIT_STATUS"
-                
-                if [ "$COMMIT_STATUS" == "pending" ]; then
-                  sleep 30
-                fi
               done
               if [ "$COMMIT_STATUS" == "success" ]; then
                 echo "Environment deployed to:"

--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -105,8 +105,8 @@ jobs:
               files+=("$ENV_URL$page")
             fi
           done
-          echo $(printf "%s||" "${files[@]}")
-          echo ::set-output name=changed_files::$(printf "%s||" "${files[@]}")
+          echo $(printf "||%s" "${files[@]}")
+          echo ::set-output name=changed_files::$(printf "||%s" "${files[@]}")
       
       - name: Comment with links
         uses: actions/github-script@v5
@@ -119,7 +119,7 @@ jobs:
               issue_number: process.env.PR_NUMBER,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Your Platform.sh environment has successfully deployed. :rocket:\n\nSee the changed pages:\n${process.env.PAGES.replace(/\|\|/g,"\n")}`
+              body: `Your Platform.sh environment has successfully deployed. :rocket:\n\nSee the changed pages:\n${process.env.PAGES.replace(/\|\|/g,"\n- [ ] ")}`
             })
 
       - name: Comment without links

--- a/docs/src/development/faq.md
+++ b/docs/src/development/faq.md
@@ -5,7 +5,7 @@ sidebarTitle: "FAQ"
 
 ---
 
-## What is the difference between a Platform, a Project and an Environment?
+## What is the difference between a Platform, a Project, and an Environment?
 
 Platform or Platform.sh is the infrastructure which is running all your projects.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The workflow to add comments was falsely reporting a lack of an integration, ~~likely cause it wasn't waiting long enough to get a report~~. Because GitHub has different hashes for different things. 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

- Added a looping check to see if a status is reported. Ends at 10 minutes to prevent running forever.
- Switched to the PR head commit for the hash
- Made link list into a checklist