### PR TITLE
:bug: Run PR comment workflow only on opening

### DIFF
--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -1,5 +1,7 @@
 name: Link to docs
-on: pull_request
+on:
+  pull_request:
+    types: [opened,reopened]
 
 env:
   PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

To keep PRs from getting cluttered with comments. Currently the links to the built site are run on every edit.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changed to only run on open and reopen (so it can be manually triggered by closing and reopening).
