### PR TITLE
:memo: Rename vague 'Get started' titles

### DIFF
--- a/docs/src/guides/drupal9/deploy/_index.md
+++ b/docs/src/guides/drupal9/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy Drupal 9 on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Drupal 9 on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy Drupal.
 ---

--- a/docs/src/guides/gatsby/deploy/_index.md
+++ b/docs/src/guides/gatsby/deploy/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "How to deploy Gatsby on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Gatsby on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
 description: |

--- a/docs/src/guides/general/_index.md
+++ b/docs/src/guides/general/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "General"
+title: General guides
 weight: -120
 description: |
   Guides for common Platform.sh best practices.

--- a/docs/src/guides/hibernate/deploy.md
+++ b/docs/src/guides/hibernate/deploy.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Deploy Hibernate ORM on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Hibernate ORM on Platform.sh
+sidebarTitle: Get started
 weight: 4
 ---
 

--- a/docs/src/guides/hibernate/deploy.md
+++ b/docs/src/guides/hibernate/deploy.md
@@ -1,5 +1,6 @@
 ---
-title: Get started
+title: "How to Deploy Hibernate ORM on Platform.sh"
+sidebarTitle: "Get started"
 weight: 4
 ---
 

--- a/docs/src/guides/ibexa/deploy.md
+++ b/docs/src/guides/ibexa/deploy.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Deploy Ibexa DXP on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Ibexa DXP on Platform.sh
+sidebarTitle: Get started
 weight: -10
 description: Learn how to use Ibexa DXP on Platform.sh.
 ---

--- a/docs/src/guides/ibexa/deploy.md
+++ b/docs/src/guides/ibexa/deploy.md
@@ -1,5 +1,6 @@
 ---
-title: Get started
+title: "How to Deploy Ibexa DXP on Platform.sh"
+sidebarTitle: "Get started"
 weight: -10
 description: Learn how to use Ibexa DXP on Platform.sh.
 ---

--- a/docs/src/guides/jakarta/deploy.md
+++ b/docs/src/guides/jakarta/deploy.md
@@ -1,6 +1,6 @@
 ---
-title: "How to Deploy Jakarta on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Jakarta on Platform.sh
+sidebarTitle: Get started
 weight: 5
 ---
 

--- a/docs/src/guides/jakarta/deploy.md
+++ b/docs/src/guides/jakarta/deploy.md
@@ -1,5 +1,6 @@
 ---
-title: Get started
+title: "How to Deploy Jakarta on Platform.sh"
+sidebarTitle: "Get started"
 weight: 5
 ---
 

--- a/docs/src/guides/micronaut/deploy/_index.md
+++ b/docs/src/guides/micronaut/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy Micronaut on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Micronaut on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy Micronaut.
 ---

--- a/docs/src/guides/quarkus/deploy/_index.md
+++ b/docs/src/guides/quarkus/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy Quarkus on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Quarkus on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy Quarkus.
 ---

--- a/docs/src/guides/spring/deploy/_index.md
+++ b/docs/src/guides/spring/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy Spring on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Spring on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy Spring.
 ---

--- a/docs/src/guides/strapi/deploy/_index.md
+++ b/docs/src/guides/strapi/deploy/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "How to deploy Strapi on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy Strapi on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
 description: |

--- a/docs/src/guides/symfony/deploy/_index.md
+++ b/docs/src/guides/symfony/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy Symfony on Platform.sh"
+title: Deploy Symfony on Platform.sh
 sidebarTitle: "Get started"
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy Symfony.
 ---

--- a/docs/src/guides/typo3/deploy/_index.md
+++ b/docs/src/guides/typo3/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy TYPO3 on Platform.sh"
+title: Deploy TYPO3 on Platform.sh
 sidebarTitle: "Get started"
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy TYPO3.
 ---

--- a/docs/src/guides/wordpress/deploy/_index.md
+++ b/docs/src/guides/wordpress/deploy/_index.md
@@ -1,9 +1,8 @@
 ---
-title: "How to Deploy WordPress on Platform.sh"
-sidebarTitle: "Get started"
+title: Deploy WordPress on Platform.sh
+sidebarTitle: Get started
 weight: -110
 layout: single
-toc: false
 description: |
     Create a Platform.sh account, download a few tools, and prepare to deploy WordPress using Composer.
 ---


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

[Searching "mariadb"](https://docs.platform.sh/search.html?q=mariadb) shows some "Get started | MariaDB" pages but actually links to using MariaDB in other systems

- https://docs.platform.sh/guides/hibernate/deploy.html#mariadb
- https://docs.platform.sh/guides/jakarta/deploy.html#mariadb

![image](https://user-images.githubusercontent.com/892961/162883018-0575217f-cbe8-49a8-b8b5-ec59e4f9ad63.png)



## What's changed

- Just changing the title while keeping the sidebar titles
- Use similar phrase to other pages e.g. https://github.com/platformsh/platformsh-docs/blob/3930274585b77ba47a2fca743e9a87660583c845/docs/src/guides/gatsby/deploy/_index.md

```
title: "How to deploy Gatsby on Platform.sh"
sidebarTitle: "Get started"
```