### PR TITLE
:memo: Add PLATFORM_CACHE_DIR variable

### DIFF
--- a/docs/src/development/variables/use-variables.md
+++ b/docs/src/development/variables/use-variables.md
@@ -346,8 +346,9 @@ You can't set or update them directly.
 The most important of these variables is the relationship information in `PLATFORM_RELATIONSHIPS`,
 which tells the app how to connect to databases and other services defined in `services.yaml`.
 
-The following table presents the available variables
-and whether they're available during builds and at runtime.
+The following table presents all available variables
+and whether they're available at build time (during [build hooks](../../administration/../configuration/app/hooks/hooks-comparison.md#build-hook))
+and at runtime.
 
 | Variable name               | Build | Runtime | Description |
 | --------------------------- | ----- | ------- | ----------- |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The `PLATFORM_CACHE_DIR` environment variable wasn't in our list of variables, though it was elsewhere.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added it to the list.