### PR TITLE
:bug: Fix broken links

### DIFF
--- a/docs/layouts/shortcodes/guides/tools.md
+++ b/docs/layouts/shortcodes/guides/tools.md
@@ -4,7 +4,7 @@ Next, you need a couple tools to interact with your Platform.sh project, one of 
   Git is the primary tool you use to manage everything your app needs to run.
   Every commit pushed results in a new deployment, and all of your configuration is driven almost entirely by a small number of YAML files in your Git repository (which we will get to in the steps below).
   Your infrastructure, described in these files, becomes part of your application itself - completely transparent and version-controlled.
-  If you do not already have Git on your computer, you should [install it now](https://help.github.com/articles/set-up-git/).
+  If you do not already have Git on your computer, you should [install it now](https://docs.github.com/en/get-started/quickstart/set-up-git).
 
 * The [Platform.sh CLI](/development/cli/_index.md).
   This lets you interact with your Platform.sh project from the command line.

--- a/docs/src/development/private-repository.md
+++ b/docs/src/development/private-repository.md
@@ -52,4 +52,4 @@ Since this account isn't used by a human, it's called a machine user.
 You can then add the machine account as collaborator
 or add the machine user to a team with access to the repositories it needs to manipulate.
 
-More information about this is available on [GitHub](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users).
+More information about this is available on [GitHub](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users).

--- a/docs/src/development/ssh/ssh-keys.md
+++ b/docs/src/development/ssh/ssh-keys.md
@@ -74,7 +74,7 @@ generate a key and have it added to your Platform.sh account automatically.
    ssh-add 'PATH_TO_YOUR_KEY'
    ```
 
-To generate a key otherwise, GitHub has a good [walk-through for creating SSH key pairs](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) on various operating systems.
+To generate a key otherwise, GitHub has a good [walk-through for creating SSH key pairs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) on various operating systems.
 
 Then you need to [add it to your Platform.sh account](#2-add-an-ssh-key-to-your-platform-account).
 

--- a/docs/src/development/tools.md
+++ b/docs/src/development/tools.md
@@ -13,7 +13,7 @@ Any change you make to your Platform.sh project will need to be committed via Gi
 Before getting started, make sure you have it installed on your computer to be able to interact with Platform.sh.
 
 {{< note title="See also">}}
-* [Install Git](https://help.github.com/articles/set-up-git/)
+* [Install Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
 * [Learn more about Git](https://git-scm.com/)
 {{< /note >}}
 
@@ -21,6 +21,6 @@ Before getting started, make sure you have it installed on your computer to be a
 
 Secure Shell (SSH) is a secure, encrypted connection between your computer and the Platform.sh environment.  That includes connecting to your Git repository.  SSH offers two secure types of authentication, based on keys or certificates.  We support both.
 
-Certificates are used automatically when you use the [Platform.sh CLI](/development/cli/_index.md) and run almost any command.  You may force a login using `platform login -f` on the command line, provided you have a web browser available.
+Certificates are used automatically when you use the [Platform.sh CLI](./cli/_index.md) and run almost any command.  You may force a login using `platform login -f` on the command line, provided you have a web browser available.
 
 To use key pairs, see the [SSH keys](./ssh/ssh-keys.md).

--- a/docs/src/guides/drupal9/deploy/configure.md
+++ b/docs/src/guides/drupal9/deploy/configure.md
@@ -18,11 +18,11 @@ description: |
 {{% guides/config-service name=Drupal %}}
 
 We recommend the latest [MariaDB](/configuration/services/mysql/_index.md) version for Drupal,
-although you can also use Oracle MySQL or [PostgreSQL](/configuration/services/postgresql.md) if you prefer.
-We also strongly recommend using [Redis](/configuration/services/redis.md) for Drupal caching.
+although you can also use Oracle MySQL or [PostgreSQL](/configuration/services/postgresql.md).
+For Drupal caching, we strongly recommend using [Redis](/configuration/services/redis.md).
 Drupal's cache can be very aggressive,
 and keeping that data out of the database helps with both performance and disk usage.
-Our Drupal template comes [pre-configured to use Redis](https://github.com/platformsh-templates/drupal9#user-content-customizations) for caching.
+See an example of Redis for caching in our [Drupal template](https://github.com/platformsh-templates/drupal9).
 
 {{% /guides/config-service %}}
 

--- a/docs/src/integrations/activity/_index.md
+++ b/docs/src/integrations/activity/_index.md
@@ -8,7 +8,7 @@ description: |
 
 {{< description >}}
 
-Check out examples from other users on the Platform.sh [Community site.](https://community.platform.sh/c/activity-scripts)
+Check out examples from other users on the Platform.sh [Community site](https://community.platform.sh/c/activity-scripts/10).
 
 ## Installing
 

--- a/docs/src/integrations/source/github.md
+++ b/docs/src/integrations/source/github.md
@@ -68,7 +68,7 @@ Optional parameters:
 * `--fetch-branches`: Track and deploy branches (true by default)
 * `--prune-branches`: Delete branches that do not exist in the remote GitHub repository (true by default)
 * `--build-pull-requests`: Track and deploy pull-requests (true by default)
-* `--build-draft-pull-requests`: If set to `true`, [draft pull requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) will also have an environment created.
+* `--build-draft-pull-requests`: If set to `true`, [draft pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) will also have an environment created.
   If false they will be ignored.
   If `--build-pull-requests` is `false` this value is ignored.  (`true` by default)
 * `--build-pull-requests-post-merge`: `false` to have Platform.sh build the branch specified in a PR.

--- a/docs/src/other/changelog.md
+++ b/docs/src/other/changelog.md
@@ -19,33 +19,33 @@ description: |
 ## 2021
 
 * **October 2021**
-  * Regions: Added a [second region in Australia](/development/regions.md#australia-2-au-2platformsh), `au-2`.
+  * Regions: Added a [second region in Australia](../development/regions.md#australia), `au-2`.
 * **September 2021**
-  * Organizations: Switched to [organizations](/administration/organizations.md) for managing Platform.sh projects, users, and billing.
-  * Vault: Added [Vault service](/configuration/services/vault.md).
-  * .Net: We now support [.Net 5.0](/languages/dotnet.md).
+  * Organizations: Switched to [organizations](../administration/organizations.md) for managing Platform.sh projects, users, and billing.
+  * Vault: Added [Vault service](../configuration/services/vault.md).
+  * .Net: We now support [.Net 5.0](../languages/dotnet.md).
 * **May 2021**
-  * Elasticsearch 6.8: We now support [Elasticsearch 6.8](/configuration/services/elasticsearch.md).
+  * Elasticsearch 6.8: We now support [Elasticsearch 6.8](../configuration/services/elasticsearch.md).
 ---
 * **April 2021**
-  * WAF: [a new page was added](/security/waf.md) describing the filtering rule sets and protections that come with the Platform.sh WAF.
+  * WAF: [a new page was added](../security/waf.md) describing the filtering rule sets and protections that come with the Platform.sh WAF.
   * [Build environment variables](../development/variables/set-variables.md#create-project-variables): environment variables can now accept the same `--visible-build` and `--visible-runtime` flags as project variables when created through the CLI. Build-visible variables are now a part of the build image ID, and therefore triggers a rebuild of the application when the value is updated. 
   * **Breaking change**: The logic by which the build image ID has changed in order to support build environment variables above. Previously, every attribute in `.platform.app.yaml` was included in the build image, used to create the unique build ID, and *accessible* via the `PLATFORM_APPLICATION` environment variable at build time. This is no longer the case, and only a subset of `.platform.app.yaml` attributes are now accessible from `PLATFORM_APPLICATION` at build time. See the [Platform.sh-provided variables](../development/variables/use-variables.md#use-platformsh-provided-variables) section for more information.
 ---
 * **March 2021**
-  * Observability: [a new page was added](/dedicated/architecture/metrics.md) describing observability and metrics available on Dedicated projects.
-  * Node.js debugging: [a new page was added](/languages/nodejs/debug.md) that includes tips for debugging Node.js applications.
-  * Parallel activities: [project activities](/integrations/activity/reference.md#maximum-activities-and-parallelism) have been split into separate queues, allowing for up to two activities across environments to occur simultaneously.
-  * Python 3.9: We now support [Python 3.9](/languages/python.md).
-  * Java 14: We now support [Java 14](/languages/java/_index.md).
-  * PostgreSQL 13: [multiple databases](/configuration/services/postgresql.md#multiple-databases) are now supported for PostgreSQL 13.
-  * Elasticsearch 7.9: We now support [Elasticsearch 7.9](/configuration/services/elasticsearch.md).
+  * Observability: [a new page was added](../dedicated/architecture/metrics.md) describing observability and metrics available on Dedicated projects.
+  * Node.js debugging: [a new page was added](../languages/nodejs/debug.md) that includes tips for debugging Node.js applications.
+  * Parallel activities: [project activities](../integrations/activity/reference.md#maximum-activities-and-parallelism) have been split into separate queues, allowing for up to two activities across environments to occur simultaneously.
+  * Python 3.9: We now support [Python 3.9](../languages/python.md).
+  * Java 14: We now support [Java 14](../languages/java/_index.md).
+  * PostgreSQL 13: [multiple databases](../configuration/services/postgresql.md#multiple-databases) are now supported for PostgreSQL 13.
+  * Elasticsearch 7.9: We now support [Elasticsearch 7.9](../configuration/services/elasticsearch.md).
 ---
 * **February 2021**
-  * Elasticsearch 5.6: We now support [Elasticsearch 5.6](/configuration/services/elasticsearch.md) on Dedicated projects.
+  * Elasticsearch 5.6: We now support [Elasticsearch 5.6](../configuration/services/elasticsearch.md) on Dedicated projects.
 ---
 * **January 2021**
-  * Default branch: [guide added](/guides/general/default-branch.md) that provides step for changing a project's default branch from `master` to `main`
+  * Default branch: [guide added](../guides/general/default-branch.md) that provides step for changing a project's default branch from `master` to `main`
 ---
 
 ## 2020
@@ -54,39 +54,39 @@ description: |
   * `us-4` region: We have [added](../development/regions.md) another US region, `us-4`.
 ---
 * **September 2020**
-  * Go 1.15: We now support [Go 1.15](/languages/go.md).
+  * Go 1.15: We now support [Go 1.15](../languages/go.md).
 ---
 * **June 2020**
-  * Node.js 14: We now support [Node.js 14](/languages/nodejs/_index.md).
+  * Node.js 14: We now support [Node.js 14](../languages/nodejs/_index.md).
 ---
 * **April 2020**
-  * We now offer [Xdebug on PHP](/languages/php/xdebug.md) containers.
+  * We now offer [Xdebug on PHP](../languages/php/xdebug.md) containers.
   * Custom [activity scripts](../integrations/activity/_index.md) are now available, in alpha.
 ---
 * **March 2020**
-  * Go 1.14: We now support [Go 1.14](/languages/go.md).
-  * Ruby 2.7: We now support [Ruby 2.7](/languages/ruby.md).
-  * .NET Core: We now support [.NET Core 3.1](/languages/dotnet.md).
-  * Memcached 1.6: We now support [Memcached 1.6](/configuration/services/memcached.md).
-  * Solr 8.4: We now support [Solr 8.4](/configuration/services/solr.md).
+  * Go 1.14: We now support [Go 1.14](../languages/go.md).
+  * Ruby 2.7: We now support [Ruby 2.7](../languages/ruby.md).
+  * .NET Core: We now support [.NET Core 3.1](../languages/dotnet.md).
+  * Memcached 1.6: We now support [Memcached 1.6](../configuration/services/memcached.md).
+  * Solr 8.4: We now support [Solr 8.4](../configuration/services/solr.md).
 ---
 * **February 2020**
-  * Memcached 1.5: We now support [Memcached 1.5](/configuration/services/memcached.md).
-  * Character set and collation are now configurable on [MySQL/MariaDB](/configuration/services/mysql/_index.md).
+  * Memcached 1.5: We now support [Memcached 1.5](../configuration/services/memcached.md).
+  * Character set and collation are now configurable on [MySQL/MariaDB](../configuration/services/mysql/_index.md).
 ---
 * **January 2020**
-  * RabbitMQ: We now support [RabbitMQ virtual host configuration](/configuration/services/rabbitmq.md#virtual-hosts)
+  * RabbitMQ: We now support [RabbitMQ virtual host configuration](../configuration/services/rabbitmq.md#virtual-hosts)
 ---
 
 ## 2019
 
 * **December 2019**
-  * Python 3.8: We now support [Python 3.8](/languages/python.md).
-  * Node.js 12: We now support [Node.js 12](/languages/nodejs/_index.md).
-  * RabbitMQ 3.8: We now support [RabbitMQ 3.8](/configuration/services/rabbitmq.md).
+  * Python 3.8: We now support [Python 3.8](../languages/python.md).
+  * Node.js 12: We now support [Node.js 12](../languages/nodejs/_index.md).
+  * RabbitMQ 3.8: We now support [RabbitMQ 3.8](../configuration/services/rabbitmq.md).
 ---
 * **October 2019**
-  * PHP 7.4: We now support [PHP 7.4](/languages/php/_index.md).
+  * PHP 7.4: We now support [PHP 7.4](../languages/php/_index.md).
 ---
 
 * **October 2019**
@@ -95,61 +95,61 @@ description: |
 
 * **September 2019**
   * "Dark mode" now available in the Console.
-  * Go 1.13: We now support [Go 1.13](/languages/go.md).
+  * Go 1.13: We now support [Go 1.13](../languages/go.md).
 ---
 
 * **July 2019**
-  * Elasticsearch 7.2: We now support [Elasticsearch 7.2](/configuration/services/elasticsearch.md).
-  * [Elasticsearch](/configuration/services/elasticsearch.md) 5.2 and 5.4 support is now deprecated
-  * Kafka 2.2: We now support [Kafka 2.2](/configuration/services/kafka.md).
-  * Java 13: We now support [Java 13](/languages/java/_index.md).
+  * Elasticsearch 7.2: We now support [Elasticsearch 7.2](../configuration/services/elasticsearch.md).
+  * [Elasticsearch](../configuration/services/elasticsearch.md) 5.2 and 5.4 support is now deprecated
+  * Kafka 2.2: We now support [Kafka 2.2](../configuration/services/kafka.md).
+  * Java 13: We now support [Java 13](../languages/java/_index.md).
 ---
 
 * **June 2019**
-  * Java: We support and documented the use of [Java](/languages/java/_index.md) runtimes 8, 11, and 12, that includes examples that use the [Java Config Reader](https://github.com/platformsh/config-reader-java/).
-  * Headless Chrome: Users can now define a [Headless Chrome](/configuration/services/headless-chrome.md) service to access a service container with a headless browser, which can be used for automated UI testing.
+  * Java: We support and documented the use of [Java](../languages/java/_index.md) runtimes 8, 11, and 12, that includes examples that use the [Java Config Reader](https://github.com/platformsh/config-reader-java/).
+  * Headless Chrome: Users can now define a [Headless Chrome](../configuration/services/headless-chrome.md) service to access a service container with a headless browser, which can be used for automated UI testing.
 ---
 
 * **May 2019**
-  * InfluxDB: We now support [InfluxDB](/configuration/services/influxdb.md) 1.7.
-  * Solr 7 & 8: We now support [Solr](/configuration/services/solr.md) 7.7 and 8.0.
+  * InfluxDB: We now support [InfluxDB](../configuration/services/influxdb.md) 1.7.
+  * Solr 7 & 8: We now support [Solr](../configuration/services/solr.md) 7.7 and 8.0.
 ---
 
 * **April 2019**
-  * Network storage service: Users can now define a [Network storage](/configuration/services/network-storage.md) service for sharing files between containers.
-  * Kafka message queue service: Users can now define a [Kafka](/configuration/services/kafka.md) service for storing, reading and analysing streaming data.
-  * Management Console: Images and wording updated throughout entire documentation alongside [Management Console](/administration/web/_index.md) release.
+  * Network storage service: Users can now define a [Network storage](../configuration/services/network-storage.md) service for sharing files between containers.
+  * Kafka message queue service: Users can now define a [Kafka](../configuration/services/kafka.md) service for storing, reading and analysing streaming data.
+  * Management Console: Images and wording updated throughout entire documentation alongside [Management Console](../administration/web/_index.md) release.
 ---
 
 * **March 2019**
-  * Ruby 2.6: A new version of [Ruby](/languages/ruby.md) is now available.
-  * Go 1.12: We now support [Go 1.12](/languages/go.md).
-  * Elasticsearch 6.5: We now support [Elasticsearch 6.5](/configuration/services/elasticsearch.md).
+  * Ruby 2.6: A new version of [Ruby](../languages/ruby.md) is now available.
+  * Go 1.12: We now support [Go 1.12](../languages/go.md).
+  * Elasticsearch 6.5: We now support [Elasticsearch 6.5](../configuration/services/elasticsearch.md).
 ---
 
 * **January 2019**
-  * RabbitMQ 3.7: We now support [RabbitMQ 3.7](/configuration/services/rabbitmq.md).
-  * Solr 7: We now support [Solr 7.6](/configuration/services/solr.md).
-  * Varnish: We now offer [Varnish](/configuration/services/varnish.md) 5.2 and 6.0.
+  * RabbitMQ 3.7: We now support [RabbitMQ 3.7](../configuration/services/rabbitmq.md).
+  * Solr 7: We now support [Solr 7.6](../configuration/services/solr.md).
+  * Varnish: We now offer [Varnish](../configuration/services/varnish.md) 5.2 and 6.0.
 ---
 
 ## 2018
 
 * **December 2018**
-  * Elasticsearch 5.4: We now offer [Elasticsearch 5.4](/configuration/services/elasticsearch.md).
+  * Elasticsearch 5.4: We now offer [Elasticsearch 5.4](../configuration/services/elasticsearch.md).
   * Improved Bash support: Bash history on application containers now persists between logins.
-  * PHP 7.3: We now support [PHP 7.3](/languages/php/_index.md).
-  * PostgreSQL 10.0 and 11.0: We now support [PostgreSQL 10.0 and 11.0](/configuration/services/postgresql.md) with an automated upgrade path.
-  * Ruby 2.5 out of beta: We now fully support [Ruby 2.5](/languages/ruby.md).
+  * PHP 7.3: We now support [PHP 7.3](../languages/php/_index.md).
+  * PostgreSQL 10.0 and 11.0: We now support [PostgreSQL 10.0 and 11.0](../configuration/services/postgresql.md) with an automated upgrade path.
+  * Ruby 2.5 out of beta: We now fully support [Ruby 2.5](../languages/ruby.md).
 ---
 
 * **October 2018**
-  * Redis updates: [Redis 4.0 and 5.0](/configuration/services/redis.md) are now supported.
-  * Go language support: [Go](/languages/go.md) is now a fully supported language platform.
+  * Redis updates: [Redis 4.0 and 5.0](../configuration/services/redis.md) are now supported.
+  * Go language support: [Go](../languages/go.md) is now a fully supported language platform.
 ---
 
 * **September 2018**
-  * Python 3.7 support: We now support [Python 3.7](/languages/python.md).
+  * Python 3.7 support: We now support [Python 3.7](../languages/python.md).
 ---
 
 * **August 2018**
@@ -161,8 +161,8 @@ description: |
 ---
 
 * **June 2018**
-  * Node.js 10: We now offer [Node.js version 10](/languages/nodejs/_index.md). All releases in the 10.x series will be included in that container.
-  * MongoDB 3.6: We now offer [MongoDB 3.2, 3.4, and 3.6](/configuration/services/mongodb.md). Note that upgrading from MongoDB 3.0 requires upgrading through all intermediary versions.
+  * Node.js 10: We now offer [Node.js version 10](../languages/nodejs/_index.md). All releases in the 10.x series will be included in that container.
+  * MongoDB 3.6: We now offer [MongoDB 3.2, 3.4, and 3.6](../configuration/services/mongodb.md). Note that upgrading from MongoDB 3.0 requires upgrading through all intermediary versions.
 ---
 
 * **March 2018**
@@ -176,42 +176,42 @@ description: |
 
 * **December 2017**
   * New project subdomains: The routes generated for subdomains and literal domains in development environments will now use `.` instead of translating them to `---`, for projects created after this date.
-  * `!include` tag support in YAML files: All YAML configuration files now support a generic [`!include`](/configuration/yaml.md) tag that can be used to embed one file within another.
-  * Extended mount definitions: A new syntax has been added for defining [mount points](/configuration/app/app-reference.md#mounts) that is more self-descriptive and makes future extension easier.
-  * Blocking older TLS versions: It is now possible to disable support for [HTTPS requests](/configuration/routes/https.md) using older versions of TLS. TLS 1.0 is known to be insecure in some circumstances and some compliance standards require a higher minimum supported version.
-  * `{all}` placeholder for routes: A new placeholder is available in [`routes.yaml`](/configuration/routes/_index.md) files that matches all configured domains.
-  * GitLab source code integration: Synchronize Git repository host on [GitLab](/integrations/source/gitlab.md) to Platform.sh.
+  * `!include` tag support in YAML files: All YAML configuration files now support a generic [`!include`](../configuration/yaml.md) tag that can be used to embed one file within another.
+  * Extended mount definitions: A new syntax has been added for defining [mount points](../configuration/app/app-reference.md#mounts) that is more self-descriptive and makes future extension easier.
+  * Blocking older TLS versions: It is now possible to disable support for [HTTPS requests](../configuration/routes/https.md) using older versions of TLS. TLS 1.0 is known to be insecure in some circumstances and some compliance standards require a higher minimum supported version.
+  * `{all}` placeholder for routes: A new placeholder is available in [`routes.yaml`](../configuration/routes/_index.md) files that matches all configured domains.
+  * GitLab source code integration: Synchronize Git repository host on [GitLab](../integrations/source/gitlab.md) to Platform.sh.
 ---
 
 * **November 2017**
-  * PHP 7.2 supported: With the release of PHP 7.2.0, Platform.sh now offers [PHP 7.2](/languages/php/_index.md) containers on Platform Professional.
+  * PHP 7.2 supported: With the release of PHP 7.2.0, Platform.sh now offers [PHP 7.2](../languages/php/_index.md) containers on Platform Professional.
 ---
 
 * **September 2017**
-  * Health notifications: Low-disk warnings will now trigger a [notification](/integrations/notifications.md) via email, Slack, or PagerDuty.
+  * Health notifications: Low-disk warnings will now trigger a [notification](../integrations/notifications.md) via email, Slack, or PagerDuty.
 ---
 
 * **August 2017**
-  * Worker instances: Applications now support [worker instances](/configuration/app/app-reference.md#workers).
+  * Worker instances: Applications now support [worker instances](../configuration/app/app-reference.md#workers).
 ---
 
 * **July 2017**
-  * Node.js 8.2: [Node.js 8.2](/languages/nodejs/_index.md) is now available.
+  * Node.js 8.2: [Node.js 8.2](../languages/nodejs/_index.md) is now available.
 ---
 
 * **June 2017**
-  * Memcache 1.4: [Memcache 1.4](/configuration/services/memcached.md) is now available as a caching backend.
-  * Custom static headers in `.platform.app.yaml`: Added support for setting custom headers for static files in `.platform.app.yaml`. [See the example](/configuration/app/web.md#how-can-i-control-the-headers-sent-with-my-files) for more information.
+  * Memcache 1.4: [Memcache 1.4](../configuration/services/memcached.md) is now available as a caching backend.
+  * Custom static headers in `.platform.app.yaml`: Added support for setting custom headers for static files in `.platform.app.yaml`. [See the example](../configuration/app/web.md#how-can-i-control-the-headers-sent-with-my-files) for more information.
 ---
 
 * **May 2017**
-  * Code-driven variables in `.platform.app.yaml`: Added support for setting [environment variables via `.platform.app.yaml`](/configuration/app/app-reference.m#variables).
+  * Code-driven variables in `.platform.app.yaml`: Added support for setting [environment variables via `.platform.app.yaml`](../configuration/app/app-reference.md#variables).
   * Python 3.6, Ruby 2.4, Node.js 6.10: Added support for updated versions of several languages.
 ---
 
 * **April 2017**
   * Support for automatic SSL certificates: All production environments are now issued an SSL certificate automatically through Let's Encrypt.
-    See the [routing documentation](/configuration/routes/https.md) for more information.
+    See the [routing documentation](../configuration/routes/https.md) for more information.
   * MariaDB 10.1: MariaDB 10.1 is now available (accessible as `mysql:10.1`).
     Additionally, both MariaDB 10.0 and 10.1 now use the Barracuda file format with `innodb_large_prefix` enabled,
     which allows for much longer indexes and resolves issues with some UTF-8 MB use cases.
@@ -220,9 +220,9 @@ description: |
 * **March 2017**
   * Elasticsearch 2.4 and 5.2 with support for plugins: Elasticsearch 2.4 and 5.2 are now available.
     Both have a number of optional plugins available.
-    See the [Elasticsearch documentation](/configuration/services/elasticsearch.md) for more information.
+    See the [Elasticsearch documentation](../configuration/services/elasticsearch.md) for more information.
   * InfluxDB 1.2: A new service type is available for InfluxDB 1.2, a time-series database.
-    See the [InfluxDB documentation](/configuration/services/influxdb.md) for more information.
+    See the [InfluxDB documentation](../configuration/services/influxdb.md) for more information.
 ---
 
 * **February 2017**
@@ -231,14 +231,14 @@ description: |
 
 * **January 2017**
   * Support for Multiple MySQL databases and restricted users: MySQL now supports multiple databases, and restricted users per MySQL service.
-    See the [MySQL documentation](/configuration/services/mysql/_index.md) for details or read our [blog post](https://platform.sh/2017/02/multi-mysql).
+    See the [MySQL documentation](../configuration/services/mysql/_index.md) for details or read our [blog post](https://platform.sh/2017/02/multi-mysql).
   * Support for Persistent Redis services:
     Added a `redis-persistent` service that is appropriate for persistent key-value data.
     The `redis` service is still available for caching.
-    See the [Redis documentation](/configuration/services/redis.md) for details.
+    See the [Redis documentation](../configuration/services/redis.md) for details.
   * Support Apache Solr 6.3 with multiple cores:
     Added an Apache 6.3 service, which can be configured with multiple cores.
-    See the [Solr documentation](/configuration/services/solr.md) for details.
+    See the [Solr documentation](../configuration/services/solr.md) for details.
   * Support for HTTP/2:
     Any site configured with HTTPS will now automatically support HTTP/2.
     Read more on our [blog post](https://platform.sh/2017/1/http2).
@@ -272,14 +272,14 @@ description: |
 ---
 
 * **October 2016**
-  * PostgreSQL 9.6: Service is [documented here](/configuration/services/postgresql.md).
+  * PostgreSQL 9.6: Service is [documented here](../configuration/services/postgresql.md).
   * PostgreSQL extensions: Read more in our [blog post](https://platform.sh/blog/the-new-and-newer-postgresql/).
-  * Node.js 6.8: Language is [documented here](/languages/nodejs/_index.md).
+  * Node.js 6.8: Language is [documented here](../languages/nodejs/_index.md).
 ---
 
 * **September 2016**
-  * Python 2.7 & 3.5: Language is [documented here](/languages/python.md).
-  * Ruby 2.3: Language is [documented here](/languages/ruby.md).
+  * Python 2.7 & 3.5: Language is [documented here](../languages/python.md).
+  * Ruby 2.3: Language is [documented here](../languages/ruby.md).
 ---
 
 * **August 2016**
@@ -323,7 +323,7 @@ description: |
 ---
 
 * **January 2016**
-  * Redis 3.0: Service is [documented here](/configuration/services/redis.md).
+  * Redis 3.0: Service is [documented here](../configuration/services/redis.md).
 ---
 
 ## 2015
@@ -339,13 +339,13 @@ description: |
 ---
 
 * **October 2015**
-  * MariaDB/MySQL 10.0: Service is [documented here](/configuration/services/mysql/_index.md).
-  * MongoDB 3.0: Service is [documented here](/configuration/services/mongodb.md).
+  * MariaDB/MySQL 10.0: Service is [documented here](../configuration/services/mysql/_index.md).
+  * MongoDB 3.0: Service is [documented here](../configuration/services/mongodb.md).
 ---
 
 * **September 2015**
   * PHP 5.4, 5.5 & 5.6: Read more in our [blog post](https://platform.sh/2015/09/release-php)
-  * RabbitMQ 3.5: Service is [documented here](/configuration/services/rabbitmq.md). Read more in our [blog post](https://platform.sh/2015/09/release-rabbitmq)
+  * RabbitMQ 3.5: Service is [documented here](../configuration/services/rabbitmq.md). Read more in our [blog post](https://platform.sh/2015/09/release-rabbitmq)
   * HHVM 3.9 & 3.12: Read more in our [blog post](https://platform.sh/2015/09/release-hhvm)
 ---
 
@@ -355,7 +355,7 @@ description: |
 
 * **June 2015**
   * Bitbucket integration: This add-on allows you to deploy any branch or pull request on a fully isolated Platform.sh environment with a dedicated URL. Read more in Bitbucket's [blog post](https://bitbucket.org/blog/bitbucket-platform-sh-remove-the-middle-man-between-your-code-and-your-deployment).
-  * PostgreSQL 9.3: Service is [documented here](/configuration/services/postgresql.md).
+  * PostgreSQL 9.3: Service is [documented here](../configuration/services/postgresql.md).
 ---
 
 * **May 2015**
@@ -367,7 +367,7 @@ description: |
 ---
 
 * **January 2015**
-  * Redis 2.8: Service is [documented here](/configuration/services/redis.md).
+  * Redis 2.8: Service is [documented here](../configuration/services/redis.md).
 ---
 
 ## 2014
@@ -377,7 +377,7 @@ description: |
   * HTTP caching per route: Support for HTTP caching at the web server level, finely configurable on a per-route basis.
   * Custom PHP configurations: Support for tweaking the PHP configuration, by enabling / disabling extensions and shipping your own php.ini.
   * Build dependencies: Support for specifying build dependencies, i.e. PHP, Python, Ruby or Node.js tools (like SASS, Grunt, UglifyJS, and more) that you want to use to build your PHP application.
-  * Elasticsearch 0.90, 1.4 & 1.7: Service is [documented here](/configuration/services/elasticsearch.md).
+  * Elasticsearch 0.90, 1.4 & 1.7: Service is [documented here](../configuration/services/elasticsearch.md).
 ---
 
 * **October 2014**
@@ -385,12 +385,12 @@ description: |
     Platform.sh provides a unique approach to protect your applications from known security issues.
     An automated protective blocking system which works a bit like an antivirus:
     it compares the code you deploy on Platform.sh with a database of signatures of known security issues in open source projects.
-    This feature is [documented here](/security/protective-block.md).
+    This feature is [documented here](../security/protective-block.md).
     Read more in our [blog post](https://platform.sh/2014/10/21/protecting-your-apps).
-  * Solr 4.10: Service is [documented here](/configuration/services/solr.md).
+  * Solr 4.10: Service is [documented here](../configuration/services/solr.md).
 ---
 
 * **July 2014**
-  * MariaDB/MySQL 5.5: Service is [documented here](/configuration/services/mysql/_index.md).
-  * Solr 3.6: Service is [documented here](/configuration/services/solr.md).
+  * MariaDB/MySQL 5.5: Service is [documented here](../configuration/services/mysql/_index.md).
+  * Solr 3.6: Service is [documented here](../configuration/services/solr.md).
 ---


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

* The Drupal 9 template README changed, so the link to a specific section was broken (as noted in #2213).
* GitHub restructured their docs

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
* Changed the link to the general template and redid the other sentences around it to have links at the end of sentences (as in the [upcoming style recommendations](https://github.com/platformsh/platformsh-docs/pull/2247/files#diff-cd95459fff6e7161b4478a42b001be388b9e7cffa0902ae17e0985be1eb61ee8R115)
* Redid the links for GitHub
* Changed a couple of other links that weren't working