### PR TITLE
Add file path to configure Bootsnap

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -340,7 +340,7 @@ For Rails, you have two choices:
 * To speed up boot you can use the [Bootsnap gem](https://github.com/Shopify/bootsnap)
   and configure it with the local `/tmp`:
 
-  ```ruby
+  ```ruby {location="config/boot.rb"}
   Bootsnap.setup(cache_dir: "/tmp/cache")
   ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Help user not used to configure bootsnap with the path

## What's changed

Add the path to the metadata of the markdown