### PR TITLE
:bug: Fix bugs in PR comment workflow

### DIFF
--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -39,6 +39,7 @@ jobs:
                 sleep 30
 
                 ENV_URL=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA  | jq -r '.[0].target_url')
+                ENV_URL=${ENV_URL/http:/https:}
                 COMMIT_STATUS=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA  | jq -r '.[0].state')
                 
                 echo "The Platform.sh environment is:"

--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -114,7 +114,7 @@ jobs:
       
       - name: Comment with links
         uses: actions/github-script@v5
-        if: steps.get-files.outputs.changed_files != ''
+        if: steps.get-files.outputs.changed_files != '||'
         env:
           PAGES: ${{ steps.get-files.outputs.changed_files }}
         with:
@@ -128,7 +128,7 @@ jobs:
 
       - name: Comment without links
         uses: actions/github-script@v5
-        if: steps.get-files.outputs.changed_files == ''
+        if: steps.get-files.outputs.changed_files == '||'
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/link-to-docs.yaml
+++ b/.github/workflows/link-to-docs.yaml
@@ -73,6 +73,8 @@ jobs:
   comment-with-links:
     runs-on: ubuntu-latest
     name: Comment with docs links
+    permissions:
+      pull-requests: write
     needs: get_url
     if: needs.get_url.outputs.commit_status == 'success'
     env:


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

* PRs run from forks (like #2187) don't have permissions currently to comment on the PR.
* The check for no changed files wasn't catching when files weren't changed
* The links to the deployed environment weren't using HTTPS

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

- Added explicit permissions for job (if it doesn't work, I can try `pull_request_target`, but it didn't work immediately
- Check for the filler text instead of an empty string when no docs are actually changed.
- Switched to HTTPS