### PR TITLE
:bug: Download artifact from other workflow

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -16,16 +16,18 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download info on PR
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: get-pr-info.yaml
+          workflow_conclusion: success
           name: pr-info
 
       - name: Get PR number
         id: pr_number
-        run: echo "::set-output name=pr_number::$(cat pr_number.txt)"
+        run: echo "::set-output name=pr_number::$(cat pr-info/pr_number.txt)"
 
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ steps.pr_number.outputs.pr_number }}
-          path: pr-comment.txt
+          path: pr-info/pr-comment.txt


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Official GitHub action doesn't allow downloading from a separate workflow (rather than the main one).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Use a different action.