### PR TITLE
:memo: Remove examples of manual SSH URI building

### DIFF
--- a/docs/src/configuration/app/workers.md
+++ b/docs/src/configuration/app/workers.md
@@ -18,27 +18,6 @@ Use the `--worker` switch in the Platform.sh CLI, like so:
 platform ssh --worker=queue
 ```
 
-To output the SSH command, run:
-
-```bash
-platform ssh --worker=queue --pipe
-```
-
-You see the URL is the name of the worker added to the user name after the application name part of the SSH URL preceded by a double dash (`--`).
-
-For example, given a project with the id `3seb7f2j6ogbm`,
-you would connect to its default environment for an app called `app` with a URL such as:
-
-```bash
-ssh 3seb7f2j6ogbm-default-7rqtwti--app@ssh.us-2.platform.sh
-```
-
-To connect to a worker called `queue` (as in the example above), you would use an SSH URL such as:
-
-```bash
-ssh 3seb7f2j6ogbm-default-7rqtwti--app--queue@ssh.us-2.platform.sh
-```
-
 ## Stopping a worker
 
 If a worker instance needs to be updated during a new deployment,

--- a/docs/src/configuration/services/rabbitmq.md
+++ b/docs/src/configuration/services/rabbitmq.md
@@ -66,36 +66,51 @@ highlight=python
 
 {{< /codetabs >}}
 
-(The specific way to inject configuration into your application will vary. Consult your application or framework's documentation.)
+(The specific way to inject configuration into your application varies.
+Consult your application or framework's documentation.)
 
 ## Connecting to RabbitMQ
 
 ### From your local development environment
 
-For debugging purposes, it's sometimes useful to be able to directly connect to a service instance. You can do this using SSH tunneling. To open a tunnel, log into your application container like usual, but with an extra flag to enable local port forwarding:
+For debugging purposes, it's sometimes useful to connect directly to a service with an SSH tunnel.
+To open a tunnel, follow these steps.
 
-```bash
-ssh -L 5672:rabbitmqqueue.internal:5672 <projectid>-<branch_ID>@ssh.eu.platform.sh
-```
+1. Get the username and password to the service by checking your app's relationships:
 
-Within that SSH session, use the following command to pretty-print your relationships. This lets you see which username and password to use, and you can double check that the remote service's port is 5672.
+   ```bash
+   platform ssh 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq .'
+   ```
 
-```bash
-php -r 'print_r(json_decode(base64_decode($_ENV["PLATFORM_RELATIONSHIPS"])));'
-```
+2. Open a tunnel with port forwarding:
 
-If your service is running on a different port, you can re-open your SSH session with the correct port by modifying your `-L` flag: `-L 5672:rabbitmqqueue.internal:<remote port>`.
+   ```bash
+   platform tunnel:single -g
+   ```
 
-Finally, while the session is open, you can launch a RabbitMQ client of your choice from your local workstation, configured to connect to `localhost:5672` using the username and password you found in the relationship variable.
+3. Launch a RabbitMQ client of your choice configured to connect to the location from step 2
+   with the username and password from step 1.
 
 ### Access the management plugin  (Web UI)
-In case you want to access the browser-based UI, you have to use an SSH tunnel. To open a tunnel, log into your application container like usual, but with an extra flag to enable local port forwarding:
 
-```bash
-ssh -L 15672:rabbitmqqueue.internal:15672 <projectid>-<branch_ID>@ssh.eu.platform.sh
-```
+To access the browser-based UI, use an SSH tunnel.
+To open a tunnel, follow these steps.
 
-After you successfully established a connection, you should be able to open `http://localhost:15672` in your browser. You'll find the credentials like mentioned above.
+1. SSH into your app container with a flag for local port forwarding:
+
+   ```bash
+   ssh $(platform ssh --pipe) -L 15672:rabbitmqqueue.internal:15672
+   ```
+
+2. Within that SSH session, get the username and password.
+   Use the following command to see your app's relationships:
+
+   ```bash
+   echo "$PLATFORM_RELATIONSHIPS" | base64 --decode | jq .
+   ```
+
+3. Open `http://localhost:15672` in your browser.
+   Use the credentials from step 2.
 
 ### From the application container
 

--- a/docs/src/configuration/services/rabbitmq.md
+++ b/docs/src/configuration/services/rabbitmq.md
@@ -74,22 +74,13 @@ Consult your application or framework's documentation.)
 ### From your local development environment
 
 For debugging purposes, it's sometimes useful to connect directly to a service with an SSH tunnel.
-To open a tunnel, follow these steps.
+Open a tunnel with port forwarding:
 
-1. Get the username and password to the service by checking your app's relationships:
+```bash
+platform tunnel:single -g
+```
 
-   ```bash
-   platform ssh 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq .'
-   ```
-
-2. Open a tunnel with port forwarding:
-
-   ```bash
-   platform tunnel:single -g
-   ```
-
-3. Launch a RabbitMQ client of your choice configured to connect to the location from step 2
-   with the username and password from step 1.
+Then launch a RabbitMQ client of your choice configured to connect to the location returned.
 
 ### Access the management plugin  (Web UI)
 

--- a/docs/src/configuration/services/rabbitmq.md
+++ b/docs/src/configuration/services/rabbitmq.md
@@ -90,7 +90,7 @@ To open a tunnel, follow these steps.
 1. SSH into your app container with a flag for local port forwarding:
 
    ```bash
-   ssh $(platform ssh --pipe) -L 15672:rabbitmqqueue.internal:15672
+   ssh $(platform ssh --pipe) -L 15672:<RELATIONSHIP_NAME>.internal:15672
    ```
 
 2. Within that SSH session, get the username and password.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The recommendation to build a SSH URI manually led to confusion. (See additional context.) The CLI should handle the selection of the right app.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changed examples to use the CLI for getting the URI.
