### PR TITLE
:white_check_mark: Lint prose on forked PRs

### DIFF
--- a/.github/workflows/lint-prose.yaml
+++ b/.github/workflows/lint-prose.yaml
@@ -1,8 +1,9 @@
 name: Linting
 on:
-  push:
-    branches-ignore:
-      - main
+  workflow_run:
+    workflows: [Get info on PR]
+    types:
+      - completed
 
 jobs:
   prose:
@@ -10,6 +11,17 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
+
+    - name: Download info on PR
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: get-pr-info.yaml
+        workflow_conclusion: success
+        name: pr-info
+
+    - name: Get PR number
+      id: pr_number
+      run: echo "::set-output name=pr_number::$(cat pr_number.txt)"
 
     - name: Vale
       uses: errata-ai/vale-action@v1.4.3
@@ -21,3 +33,4 @@ jobs:
       env:
         # Required
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        OVERRIDE_GITHUB_SHA: ${{ steps.pr_number.outputs.pr_number }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The Vale action only had permissions to annotate PRs from non-forked repos.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Switched to run after the **Get PR info** workflow and override the GitHub SHA.
Based on https://github.com/errata-ai/vale-action/issues/58, this should work similar to our other PR comments
