### PR TITLE
Use explicit curl in Windows

### DIFF
--- a/docs/src/gettingstarted/introduction/own-code/cli-install.md
+++ b/docs/src/gettingstarted/introduction/own-code/cli-install.md
@@ -33,7 +33,7 @@ highlight=bash
 markdownify=false
 ---
 
-curl -f https://platform.sh/cli/installer -o cli-installer.php
+curl.exe -f https://platform.sh/cli/installer -o cli-installer.php
 php cli-installer.php
 {{< /codetabs >}}
 


### PR DESCRIPTION
## Why

`curl` is an alias to Invoke-WebRequest on Windows. When you really want curl, you have to add the `.exe`
