### PR TITLE
🐛 Use Vale version that recognizes workflow runs

### DIFF
--- a/.github/workflows/lint-prose.yaml
+++ b/.github/workflows/lint-prose.yaml
@@ -24,7 +24,7 @@ jobs:
       run: echo "::set-output name=pr_number::$(cat pr_number.txt)"
 
     - name: Vale
-      uses: errata-ai/vale-action@v1.4.3
+      uses: errata-ai/vale-action@ff9447943c1cad0f45649b630e29112511f80e5a
       with:
         # Switch to this when the number of errors goes down
         # files: __onlyModified


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The changes in #2287 haven't been released in a version of the Vale action, so the [workflow run failed](https://github.com/platformsh/platformsh-docs/runs/6179626912?check_suite_focus=true).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Switched to a commit that uses the change that includes the fix #2287 relied on.