### PR TITLE
Provide a .environment/rsync warning

### DIFF
--- a/docs/src/development/variables/set-variables.md
+++ b/docs/src/development/variables/set-variables.md
@@ -137,15 +137,16 @@ Like everything else, the sourced `.environment` file runs in dash (not bash), a
 URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select (.value.id == "api") | .key')
 ```
 
-In the above example, `jq` is used to retrieve a backend Drupal application's url for the current environment using it's `id` that has been defined in `routes.yaml`. 
+In the above example, `jq` is used to retrieve a backend Drupal application's URL for the current environment using it's `id` that has been defined in `routes.yaml`. 
 
 Note that the file is sourced after all other environment variables above are defined and so they're available to the script.
 This also means the `.environment` script has the last word on environment variable values and can override anything it wants to.
 
 {{< note >}}
-You may find that a command that works during an SSH session will provide a `bad substitution` error when placed in a `.environment` file. Remember, `.environment` will be sourced using dash, not bash. While testing your `.environment` logic, be sure to enter a `dash` session in your terminal or within the SSH session first. 
+You may find that a command that works during an SSH session provides a `bad substitution` error when placed in a `.environment` file. 
+Remember, `.environment` is sourced using dash, not bash. While testing your `.environment` logic, be sure to enter a `dash` session in your terminal or within the SSH session first. 
 
-Additionally, because the `.environment` file is sourced at the start of an SSH session, anything that prints to stdout (like an `echo` or `printf` command) will appear at the start of the session. 
+Additionally, because the `.environment` file is sourced at the start of an SSH session, anything that prints to stdout (like an `echo` or `printf` command) appears at the start of the session. 
 
 ```bash {location=".environment"}
 if [ -f "deploy/environment.tracker.txt" ]; then 
@@ -156,9 +157,11 @@ else
     export DEPLOY='Never on a Friday'
 ```
 
-In the above example, when some `deploy/environment.tracker.txt` file is found the variable `DEPLOY` will equal `Friday`, and otherwise if it's missing it will be `Never on a Friday`. When you SSH into the app container, one of the first things you'll see (if the file exists) will be `File found.`. 
+In the above example, when some `deploy/environment.tracker.txt` file is found the variable `DEPLOY` is set to `Friday`, and otherwise if it's missing `Never on a Friday`. 
+When you SSH into the app container, `File found.` prints to the session. 
 
-While sanity checks like this are useful while troubleshooting, including these kinds of commands is not recommended. Even though your SSH command will execute successfully, if you later on attempt to download data from one of your mounts using the CLI command `platform mount:download`, you will get the following error:
+While sanity checks like this are useful while troubleshooting, including these kinds of commands isn't recommended. 
+Even though your SSH command executes successfully, if you later on attempt to download data from one of your mounts using the CLI command `platform mount:download`, this error returns:
 
 ```bash
 protocol version mismatch -- is your shell clean?

--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -82,6 +82,7 @@ serverless
 shard
 shortcode
 Stempel
+stdout
 Strapi
 Symfony
 Thorntail


### PR DESCRIPTION

## Why

No existing issue open.

I've done this plenty of times, but never run into the issue before because I was not running `platform mount:download`. 

1. You want to track if some conditional thing has occurred on an environment. 
2. You put that logic in `.environment`.
3. To sanity check/troubleshoot, you add some feedback/output to that file with an `echo` command so you can more easily track whats going on. 

That's all fine, until you try to run `platform mount:download`. `rsync` doesn't expect the output coming from your `echo` command, resulting in the following error:

```bash
$ platform mount:download -A nextjs -e pr-1 -m deploy --target . -y

Downloading files from the remote mount deploy to .

Are you sure you want to continue? [Y/n] y

  protocol version mismatch -- is your shell clean?
  (see the rsync man page for an explanation)
  rsync error: protocol incompatibility (code 2) at /System/Volumes/Data/SWE/macOS/BuildRoots/220e8a1b79/Library/Caches/com.apple.xbs/Sources/rsync/rsync-55/rsync/compat.c(61) [receiver=2.6.9]

                                                                                                                                                
  [ProcessFailedException]                                                                                                                      
  The command failed with the exit code: 2                                                                                                      
                                                                                                                                                
  Full command: 'rsync' '--archive' '--compress' '--human-readable' '-v' '65o73exizvbli-pr-1-djjnuwy--nextjs@ssh.eu-3.platform.sh:deploy/' '.' 
```

Totally caused by the fact that this `.environment`:

```bash
if [ -f "deploy/environment.tracker.txt" ]; then 
    echo "File found."
    export DEPLOY='Friday'
else
    echo "File not found."
    export DEPLOY='Never on Friday'
```

prints `File found/not found` at the start of an SSH session. 

[Source](https://dev-maziarz.blogspot.com/2015/01/rsync-error-protocol-incompatibility.html)

## What's changed

Added a note to [`.environment` section](https://docs.platform.sh/development/variables/set-variables.html#set-variables-via-script) that 

1. reminds the user that they're dealing in dash, not bash.
2. recommends they don't do what I described, including the error so its searchable. (The dash addition seemed relevant since it's another time adding an `echo` is useful. 