### PR TITLE
:memo: Clarify backups only work with active envs

### DIFF
--- a/contributing/markup-format.md
+++ b/contributing/markup-format.md
@@ -2,19 +2,27 @@
 
 ## Table of contents
 
-- [Markdown](#markdown)
-- [Front matter](#front-matter)
-- [Headings](#headings)
-- [Line wrapping](#line-wrapping)
-- [Links](#links)
-- [Notes](#notes)
-- [Images](#images)
-- [Videos & asciinema](#videos--asciinema)
-- [Code](#code)
-  - [Indentation](#indentation)
-- [Refer to the UI and keys](#refer-to-the-ui-and-keys)
-- [Code tabs](#code-tabs)
-- [Reuse content](#reuse-content)
+- [Markup reference for Platform.sh docs](#markup-reference-for-platformsh-docs)
+  - [Table of contents](#table-of-contents)
+  - [Markdown](#markdown)
+  - [Front matter](#front-matter)
+  - [Headings](#headings)
+  - [Line wrapping](#line-wrapping)
+  - [Links](#links)
+    - [Links to headers](#links-to-headers)
+  - [Notes](#notes)
+    - [Footnotes](#footnotes)
+  - [Images](#images)
+  - [Videos & asciinema](#videos--asciinema)
+  - [Code](#code)
+    - [Indentation](#indentation)
+    - [Code block location](#code-block-location)
+  - [Refer to the UI and keys](#refer-to-the-ui-and-keys)
+  - [Code tabs](#code-tabs)
+  - [Reuse content](#reuse-content)
+    - [Variables in the file](#variables-in-the-file)
+    - [Inner content](#inner-content)
+    - [Static files](#static-files)
 
 ## Markdown
 
@@ -105,7 +113,7 @@ By default, a title of `Note:` is added.
 
 A short note.
 
-{{< /note }}
+{{< /note >}}
 ```
 
 This shortcode accepts two optional parameters:

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -10,6 +10,14 @@ description: |
 Code is managed through Git and can be restored using normal Git routines.
 The built code file system isn't affected by backups or restores.
 
+{{< note title="Inactive environments" >}}
+
+Only active environments can be backed up and restored.
+To work with an [inactive environment](../other/glossary.md#inactive-environment),
+first activate it.
+
+{{< /note >}}
+
 ## Backups
 
 You need to have the "admin" role in order to create a backup of an environment.

--- a/docs/src/administration/web/environments.md
+++ b/docs/src/administration/web/environments.md
@@ -25,7 +25,7 @@ An environment is tied to a Git branch and can be created on demand.
 With Bitbucket and GitHub integrations you can even get a "development server" automatically for each and every pull request.
 
 You can have branches that aren't tied to a running instance of your application;
-these are called "inactive environments".
+these are called [inactive environments](../../other/glossary.md#inactive-environment).
 
 ## Default branch
 

--- a/docs/src/development/faq.md
+++ b/docs/src/development/faq.md
@@ -54,7 +54,7 @@ these mounts are cloned with the rest of your data.
 ## What happens if I push a local branch to my project?
 
 If you push a local branch that you created with Git,
-you create what's called an `inactive environment`, an environment that isn't deployed.
+you create what's called an [inactive environment](../../other/glossary.md#inactive-environment).
 
 This means there aren't any services attached to this branch.
 

--- a/docs/src/development/ssh/troubleshoot-ssh.md
+++ b/docs/src/development/ssh/troubleshoot-ssh.md
@@ -12,7 +12,10 @@ There are several places to check to try to solve such issues.
 
 ## Check your environment
 
-If your environment is inactive or the deployment has failed, you can't log in to it. To make sure the environment is active and the deployment has succeeded, check it using `platform environment:list` or in the [management console](https://console.platform.sh/) .
+If your environment is [inactive](../../other/glossary.md#inactive-environment) or the deployment has failed,
+you can't log in to it.
+To make sure the environment is active and the deployment has succeeded,
+check it using `platform environment:list` or in the [management console](https://console.platform.sh/) .
 
 ## Redeploy your environment
 

--- a/docs/src/development/ssh/troubleshoot-ssh.md
+++ b/docs/src/development/ssh/troubleshoot-ssh.md
@@ -88,7 +88,7 @@ To resolve this:
 
 {{< codetabs >}}
 ---
-title=In the CLI
+title=Using the CLI
 file=none
 highlight=false
 ---
@@ -98,7 +98,7 @@ Log in using the browser by running `platform login`.
 <--->
 
 ---
-title=Using the console
+title=In the console
 file=none
 highlight=false
 ---

--- a/docs/src/gettingstarted/developing/dev-environments/create-environment.md
+++ b/docs/src/gettingstarted/developing/dev-environments/create-environment.md
@@ -34,7 +34,7 @@ Platform.sh supports the deployment of isolated development environments from yo
 
     If you create a new branch with Git (`git checkout -b new-feature`),
     when you push its commits to Platform.sh that branch isn't automatically built.
-    The new branch (`new-feature`) is an *inactive environment*
+    The new branch (`new-feature`) is an [inactive environment](../../../other/glossary.md#inactive-environment)
     because Platform.sh doesn't assume that every branch should be associated with an active environment,
     since your plan limits the number of active environments you are allowed.
 

--- a/docs/src/gettingstarted/developing/dev-environments/create-environment.md
+++ b/docs/src/gettingstarted/developing/dev-environments/create-environment.md
@@ -12,58 +12,58 @@ Platform.sh supports the deployment of isolated development environments from yo
 
 1. **Create branch, make changes, push to Platform.sh**
 
-    Create and checkout a branch for your new feature.
+   Create and checkout a branch for your new feature.
 
-    ```bash
-    platform branch dev
-    ```
+   ```bash
+   platform branch dev
+   ```
 
-    This command creates a new branch `dev` from your default branch
-    as well as a local `dev` branch for you to work on.
-    The `dev` branch is a clone of your default branch, including an exact-copy of all of its data and files.
+   This command creates a new branch `dev` from your default branch
+   as well as a local `dev` branch for you to work on.
+   The `dev` branch is a clone of your default branch, including an exact-copy of all of its data and files.
 
-    Make changes to your code, commit them, and push to the Platform.sh remote.
+   Make changes to your code, commit them, and push to the Platform.sh remote.
 
-    ```bash
-    git add .
-    git commit -m "Commit message."
-    git push platform dev
-    ```
+   ```bash
+   git add .
+   git commit -m "Commit message."
+   git push platform dev
+   ```
 
-    {{< note >}}
+   {{< note >}}
 
-    If you create a new branch with Git (`git checkout -b new-feature`),
-    when you push its commits to Platform.sh that branch isn't automatically built.
-    The new branch (`new-feature`) is an [inactive environment](../../../other/glossary.md#inactive-environment)
-    because Platform.sh doesn't assume that every branch should be associated with an active environment,
-    since your plan limits the number of active environments you are allowed.
+   If you create a new branch with Git (`git checkout -b new-feature`),
+   when you push its commits to Platform.sh that branch isn't automatically built.
+   The new branch (`new-feature`) is an [inactive environment](../../../other/glossary.md#inactive-environment)
+   because Platform.sh doesn't assume that every branch should be associated with an active environment,
+   since your plan limits the number of active environments you are allowed.
 
-    If you want to activate the `new-feature` environment after it has been pushed, you can do so with the command
+   If you want to activate the `new-feature` environment after it has been pushed, you can do so with the command
 
-    ```bash
-    platform environment:activate new-feature
-    ```
-    {{< /note >}}
+   ```bash
+   platform environment:activate new-feature
+   ```
 
+   {{< /note >}}
 
 2. **Verify**
 
-    After Platform.sh has built and deployed the environment, verify that it has been activated by visiting its new URL:
+   After Platform.sh has built and deployed the environment, verify that it has been activated by visiting its new URL:
 
-    ```bash
-    platform url
-    ```
+   ```bash
+   platform url
+   ```
 
-    The command provides a list of the generated routes for the application
-    according to how the [routes](/configuration/routes/_index.md) were configured.
-    The structure is:
+   The command provides a list of the generated routes for the application
+   according to how the [routes](/configuration/routes/_index.md) were configured.
+   The structure is:
 
-    ```text
-    Enter a number to open a URL
-      [0] https://<branch name>-<hash of branch name>-<project ID>.<region>.platformsh.site/
-      [1] https://www.<branch name>-<hash of branch name>-<project ID>.<region>.platformsh.site/
-    ```
+   ```text
+   Enter a number to open a URL
+     [0] https://<branch name>-<hash of branch name>-<project ID>.<region>.platformsh.site/
+     [1] https://www.<branch name>-<hash of branch name>-<project ID>.<region>.platformsh.site/
+   ```
 
-    The above URLs represent the upstream (0) and redirect (1) routes for the most common `routes.yaml` configuration.
+   The above URLs represent the upstream (0) and redirect (1) routes for the most common `routes.yaml` configuration.
 
 {{< guide-buttons next="I've created a development environment" >}}

--- a/docs/src/other/glossary.md
+++ b/docs/src/other/glossary.md
@@ -38,8 +38,31 @@ You can also configure them manually.
 An environment that isn't deployed.
 To activate an inactive environment:
 
-* In the console, go to the **Settings** page for that environment.
-* Using the CLI, run `platform environment:activate -e <ENVIRONMENT_ID>`.
+{{< codetabs >}}
+
+---
+title=Using the CLI
+file=none
+highlight=bash
+---
+
+platform environment:activate -e <ENVIRONMENT_ID>
+
+<--->
+
+---
+title=In the console
+file=none
+highlight=false
+---
+
+1. In the [console](https://console.platform.sh), navigate to the project you want.
+2. Select the environment from the menu.
+3. Click **Settings**.
+4. Expand the **Status is Inactive** option.
+5. Click **Activate**.
+
+{{< /codetabs >}}
 
 ## Live environment
 

--- a/docs/src/other/glossary.md
+++ b/docs/src/other/glossary.md
@@ -36,7 +36,10 @@ You can also configure them manually.
 ## Inactive environment
 
 An environment that isn't deployed.
-You can activate an inactive environment from the environment configuration page on the Platform.sh management console.
+To activate an inactive environment:
+
+* In the console, go to the **Settings** page for that environment.
+* Using the CLI, run `platform environment:activate -e <ENVIRONMENT_ID>`.
 
 ## Live environment
 


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Backups only work with active environments but that wasn't clear in the docs on them. See additional context for request

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
* Added a note about inactive environments
* Linked to glossary there and elsewhere
* Added steps to activate in glossary
