### PR TITLE
:memo: New Relic now available for PHP 8.0

### DIFF
--- a/docs/src/integrations/observability/new-relic/php.md
+++ b/docs/src/integrations/observability/new-relic/php.md
@@ -2,11 +2,8 @@
 title: "PHP"
 ---
 
-{{< note title="PHP version">}}
-
-Due to New Relic [dropping support for Zend Thread Safe (ZTS) versions](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/), you can't use New Relic with PHP v8.0+. To use New Relic with PHP, specify `type: 'php:7.4'` in your `.platform.app.yaml` file.
-
-{{< /note >}}
+New Relic isn't yet available on PHP 8.1.
+To use New Relic with PHP, specify `type: 'php:8.0'` or lower in your `.platform.app.yaml` file.
 
 ## Get your license key
 

--- a/docs/src/integrations/observability/new-relic/php.md
+++ b/docs/src/integrations/observability/new-relic/php.md
@@ -3,7 +3,7 @@ title: "PHP"
 ---
 
 New Relic isn't yet available on PHP 8.1.
-To use New Relic with PHP, specify `type: 'php:8.0'` or lower in your `.platform.app.yaml` file.
+To use New Relic with PHP, specify `type: 'php:8.0'` or lower in your [app configuration](../../../configuration/app/app-reference.md#type).
 
 ## Get your license key
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

New Relic is now available for PHP 8.1.
See additional context

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Decreased importance of note and changed it to only 8.1.