### PR TITLE
Fix typo in backup docs

### DIFF
--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -108,7 +108,7 @@ crons:
         spec: '0 5 * * *'
         commands:
             start: |
-                if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
+                if [ "$PLATFORM_ENVIRONMENT_TYPE" == production ]; then
                     platform backup:create --yes --no-wait
                 fi
 ```


### PR DESCRIPTION
Just a simple typo update in example command

