### PR TITLE
🧑‍💻 Move external site indexing to a cron job

### DIFF
--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -27,6 +27,15 @@ web:
 # The size of the persistent disk of the application (in MB).
 disk: 2048
 
+crons:
+    indexExternalSites:
+        # Run at 06:00 UTC every day
+        spec: '0 6 * * *'
+        commands:
+            start: !include
+                type: string
+                path: index_external_sites.sh
+
 mounts:
     "data.ms":
         source: local

--- a/search/index_external_sites.sh
+++ b/search/index_external_sites.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+cleanup(){
+    echo "* CLEANING UP OLD DOCS INDEX"
+    rm -f output/docs.json
+}
+
+scrape(){
+    echo "* SCRAPING EXTERNAL SITES"
+    # Scrape all indexes defined in config/scrape.json
+    DATA=scrape.json
+    for i in $(jq '.indexes | keys | .[]' $DATA); do
+        index=`echo $i | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
+        echo "* REMOVING OLD $index INDEX"
+        rm -f output/$index.json
+        index_spider=$(jq --arg index "$index" '.indexes[$index].spider' $DATA)
+        spider=`echo $index_spider | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
+        echo "- Scraping $index..."
+        poetry run scrapy runspider -o output/$index.json $spider -L ERROR
+    done
+}
+
+update_index(){
+    echo "* UPDATING INDEX"
+    # Update indexes
+    poetry run python main.py
+}
+
+scrape
+update_index

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
 cleanup(){
-    echo "* CLEANING UP OLD DATA"
-    # Clean up output mounts.
-    OUTPUT_DIR=output
-    rm -f $OUTPUT_DIR/*.json
+    echo "* CLEANING UP OLD DOCS INDEX"
+    rm -f output/docs.json
 }
 
 getDocsData() {
@@ -18,19 +16,6 @@ getDocsData() {
     rm -f data/templates.yaml
     # Get the updated index for templates
     curl -s "${FRONTEND_URL}files/indexes/templates.yaml" >> data/templates.yaml
-}
-
-scrape(){
-    echo "* SCRAPING EXTERNAL SITES"
-    # Scrape all indexes defined in config/scrape.json
-    DATA=scrape.json
-    for i in $(jq '.indexes | keys | .[]' $DATA); do
-        index=`echo $i | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
-        index_spider=$(jq --arg index "$index" '.indexes[$index].spider' $DATA)
-        spider=`echo $index_spider | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
-        echo "- Scraping $index..."
-        poetry run scrapy runspider -o output/$index.json $spider -L ERROR
-    done
 }
 
 update_index(){
@@ -51,5 +36,4 @@ else
     getDocsData
 fi
 
-scrape 
 update_index


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2322

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Split indexing of external sites into a separate script. Set it to run at 6:00 UTC every day instead of after every deploy.
