### PR TITLE
:memo: Clarify PORT and SOCKET variables

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -235,9 +235,12 @@ web:
 
 #### Where to listen
 
-If `socket_family` is set to `tcp`, your app should listen on the port specified by the `PORT` environment variable.
+Where to listen depends on your setting for `web.upstream.socket_family` (defaults to `tcp`).
 
-If `socket_family` is set to `unix`, your app should open the Unix socket file specified by the `SOCKET` environment variable.
+| `socket_family` | Where to listen |
+| --------------- | --------------- |
+| `tcp`           | The port specified by the [`PORT` environment variable](../../development/variables/use-variables.md#use-platformsh-provided-variables) |
+| `unix`          | The Unix socket file specified by the [`SOCKET` environment variable](../../development/variables/use-variables.md#use-platformsh-provided-variables) |
 
 If your application isn't listening at the same place that the runtime is sending requests,
 you see `502 Bad Gateway` errors when you try to connect to your website.

--- a/docs/src/development/troubleshoot.md
+++ b/docs/src/development/troubleshoot.md
@@ -103,6 +103,9 @@ it indicates your application is crashing or unavailable.
 
 Typical causes and potential solutions include:
 
+* Your app is listening at the wrong place.
+  * Check your app's [upstream properties](../configuration/app/app-reference.md#upstream).
+  * If your app listening at a port, make sure it's using the [`PORT` environment variable](./variables/use-variables.md#use-platformsh-provided-variables).
 * Your `.platform.app.yaml` configuration has an error and a process isn't starting
   or requests can't be forwarded to it correctly.
   * Check your `web.commands.start` entry or your `passthru` configuration.

--- a/docs/src/development/variables/use-variables.md
+++ b/docs/src/development/variables/use-variables.md
@@ -334,7 +334,7 @@ console.log(stuffColors);
 ## Use Platform.sh-provided variables
 
 Platform.sh also provides a series of variables to inform your app about its runtime configuration.
-They're always prefixed with `PLATFORM_` to differentiate them from user-provided values.
+They're mostly prefixed with `PLATFORM_` to differentiate them from user-provided values.
 You can't set or update them directly.
 
 The most important of these variables is the relationship information in `PLATFORM_RELATIONSHIPS`,
@@ -361,6 +361,8 @@ and whether they're available during builds and at runtime.
 | `PLATFORM_SOURCE_DIR`       | Yes   | No      | Equivalent to `PLATFORM_APP_DIR` in the context of a running [source operation](../../configuration/app/source-operations.md). The directory contains a writable copy of your repository that you can commit to during the operation. |
 | `PLATFORM_TREE_ID`          | Yes   | Yes     | The ID of the tree the application was built from, essentially the SHA hash of the tree in Git. Use when you need a unique ID for each build. |
 | `PLATFORM_VARIABLES`        | Some  | Some    | A base64-encoded JSON object with all user-defined project and environment variables that don't use a [prefix](./_index.md#variable-prefixes). The keys are the variable names and the values are the variable values. Availability during builds and at runtime depends on the settings for each variable. See how to [access individual variables](#accessing-variables-in-a-shell). |
+| `PORT`                      | No    | Yes     | A `string` representing the port to which requests are sent if the [`web.upstream.socket_family` property](../../configuration/app/app-reference.md#upstream) is unset or set to `tcp`. |
+| `SOCKET`                    | No    | Yes     | A `string` representing the path to the Unix socket file to use if the [`web.upstream.socket_family` property](../../configuration/app/app-reference.md#upstream) is set to `unix`. |
 
 ### Variables on Dedicated environments
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Our docs didn't specify the PORT and SOCKET environment variables, so people who were trying to set a port to listen to could get confused (see additonal context for example). 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
- Added a note to 502 troubleshooting section
- Added links at app reference
- Switched reference to a table for easier scanning
- Added variables in list of Platform variables
