### PR TITLE
:memo: Generalize examples

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -37,7 +37,7 @@ To override any part of a property, you have to provide the entire property.
 | `dependencies`  | A [dependencies dictionary](#dependencies)      |          | No               | What global dependencies to install before the `build` hook is run. |
 | `hooks`         | A [hooks dictionary](#hooks)                    |          | No               | What commands run at different stages in the build and deploy process. |
 | `crons`         | A [cron dictionary](#crons)                     |          | No               | Scheduled tasks for the app. |
-| `source.root`   | `string`                                        |          | No               | The path where the app code lives. Defaults to the path of the configuration file. Useful for [multi-app setups](./multi-app.md) |
+| `source`        | A [source dictionary](#source)                  |          | No               | Information on the app's source code and operations that can be run on it.  |
 | `runtime`       | A [runtime dictionary](#runtime)                |          | No               | Customizations to your PHP or Lisp runtime. |
 
 ## Types
@@ -699,3 +699,12 @@ The following table shows the properties that can be set in `sizing_hints`:
 | `reserved_memory` | `integer` | 70      | 70      | The amount of memory reserved in MB. |
 
 See more about [PHP-FPM workers and sizing](../../languages/php/fpm.md).
+
+## Source
+
+The following table shows the properties that can be set in `source`:
+
+| Name         | Type                     | Required | Description |
+| ------------ | ------------------------ | -------- | ----------- |
+| `operations` | An operations dictionary |          |  Operations that can be applied to the source code. See [source operations](./source-operations.md) |
+| `root`       | `string`                 |          |  The path where the app code lives. Defaults to the path of the configuration file. Useful for [multi-app setups](./multi-app.md). |

--- a/docs/src/configuration/app/hooks/hooks-comparison.md
+++ b/docs/src/configuration/app/hooks/hooks-comparison.md
@@ -80,13 +80,10 @@ the execution of the `deploy` hook is logged in the [deploy log](../../../develo
 For example:
 
 ```bash
-[2021-07-03 10:03:51.100476] Launching hook 'cd public ; drush -y updatedb'.
+[2022-03-01 08:27:25.495579] Launching command 'bash export-config.sh'.
 
-My_custom_profile  7001  Update 7001: Enable the Platform module.
-Do you wish to run all pending updates? (y/n): y
-Performed update: my_custom_profile_update_7001
-'all' cache was cleared.
-Finished performing updates.
+🔥 Successfully cleared configuration
+🚀 Added new configuration details
 ```
 
 Your `deploy` hook is tied to commits in the same way as your builds.

--- a/docs/src/configuration/app/multi-app.md
+++ b/docs/src/configuration/app/multi-app.md
@@ -101,9 +101,6 @@ For example, the following `.platform/applications.yaml` file defines three appl
         build: |
             go build -o bin/app
     web:
-        upstream:
-            socket_family: tcp
-            protocol: http
         commands:
             start: ./bin/app
         locations:
@@ -157,11 +154,11 @@ That means the project must be structured like this:
 app1/
     .platform.app.yaml
     app1-submodule/
-        index.php
+        <CODE_FROM_SUBMODULE>
 app2/
     .platform.app.yaml
     app2-submodule/
-        index.php
+        <CODE_FROM_SUBMODULE>
 ```
 
 This puts your applications' files at a different path relative to your `.platform.app.yaml` files.

--- a/docs/src/configuration/app/source-operations.md
+++ b/docs/src/configuration/app/source-operations.md
@@ -1,6 +1,5 @@
 ---
 title: "[Beta] Source operations"
-toc: false
 sidebarTitle: "Source operations"
 tier:
   - Elite
@@ -186,26 +185,26 @@ source:
 
 The following Source Operation syncronizes your branch with an upstream Git repository.
 
-1. Add a project-level variable named `env:UPSTREAM_REMOTE` with the Git URL of the upstream repository.
-That will make that repository available as a Unix environment variable in all environments,
-including in the Source Operations environment.
+1. [Add a project-level variable](../../development/variables/set-variables.md#create-project-variables)
+   named `env:UPSTREAM_REMOTE` with the Git URL of the upstream repository.
+   That makes that repository available as a Unix environment variable in all environments,
+   including in the Source Operations environment.
 
-  - Variable name: `env:UPSTREAM:REMOTE`
-  - Variable example value: `https://github.com/platformsh/platformsh-docs`
+   - Variable name: `env:UPSTREAM_REMOTE`
+   - Variable example value: `https://github.com/platformsh/platformsh-docs`
 
-2. In your  `.platform.app.yaml` file, define a Source Operation to fetch from that upstream repository:
+2. In your app configuration, define a source operation to fetch from that upstream repository:
 
-  ```yaml
-  source:
-      operations:
-          upstream-update:
-              command: |
-                  set -e
-                  git remote add upstream $UPSTREAM_REMOTE
-                  git fetch --all
-                  git merge upstream/main
-  ```
-
+   ```yaml {location=".platform.app.yaml"}
+   source:
+       operations:
+           upstream-update:
+               command: |
+                   set -e
+                   git remote add upstream $UPSTREAM_REMOTE
+                   git fetch --all
+                   git merge upstream/main
+   ```
 
 3. Now every time you run `platform source-operation:run upstream-update` using the CLI on a given branch,
    the branch fetches all changes from the upstream git repository

--- a/docs/src/configuration/app/source-operations.md
+++ b/docs/src/configuration/app/source-operations.md
@@ -11,36 +11,35 @@ An application can define a number of operations that apply to its source code a
 
 {{< note >}}
 
-Source Operations are currently in Beta.
-While the syntax is not expected to change, some behavior might in the future.
+Source operations are currently in Beta.
+While the syntax isn't expected to change, some behavior might.
 
 {{< /note >}}
 
-A basic, common source operation could be to automatically update dependencies.
-For instance, with composer:
+To define source operation, add them to your [app configuration](./_index.md).
+The key for each operation is its name (whatever you want to call it).
+It needs to have a `command` property where you define what's run when the operation is triggered.
 
-```yaml
+For example, to update a file from a remote location, you could define an operation like this:
+
+```yaml {location=".platform.app.yaml"}
 source:
     operations:
-        update:
+        update-file:
             command: |
                 set -e
-                composer update
-                git add composer.lock
-                git commit -m "Update Composer dependencies."
+                curl -O https://example.com/myfile.txt
+                git add myfile.txt
+                git commit -m "Update remote file"
 ```
 
-The `update` key is the name of the operation.
-It is arbitrary, and multiple source operations can be defined.
-(You may wish to include more robust error handling than this example.)
-
-The environment resource gets a new `source-operation` action which can be triggered by the CLI:
+You now have a new `source-operation` action that can be triggered by the CLI:
 
 ```bash
-platform source-operation:run update
+platform source-operation:run update-file
 ```
 
-The `source-operation:run` command takes the command name (i.e. `update`) to run.
+The `source-operation:run` command takes the command name (i.e. `update-file`) to run.
 Additional variables can be added to inject into the environment of the source operation.
 They will be interpreted the same way as any other [variable](../../development/variables/_index.md) set through the management console or the CLI,
 which means you need an `env:` prefix to expose them as a Unix environment variable.
@@ -69,7 +68,119 @@ Also, if multiple applications in a single project both result in a new commit,
 that will appear as two distinct commits in the Git history but only a single new build/deploy cycle will occur.
 If multiple applications define source operations with the same name, they will all be executed sequentially on each application.
 
-## Source Operations usage examples
+## Usage examples
+
+### Update dependencies
+
+You might want to automatically update your project's dependencies.
+Do so in a source operation depending on your dependency manager:
+
+<!--vale off -->
+{{< codetabs >}}
+
+---
+title=Composer
+file=none
+highlight=yaml
+---
+
+source:
+    operations:
+        update:
+            command: |
+                set -e
+                composer update
+                git add composer.lock
+                git commit -m "Update Composer dependencies"
+
+<--->
+
+---
+title=npm
+file=none
+highlight=yaml
+---
+
+source:
+    operations:
+        update:
+            command: |
+                set -e
+                npm update
+                git add package.json package-lock.json 
+                git commit -m "Update npm dependencies"
+
+<--->
+
+---
+title=Yarn
+file=none
+highlight=yaml
+---
+
+source:
+    operations:
+        update:
+            command: |
+                set -e
+                yarn upgrade
+                git add yarn.lock
+                git commit -m "Update yarn dependencies"
+
+<--->
+
+---
+title=Go
+file=none
+highlight=yaml
+---
+
+source:
+    operations:
+        update:
+            command: |
+                set -e
+                go get -u
+                go mod tidy
+                git add go.mod go.sum
+                git commit -m "Update Go dependencies"
+
+<--->
+
+---
+title=Pipenv
+file=none
+highlight=yaml
+---
+
+source:
+    operations:
+        update:
+            command: |
+                set -e
+                pipenv update
+                git add Pipfile Pipfile.lock
+                git commit -m "Update Python dependencies"
+
+<--->
+
+---
+title=Bundler
+file=none
+highlight=yaml
+---
+
+source:
+    operations:
+        update:
+            command: |
+                set -e
+                bundle update --all
+                git add Gemfile Gemfile.lock
+                git commit -m "Update Ruby dependencies"
+
+{{< /codetabs >}}
+<!--vale on -->
 
 ### Update a site from an upstream repository or template
 

--- a/docs/src/configuration/routes/ssi.md
+++ b/docs/src/configuration/routes/ssi.md
@@ -46,7 +46,7 @@ And your final rendered page includes the other file:
 
 ## Caching and dynamic content
 
-You can use SSI to have caching and dynamic content in one.
+You can use SSI to have [caching](./cache.md) and dynamic content in one.
 So one file is cached, while another updates dynamically.
 
 For example, you can activate SSI on one route with cache disabled and enable cache on another route:

--- a/docs/src/configuration/services/redis.md
+++ b/docs/src/configuration/services/redis.md
@@ -127,18 +127,73 @@ highlight=python
 
 ## Multiple databases
 
-Redis 3.0 and above are configured to support up to 64 databases.  Redis does not support distinct users for different databases so the same relationship connection gives access to all databases.  To use a particular database, use the Redis [`select` command](https://redis.io/commands/select) through your API library.  For instance, in PHP you could write:
+Redis 3.0 and above are configured to support up to 64 databases.
+Redis doesn't support distinct users for different databases
+so one relationship connection gives access to all databases.
+
+The way to access a particular database depends on the [client library](https://redis.io/clients) you're using:
+
+{{< codetabs >}}
+
+---
+title=PHP
+file=none
+highlight=false
+---
+
+Use the Redis [`select` command](https://redis.io/commands/select):
 
 ```php
 <?php
-$redis->select(0);    // switch to DB 0
-$redis->set('x', '42');    // write 42 to x
-$redis->move('x', 1);    // move to DB 1
+$redis->select(0);       // switch to DB 0
+$redis->set('x', '42'); // write 42 to x
+$redis->move('x', 1);  // move to DB 1
 $redis->select(1);    // switch to DB 1
 $redis->get('x');    // will return 42
 ```
 
-Consult the documentation for your connection library and Redis itself for further details.
+<--->
+
+---
+title=Python
+file=none
+highlight=false
+---
+
+To manage [thread safety](https://github.com/redis/redis-py#thread-safety),
+the Python library suggests using separate client instances for each database:
+
+```python
+from redis import Redis
+from platformshconfig import Config
+
+# Get the credentials to connect to the Redis service.
+config = Config()
+credentials = config.credentials('redis')
+
+database0 = Redis(host='xxxxxx.cache.amazonaws.com', port=6379, db=0)
+database1 = Redis(host='xxxxxx.cache.amazonaws.com', port=6379, db=0)
+```
+
+<--->
+
+---
+title=Node.js
+file=none
+highlight=false
+---
+
+Use the Redis [`select` command](https://redis.io/commands/select):
+
+```javascript
+await client.SELECT(0);                  // switch to DB 0
+await client.set('x', '42');            // write 42 to x
+await client.MOVE('x', 1);             // move to DB 1
+await client.SELECT(1);               // switch to DB 1
+const value = await client.get('x'); // returns 42
+```
+
+{{< /codetabs >}}
 
 ## Eviction policy
 

--- a/docs/src/dedicated/architecture/options.md
+++ b/docs/src/dedicated/architecture/options.md
@@ -11,9 +11,21 @@ A dedicated single-node staging machine can be provisioned for your application 
 
 ## Multiple applications
 
-Each application deployed to the Dedicated Cluster corresponds to a single Git repository in the Development Environment.  Multiple `.platform.app.yaml` files are not supported.  While it is possible to host multiple application code bases in separate subdirectories/subpaths of the application (such as `/drupal`, `/api`, `/symfony`, etc.) controlled by a single `.platform.app.yaml`, it is not recommended and requires additional configuration.  One or more domains may be mapped to the application.
+Each application deployed to a Dedicated Cluster corresponds to a single Git repository in the Development Environment.
+Multiple `.platform.app.yaml` files aren't supported.
+While you can host multiple application code bases in separate subdirectories
+(such as `/app` and `/api`) controlled by a single `.platform.app.yaml`,
+it isn't recommended and requires additional configuration.
 
-Our experience has shown that hosting multiple applications on a common resource pool is often bad for all applications on the cluster.  We therefore limit the number of applications that may be hosted on a single Dedicated Cluster.  On a D6 instance, only one application is supported.  On D12 and larger Dedicated plans multiple applications are supported at an extra cost.  Each application would correspond to a different Development Environment and Git repository and cannot share data or files with other applications.  This configuration is discouraged.
+You can map one or more domains to your app.
+
+Experience has shown that hosting multiple apps on a common resource pool is often bad for all apps in the cluster.
+So the number of apps you can host on a single Dedicated Cluster is limited.
+On a D6 instance, you can only have only one app.
+On D12 and larger Dedicated plans, you can have multiple applications at an extra cost.
+Each application would correspond to a different Development Environment and Git repository.
+It can't share data or files with other apps.
+This configuration is discouraged.
 
 ## Multiple-AZ
 

--- a/docs/src/development/local/_index.md
+++ b/docs/src/development/local/_index.md
@@ -44,27 +44,30 @@ You will also notice a new directory in your project, `.platform/local`, which i
 
 ## Building the site locally
 
-Run the `platform build` command to run through the same build process as would be run on Platform.sh.  That will produce a `_www` directory in your project root that is a symlink to the currently active build in the `.platform/local/builds` folder. It should be used as the document root for your local web server.
+Run the `platform build` command to run through the same build process as would be run on Platform.sh.
+This creates `_www` directory in your project root that's a symbolic link to the currently active build in the `.platform/local/builds` folder.
+Run your local server from the `www` directory.
 
 ```bash
-~/htdocs/my-project $ platform build
-Building application myapp (runtime type: php)
-  Beginning to build ~/htdocs/my-project/project.make.
-  drupal-7.38 downloaded.
-  drupal patched with install-redirect-on-empty-database-728702-36.patch.
-  Generated PATCHES.txt file for drupal
-  platform-7.x-1.3 downloaded.
-Running post-build hooks
-Symlinking files from the 'shared' directory to sites/default
+$ platform build
 
-Build complete for application myapp
-Web root: ~/htdocs/my-project/_www
-~/htdocs/my-project $
+Building application app (runtime type: golang:1.17)
+Running post-build hooks
+Creating symbolic links to mimic shared file mounts
+  Symlinking .cache to .platform/local/shared/cache
+
+Build complete for application app
+Web root: <PATH_TO_PROJECT>/_www
 ```
 
-Because the `platform build` command will run locally, any runtime or tools used in your build process need to be available in your local environment, or the build will fail.  It may also result in side effects, such as the installation on your local computer of packages referenced in your `dependencies` block.
+Because the `platform build` command runs locally,
+you need to have any runtime or tools used in your build process available in your local environment
+or the build fails.
 
-If that is undesirable, a local virtual machine will let you create an enclosed local development environment that won't affect your main system.
+The process may also result in side effects,
+such as the installation on your local computer of packages referenced in your `dependencies` block.
+If you don't want that, use a local virtual machine
+as an enclosed local development environment that doesn't affect your main system.
 
 ## Running the code
 

--- a/docs/src/development/local/_index.md
+++ b/docs/src/development/local/_index.md
@@ -45,7 +45,8 @@ You will also notice a new directory in your project, `.platform/local`, which i
 ## Building the site locally
 
 Run the `platform build` command to run through the same build process as would be run on Platform.sh.
-This creates `_www` directory in your project root that's a symbolic link to the currently active build in the `.platform/local/builds` folder.
+This creates a `_www` directory in your project root
+that's a symbolic link to the currently active build in the `.platform/local/builds` folder.
 Run your local server from the `www` directory.
 
 ```bash


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Part of #2199

- [x] Server side includes could have examples that don't require PHP knowledge -- plain HTML would work
- [ ]  Examples in other languages for InfluxDB could use InfluxDB clients
- [x]  Examples for network storage workers should be more generic, especially for "How do I give my workers access to my main application’s files?"
- [x] Redis example should be not specific to PHP
- [x] Consider other examples for app overview -- what would best show the minimum and more options
- [x] For source operations, consider examples not using Composer
- [x] index.php files aren't generally necessary, should be more generic
- [x] A more generic log file for the example
- [x] Make examples generic and not framework-focused
- [x] Make local build more generic (nothing about document root)

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
- Added HTML SSI example and made a note about PHP not being necessary (Node.js and such wouldn't work in such a simple way, so I think it's actually OK :shrug: )
- Generalized section on worker instances in network storage and removed more in-depth example suited specifically to Drupal. The general example should be enough to accomplish the task without getting caught up in the details.
- Added Python and Node.js examples for Redis
- Made first source operations example generic and moved dependency updates to longer example list with other examples (taken from the templates automatic updates)
- Made example for submodules in multiple apps non-specific (and removed uneccessary default setting from Go app)
- Made log for deploy hook non-specific
- Made example for dedicated more generic (no framework names)
- Made local build example simpler and adjust partly to style rules.

The examples for InfluxDB are left for now. Hope to get them by DevRel through https://examples.docs.platform.sh/ Will be a future PR.