### PR TITLE
:bug: Only report deployed env if successful

### DIFF
--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -127,7 +127,7 @@ jobs:
       # If there are no changed pages, create a comment
       # with a link to general URL
       - name: Comment without links
-        if: steps.get-files.outputs.changed_files == ''
+        if: steps.get-files.outputs.changed_files == '' && steps.get_env_url.outputs.env_status == 'success'
         env:
           ENV_URL: ${{ steps.get_env_url.outputs.env_url }}
         run: |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The step `Comment without links` was running even when deployment wasn't successful (see comment on #2224). This meant overriding the failure message.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added a condition to only run that step on success.
