### PR TITLE
:sparkles: Add new environment_type activity type

### DIFF
--- a/docs/src/integrations/activity/reference.md
+++ b/docs/src/integrations/activity/reference.md
@@ -38,6 +38,10 @@ Its value is one of:
 * `environment.access.add`: A new user has been given access to the environment.
 * `environment.access.remove`: A user has been removed from the environment.
 ---
+* `environment_type.access.create`: A user has been given access to an environment type (Production, Staging, Development).
+* `environment_type.access.delete`: A user has had their access removed from an environment type.
+* `environment_type.access.update`: A user has had their access to an environment type updated.
+---
 * `environment.backup`: A user triggered a [backup](/administration/backup-and-restore.md).
 * `environment.restore`: A user restored a [backup](/administration/backup-and-restore.md).
 * `environment.backup.delete`: A user deleted a [backup](/administration/backup-and-restore.md)


### PR DESCRIPTION
## Why

Three new activity types are now used by git:
- `environment_type.access.delete`
- `environment_type.access.create`
- `environment_type.access.update`

Without knowing these, users may not be able to get a full picture of user access changes when using the CLI `platform activity:list` and may assume they need to filter with `environment.access.add` or `environment.access.remove` when that may not be the case.