### PR TITLE
Document the new {default} behavior

### DIFF
--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -132,14 +132,17 @@ The generated URL for the `feature` environment is:
 https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
-{{< note theme="warning" title="This behavior will change in an upcoming release" >}}
+When you use the absolute URL, make sure your URLs aren't [too long for SSL certificates](./https.md#error-provisioning-certificates).
+
+{{< note theme="warning" >}}
+
+#### This behavior will change in an upcoming release
 
 The inconsistency in domains between Production and other environments will soon be fixed.
 At that point, the following will apply:
 
 If you have set your default domain to `example.com`,
 `example.com` and `{default}` in your `.platform/routes.yaml` file result in the same URLs for your non-Production environments.
-
 In both cases, you get the same URL for a `feature` environment:
 
 ```txt
@@ -147,14 +150,13 @@ https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
 If you haven't set a default domain, the URLs differ depending on whether you use the placeholder.
-
-Using the `{default}` placeholder with no default domain results in the following URL:
+If you use the `{default}` placeholder, you get the following URL:
 
 ```txt
 https://feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
-This leaves out the `example.com` prefix that you find if you use an absolute URL.
+This leaves out the `example.com` prefix that you get if you use an absolute URL.
 
 {{< /note >}}
 

--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -71,7 +71,7 @@ Each route in your `.platform/routes.yaml` configuration file is defined in one 
 * An explicit URL such as `https://example.com/blog`
 * A placeholder URL such as `https://{default}/blog`
 
-Placeholders can be either `{default}` or `{all}`, and they will map to the [custom domains](../../domains/quick-start.md) that 
+Placeholders can be either `{default}` or `{all}`, and they map to the [custom domains](../../domains/quick-start.md) that 
 you have defined in your project settings.
 
 These domains can be top level domains (`example.com`) or subdomains (`app.example.com`).
@@ -82,9 +82,9 @@ These domains can be top level domains (`example.com`) or subdomains (`app.examp
 
 Assuming that you set your default domain to `example.com`.
 
-Using both `example.com` and `{default}` in your `.platform/routes.yaml` file will generate the same URLs for your **production** environment.
+Using both `example.com` and `{default}` in your `.platform/routes.yaml` file generates the same URLs for your **production** environment.
 
-However, your **development** environment URLs will differ depending on the method you use.
+However, your **development** environment URLs differ depending on the method you use.
 
 1. If you use the default placeholder:
 
@@ -94,7 +94,7 @@ However, your **development** environment URLs will differ depending on the meth
     upstream: "app:http"
 ```
 
-The generated development URL of the `feature` environment will be:
+The generated development URL of the `feature` environment is:
 
 ```txt
 https://feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
@@ -108,15 +108,15 @@ https://feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
     upstream: "app:http"
 ```
 
-The generated development URL of the `feature` environment will be:
+The generated development URL of the `feature` environment is:
 
 ```txt
 https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
-WARNING: THIS INCONSISTENT BEHAVIOR WILL BE FIXED IN THE UPCOMING RELEASE.
+WARNING: THIS INCONSISTENT BEHAVIOR IS FIXED IN THE UPCOMING RELEASE.
 
-Using both `example.com` and `{default}` in your `.platform/routes.yaml` file will generate the same URLs for your **production** and **development** environments.
+Using both `example.com` and `{default}` in your `.platform/routes.yaml` file generates the same URLs for your **production** and **development** environments.
 
 If you use the default placeholder:
 
@@ -134,7 +134,7 @@ And if you use the explicit domain method:
     upstream: "app:http"
 ```
 
-Both methods will generate the same development URL for the `feature` environment with the domain being prefixed to the URL:
+Both methods generate the same development URL for the `feature` environment with the domain being prefixed to the URL:
 
 ```txt
 https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog

--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -66,79 +66,97 @@ so consider using a path like `https://{default}/api` instead.
 
 ## Route placeholders
 
-Each route in your `.platform/routes.yaml` configuration file is defined in one of two ways:
+Each route in your configuration file is defined in one of two ways:
 
-* An explicit URL such as `https://example.com/blog`
-* A placeholder URL such as `https://{default}/blog`
+* An absolute URL such as `https://example.com/blog`
+* A URL with a placeholder such as `https://{default}/blog`
 
-Placeholders can be either `{default}` or `{all}`, and they map to the [custom domains](../../domains/quick-start.md) that 
-you have defined in your project settings.
+The available placeholders are `{default}` and `{all}`.
+They stand in for the [custom domains](../../domains/quick-start.md) you've defined in your project.
 
-These domains can be top level domains (`example.com`) or subdomains (`app.example.com`).
+These domains can be top-level domains (`example.com`) or subdomains (`app.example.com`).
 
 ### `{default}`
 
 `{default}` represents your default custom domain.
+If you have set your default domain to `example.com`,
+`example.com` and `{default}` in your `.platform/routes.yaml` file have the same result for your Production environment.
 
-Assuming that you set your default domain to `example.com`.
-
-Using both `example.com` and `{default}` in your `.platform/routes.yaml` file generates the same URLs for your **production** environment.
-
-However, your **development** environment URLs differ depending on the method you use.
-
-1. If you use the default placeholder:
+You can use the `{default}` placeholder:
 
 ```yaml {location=".platform/routes.yaml"}
-"https://{default}/":
+"https://{default}/blog":
     type: upstream
     upstream: "app:http"
 ```
 
-The generated development URL of the `feature` environment is:
+And you can use an absolute URL:
+
+```yaml {location=".platform/routes.yaml"}
+"https://example.com/blog":
+    type: upstream
+    upstream: "app:http"
+```
+
+In both cases, the URLs for your Production environment are the same.
+
+#### URLs in non-Production environments
+
+URLs in non-Production environments differ depending on whether or not you use the `{default}` placeholder.
+
+If you use the `{default}` placeholder:
+
+```yaml {location=".platform/routes.yaml"}
+"https://{default}/blog":
+    type: upstream
+    upstream: "app:http"
+```
+
+The generated URL for the `feature` environment is:
 
 ```txt
 https://feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
-2. If you use the explicit domain method:
+If you use an absolute URL:
 
 ```yaml {location=".platform/routes.yaml"}
-"https://example.com/":
+"https://example.com/blog":
     type: upstream
     upstream: "app:http"
 ```
 
-The generated development URL of the `feature` environment is:
+The generated URL for the `feature` environment is:
 
 ```txt
 https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
-WARNING: THIS INCONSISTENT BEHAVIOR IS FIXED IN THE UPCOMING RELEASE.
+{{< note theme="warning" title="This behavior will change in an upcoming release" >}}
 
-Using both `example.com` and `{default}` in your `.platform/routes.yaml` file generates the same URLs for your **production** and **development** environments.
+The inconsistency in domains between Production and other environments will soon be fixed.
+At that point, the following will apply:
 
-If you use the default placeholder:
+If you have set your default domain to `example.com`,
+`example.com` and `{default}` in your `.platform/routes.yaml` file result in the same URLs for your non-Production environments.
 
-```yaml {location=".platform/routes.yaml"}
-"https://{default}/":
-    type: upstream
-    upstream: "app:http"
-```
-
-And if you use the explicit domain method:
-
-```yaml {location=".platform/routes.yaml"}
-"https://example.com/":
-    type: upstream
-    upstream: "app:http"
-```
-
-Both methods generate the same development URL for the `feature` environment with the domain being prefixed to the URL:
+In both cases, you get the same URL for a `feature` environment:
 
 ```txt
 https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
+
+If you haven't set a default domain, the URLs differ depending on whether you use the placeholder.
+
+Using the `{default}` placeholder with no default domain results in the following URL:
+
+```txt
+https://feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
+```
+
+This leaves out the `example.com` prefix that you find if you use an absolute URL.
+
+{{< /note >}}
 
 ### `{all}`
 
@@ -353,7 +371,7 @@ You can configure each route separately with the following properties:
 ## CLI access
 
 The [Platform.sh CLI](../../development/cli/_index.md) can show you the routes you have configured for an environment.
-These are the routes as defined in the `.platform/routes.yaml` file with the [placeholders](#route-templates)
+These are the routes as defined in the `.platform/routes.yaml` file with the [placeholders](#route-placeholders)
 plus the default redirect from HTTP to HTTPS.
 They aren't the final generated routes.
 

--- a/docs/src/configuration/routes/_index.md
+++ b/docs/src/configuration/routes/_index.md
@@ -64,31 +64,77 @@ The route for the `api` app could be anything in the domain, even a subdomain li
 Be aware that using a subdomain might [double your network traffic](https://nickolinger.com/blog/2021-08-04-you-dont-need-that-cors-request/),
 so consider using a path like `https://{default}/api` instead.
 
-## Route templates
+## Route placeholders
 
-Each route in your configuration file is defined in one of two ways:
+Each route in your `.platform/routes.yaml` configuration file is defined in one of two ways:
 
-* An absolute URL such as `https://example.com/blog`
-* A URL template such as `https://{default}/blog`
+* An explicit URL such as `https://example.com/blog`
+* A placeholder URL such as `https://{default}/blog`
 
-The templates include a placeholder, either `{default}` or `{all}`,
-to stand in for [custom domains](../../domains/quick-start.md) you've defined in your project.
+Placeholders can be either `{default}` or `{all}`, and they will map to the [custom domains](../../domains/quick-start.md) that 
+you have defined in your project settings.
+
 These domains can be top level domains (`example.com`) or subdomains (`app.example.com`).
 
 ### `{default}`
 
 `{default}` represents your default custom domain.
-If you have set your default domain to `example.com`,
-`example.com` and `{default}` in your `.platform/routes.yaml` file have the same meaning for your production environment.
 
-Each development environment gets its own domain with a unique identifier.
-If you use the URL template on a `feature` branch, you get something like the following:
+Assuming that you set your default domain to `example.com`.
+
+Using both `example.com` and `{default}` in your `.platform/routes.yaml` file will generate the same URLs for your **production** environment.
+
+However, your **development** environment URLs will differ depending on the method you use.
+
+1. If you use the default placeholder:
+
+```yaml {location=".platform/routes.yaml"}
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+```
+
+The generated development URL of the `feature` environment will be:
 
 ```txt
 https://feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
 ```
 
-If you use the absolute URL method (like `example.com`), that domain looks similar to this:
+2. If you use the explicit domain method:
+
+```yaml {location=".platform/routes.yaml"}
+"https://example.com/":
+    type: upstream
+    upstream: "app:http"
+```
+
+The generated development URL of the `feature` environment will be:
+
+```txt
+https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog
+```
+
+WARNING: THIS INCONSISTENT BEHAVIOR WILL BE FIXED IN THE UPCOMING RELEASE.
+
+Using both `example.com` and `{default}` in your `.platform/routes.yaml` file will generate the same URLs for your **production** and **development** environments.
+
+If you use the default placeholder:
+
+```yaml {location=".platform/routes.yaml"}
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+```
+
+And if you use the explicit domain method:
+
+```yaml {location=".platform/routes.yaml"}
+"https://example.com/":
+    type: upstream
+    upstream: "app:http"
+```
+
+Both methods will generate the same development URL for the `feature` environment with the domain being prefixed to the URL:
 
 ```txt
 https://example.com.feature-t6dnbai-abcdef1234567.us-2.platformsh.site/blog

--- a/docs/src/configuration/routes/https.md
+++ b/docs/src/configuration/routes/https.md
@@ -214,23 +214,32 @@ Provisioning certificates
   Environment certificates
 W: Missing certificate for domain a-new-and-really-awesome-feature-abc1234-defghijk56789.eu3.platformsh.site
 ```
+
 The renewal may fail because of the 64 character limit Let's Encrypt places on URLs.
 If you have a branch with a long name, the environment URL is over this limit and the certificate is rejected.
 Shortening the branch name to fewer than 20 characters should solve the issue.
 
 Generated URLs have the following pattern:
 
-```
+```bash
 <PLATFORM_ENVIRONMENT>-<PLATFORM_PROJECT>.<REGION>.platformsh.site
 ```
 
+If you have a default domain and include it as an absolute URL, it's added to the start of your URL.
+See [URLs in non-Production environments](./_index.md#urls-in-non-production-environments).
+
+```bash
+<DEFAULT_DOMAIN>.<PLATFORM_ENVIRONMENT>-<PLATFORM_PROJECT>.<REGION>.platformsh.site
+```
+
+* `DEFAULT_DOMAIN` = however many characters your default domain is
 * `PLATFORM_ENVIRONMENT` = `PLATFORM_BRANCH` + 7 character hash
 * `PLATFORM_PROJECT` = 13 characters
-* `REGION` = 2-4 characters, depending on the region
+* `REGION` = 2 to 4 characters, depending on the region
 * `platformsh.site` = 15 characters
-* extra characters (`.` & `-`) = 4 characters
+* extra characters (`.` & `-`) = 4 to 5 characters, depending on if you have a default domain
 
-This leaves you with 21--23 characters for your branch name (`PLATFORM_BRANCH`) without going over the 64 character limit,
+This leaves you with 21 to 23 characters for your branch name (`PLATFORM_BRANCH`) without going over the 64 character limit,
 depending on the region.
 Since this pattern for generated URLs should remain similar even if it may change slightly,
 your branch names should be no more than 20 characters.


### PR DESCRIPTION
## Why

Closes #2253

## What's changed

- [x] Properly document the current `{default}` behavior for both production and development URLs
- [x] Properly document the upcoming `{default}` behavior for both production and development URLs.
- [x] Add a `Breaking Change` notice banner.