### PR TITLE
:memo: Default Elite cron interval 1 min

### DIFF
--- a/docs/src/configuration/app/app-reference.md
+++ b/docs/src/configuration/app/app-reference.md
@@ -674,13 +674,6 @@ Minimum time between cron jobs being triggered:
 | Professional        | 5 minutes |
 | Elite or Enterprise | 1 minute  |
 
-{{< note >}}
-
-The time between cron jobs defaults to 5 minutes even for Elite and Enterprise plans.
-To set it to 1 minute, create a [support ticket](https://console.platform.sh/-/users/~/tickets/open).
-
-{{< /note >}}
-
 For each app container, only one cron job can run at a time.
 If a new job is triggered while another is running, the new job is paused until the other completes.
 To minimize conflicts, a random offset is applied to all triggers.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The default for minimum cron intervals is 1 min for new projects

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Removed the note about needing to open a support ticket