### PR TITLE
:memo: Add workers and Blackfire configuration to the Laravel guide

### DIFF
--- a/docs/src/guides/laravel/deploy/blackfire.md
+++ b/docs/src/guides/laravel/deploy/blackfire.md
@@ -1,0 +1,15 @@
+---
+title: "Continous Observability with Blackfire"
+sidebarTitle: "Blackfire"
+weight: -100
+description: How to set up a Continuous Observability strategy for your Laravel application with Blackfire.
+---
+
+[Blackfire.io](../../../integrations/observability/blackfire) is the recommended solution for monitoring and profiling web sites and applications. Blackfire works seamlessly with any application built with Laravel, like any PHP application.
+
+For advanced cases, the Blackfire PHP SDK provides the following integrations with Laravel:
+- [Laravel Artisan](https://blackfire.io/docs/php/integrations/laravel/artisan)
+- [Laravel Horizon and other queue services](https://blackfire.io/docs/php/integrations/laravel/horizon)
+- [Laravel Tests](https://blackfire.io/docs/php/integrations/laravel/tests)
+
+A `.blackfire.yaml` file is provided within the [Laravel Template](https://github.com/platformsh-templates/laravel/blob/master/.blackfire.yaml) to help you bootstrap the writing of custom [performance tests](https://blackfire.io/docs/testing-cookbooks/index) and automated [builds](https://blackfire.io/docs/builds-cookbooks/index).

--- a/docs/src/guides/laravel/deploy/blackfire.md
+++ b/docs/src/guides/laravel/deploy/blackfire.md
@@ -1,11 +1,11 @@
 ---
 title: "Continous Observability with Blackfire"
 sidebarTitle: "Blackfire"
-weight: -100
+weight: -90
 description: How to set up a Continuous Observability strategy for your Laravel application with Blackfire.
 ---
 
-[Blackfire.io](../../../integrations/observability/blackfire) is the recommended solution for monitoring and profiling web sites and applications. Blackfire works seamlessly with any application built with Laravel, like any PHP application.
+[Blackfire.io](../../../integrations/observability/blackfire.md) is the recommended solution for monitoring and profiling web sites and applications. Blackfire works seamlessly with any application built with Laravel, like any PHP application.
 
 For advanced cases, the Blackfire PHP SDK provides the following integrations with Laravel:
 - [Laravel Artisan](https://blackfire.io/docs/php/integrations/laravel/artisan)

--- a/docs/src/guides/laravel/deploy/blackfire.md
+++ b/docs/src/guides/laravel/deploy/blackfire.md
@@ -1,8 +1,8 @@
 ---
-title: "Continous Observability with Blackfire"
+title: "Continous observability with Blackfire"
 sidebarTitle: "Blackfire"
 weight: -90
-description: How to set up a Continuous Observability strategy for your Laravel application with Blackfire.
+description: Set up a continuous observability strategy for your Laravel app with Blackfire.
 ---
 
 [Blackfire.io](../../../integrations/observability/blackfire.md) is the recommended solution for monitoring and profiling web sites and applications. Blackfire works seamlessly with any application built with Laravel, like any PHP application.

--- a/docs/src/guides/laravel/deploy/deploy.md
+++ b/docs/src/guides/laravel/deploy/deploy.md
@@ -3,7 +3,7 @@ title: "Deploy Laravel"
 sidebarTitle: "Deploy"
 weight: -80
 description: |
-  Now that your site is ready, push it to Platform.sh and import your data.
+  Now that your Laravel app is ready, push it to Platform.sh and import your data.
 ---
 {{< guides/deployment >}} 
 

--- a/docs/src/guides/laravel/deploy/scheduling.md
+++ b/docs/src/guides/laravel/deploy/scheduling.md
@@ -12,17 +12,17 @@ The recommended way is a cron configuration entry running the `artisan schedule:
 
 ```yaml {location=".platform.app.yaml"}
 crons:
-    # Run Laravel's scheduler every 5 minutes, which is as often as crons can run.
+    # Run Laravel's scheduler every 5 minutes, which is as often as crons can run on Professional plans.
     scheduler:
         spec: '*/5 * * * *'
         cmd: 'php artisan schedule:run'
 ```
 
-The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. The tasks scheduling may then be contradicted by the cron minimum frequency.
+The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency.
 
 This [blog post](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help you understand the stakes and harmonize the frequencies so all your scheduled tasks can be effectively triggered.
 
-You could also [configure a worker](../../../configuration/app/workers.md) relying on the `artisan schedule:work`.
+You could also [configure a worker](../../../configuration/app/workers.md) that relies on `artisan schedule:work`.
 To invoke the scheduler every minute, run [the following command](https://laravel.com/docs/scheduling#running-the-scheduler-locally):
 
 ```yaml {location=".platform.app.yaml"}

--- a/docs/src/guides/laravel/deploy/scheduling.md
+++ b/docs/src/guides/laravel/deploy/scheduling.md
@@ -18,7 +18,7 @@ crons:
         cmd: 'php artisan schedule:run'
 ```
 
-The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency. Schedules outside the specified cron frequency will be ignored and the related tasks won't be triggered.
+The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency. Schedules outside the specified cron frequency are ignored and the related tasks aren't triggered.
 
 This [blog post](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help you understand the stakes and harmonize the frequencies so all your scheduled tasks can be effectively triggered.
 

--- a/docs/src/guides/laravel/deploy/scheduling.md
+++ b/docs/src/guides/laravel/deploy/scheduling.md
@@ -1,11 +1,11 @@
 ---
-title: "Workers, Cron Jobs and Task Scheduling"
-sidebarTitle: "Scheduling Tasks"
+title: "Workers, cron jobs, and task scheduling"
+sidebarTitle: "Scheduling tasks"
 weight: -100
-description: How to schedule Tasks for your Laravel application.
+description: Schedule tasks for your Laravel app.
 ---
 
-Laravel offers a very convenient and flexible way of scheduling tasks. A large set of [helpers functions](https://laravel.com/docs/scheduling#schedule-frequency-options) allows the easy scheduling of Commands and Jobs.
+Laravel offers a very convenient and flexible way of scheduling tasks. A large set of [helper functions](https://laravel.com/docs/scheduling#schedule-frequency-options) help you schedule commands and jobs.
 
 Once the scheduled tasks are defined, they need to be effectively executed at the right time and pace.
 The recommended way is a cron configuration entry running the `artisan schedule:run` command.
@@ -20,17 +20,16 @@ crons:
 
 The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. The tasks scheduling may then be contradicted by the cron minimum frequency.
 
-This [blogpost](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help understanding the stakes and harmonazing the frequencies so all your scheduled tasks can be effectively triggered.
+This [blog post](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help you understand the stakes and harmonize the frequencies so all your scheduled tasks can be effectively triggered.
 
 You could also [configure a worker](../../../configuration/app/workers.md) relying on the `artisan schedule:work`.
-[This command](https://laravel.com/docs/scheduling#running-the-scheduler-locally) will invoke the scheduler every minute. 
+To invoke the scheduler every minute, run [the following command](https://laravel.com/docs/scheduling#running-the-scheduler-locally):
 
 ```yaml {location=".platform.app.yaml"}
 workers:
    queue:
        size: S
        commands:
-           start: |
-          php artisan schedule:work
+           start: php artisan schedule:work
 ```
 

--- a/docs/src/guides/laravel/deploy/scheduling.md
+++ b/docs/src/guides/laravel/deploy/scheduling.md
@@ -18,7 +18,7 @@ crons:
         cmd: 'php artisan schedule:run'
 ```
 
-The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency.
+The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency. Schedules outside the specified cron frequency will be ignored and the related tasks won't be triggered.
 
 This [blog post](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help you understand the stakes and harmonize the frequencies so all your scheduled tasks can be effectively triggered.
 

--- a/docs/src/guides/laravel/deploy/scheduling.md
+++ b/docs/src/guides/laravel/deploy/scheduling.md
@@ -18,11 +18,11 @@ crons:
         cmd: 'php artisan schedule:run'
 ```
 
-The [minimum time between cron jobs](../../../configuration/app/app-reference.html#cron-job-timing) being triggered depends on your plan. The tasks scheduling may then be contradicted by the cron minimum frequency.
+The [minimum time between cron jobs](../../../configuration/app/app-reference.md#cron-job-timing) being triggered depends on your plan. The tasks scheduling may then be contradicted by the cron minimum frequency.
 
 This [blogpost](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help understanding the stakes and harmonazing the frequencies so all your scheduled tasks can be effectively triggered.
 
-You could also [configure a worker](../../../configuration/app/workers) relying on the `artisan schedule:work`.
+You could also [configure a worker](../../../configuration/app/workers.md) relying on the `artisan schedule:work`.
 [This command](https://laravel.com/docs/scheduling#running-the-scheduler-locally) will invoke the scheduler every minute. 
 
 ```yaml {location=".platform.app.yaml"}

--- a/docs/src/guides/laravel/deploy/scheduling.md
+++ b/docs/src/guides/laravel/deploy/scheduling.md
@@ -1,0 +1,36 @@
+---
+title: "Workers, Cron Jobs and Task Scheduling"
+sidebarTitle: "Scheduling Tasks"
+weight: -100
+description: How to schedule Tasks for your Laravel application.
+---
+
+Laravel offers a very convenient and flexible way of scheduling tasks. A large set of [helpers functions](https://laravel.com/docs/scheduling#schedule-frequency-options) allows the easy scheduling of Commands and Jobs.
+
+Once the scheduled tasks are defined, they need to be effectively executed at the right time and pace.
+The recommended way is a cron configuration entry running the `artisan schedule:run` command.
+
+```yaml {location=".platform.app.yaml"}
+crons:
+    # Run Laravel's scheduler every 5 minutes, which is as often as crons can run.
+    scheduler:
+        spec: '*/5 * * * *'
+        cmd: 'php artisan schedule:run'
+```
+
+The [minimum time between cron jobs](../../../configuration/app/app-reference.html#cron-job-timing) being triggered depends on your plan. The tasks scheduling may then be contradicted by the cron minimum frequency.
+
+This [blogpost](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help understanding the stakes and harmonazing the frequencies so all your scheduled tasks can be effectively triggered.
+
+You could also [configure a worker](../../../configuration/app/workers) relying on the `artisan schedule:work`.
+[This command](https://laravel.com/docs/scheduling#running-the-scheduler-locally) will invoke the scheduler every minute. 
+
+```yaml {location=".platform.app.yaml"}
+workers:
+   queue:
+       size: S
+       commands:
+           start: |
+          php artisan schedule:work
+```
+


### PR DESCRIPTION
The link https://github.com/platformsh-templates/laravel/blob/master/.blackfire.yaml is missing, while https://github.com/platformsh/template-builder/pull/591 is not merged.

Also, I may have issues with internal links. Yet, they are working with Hugo. I may need your help here @CollierCZ 