### PR TITLE
:bug: Fix links to home from search

### DIFF
--- a/docs/layouts/partials/meilindex/fields/url.html
+++ b/docs/layouts/partials/meilindex/fields/url.html
@@ -4,4 +4,5 @@
 {{- if ne $tempURL "/index" -}}
   {{- $url = printf "%s.html" $tempURL -}}
 {{- end -}}
+{{- $url = replace $url "/.html" "/" -}}
 {{ $url }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Links from search to the home page had `/.html` in them, causing a 404 error.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Replaced that string with just `/`.
