### PR TITLE
:bug: Add synonyms to improve search for auth

### DIFF
--- a/docs/src/overview/environments/http-access-control.md
+++ b/docs/src/overview/environments/http-access-control.md
@@ -1,6 +1,8 @@
 ---
 title: Configure HTTP access control
 description: Learn how to control access to.a given environment using HTTP methods.
+keywords:
+  - basic authentication
 ---
 
 When developing your site, you might want to hide your development environments from outside viewers.

--- a/search/main.py
+++ b/search/main.py
@@ -44,6 +44,7 @@ class Search:
             "public ip addresses": ["regions"],
             "ssl": ["https", "tls"],
             "https": ["ssl"],
+            "auth": ["authentication", "access control"], # Only needs to be one way since we don't use "auth" in the docs
         }
 
         # Ranking rules:


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Searching for `HTTP auth` and `basic auth` didn't turn up [expected page](https://docs.platform.sh/overview/environments/http-access-control.html).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
- Added synonyms
- Added a keyword
