### PR TITLE
:bug: Update available PHP extensions

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -115,7 +115,7 @@ and turn off those on by default with the `disabled_extensions` key.
 | `sysvsem`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
 | `sysvshm`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
 | `tideways`        |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
-| `tideways-xhprof` |       |       |       | Avail | Avail | Avail | Avail | Avail |       |       |
+| `tideways_xhprof` |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
 | `tidy`            | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
 | `tokenizer`       |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
 | `uuid`            |       |       |       |       | Avail | Avail | Avail | Avail | Avail | Avail |


### PR DESCRIPTION
tideways-xhprof has been available for some time but was removed on
https://github.com/platformsh/platformsh-docs/pull/2034

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Reported on public slack channel

## What's changed

Rename to real module name `tideways_xhprof` and make it available