### PR TITLE
📝 Recommend Network Storage 2.0 even on Grid

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -559,9 +559,11 @@
     "runtime": false,
     "type": "network-storage",
     "versions": {
-      "deprecated": [],
-      "supported": [
+      "deprecated": [
         "1.0"
+      ],
+      "supported": [
+        "2.0"
       ]
     },
     "versions-dedicated-gen-3": {

--- a/docs/src/add-services/network-storage.md
+++ b/docs/src/add-services/network-storage.md
@@ -37,6 +37,12 @@ Any change to the service version results in existing data becoming inaccessible
 
 {{< /note >}}
 
+{{% deprecated-versions %}}
+
+| Grid | Dedicated | Dedicated Generation 3 |
+| ---- | --------- | ---------------------- |
+|  {{< image-versions image="network-storage" status="deprecated" environment="grid" >}} | {{< image-versions image="network-storage" status="deprecated" environment="dedicated" >}} | {{< image-versions image="network-storage" status="deprecated" environment="dedicated-gen-3" >}} |
+
 {{% legacy-regions featureIntro="The Network Storage service" featureShort="the service" %}}
 
 ## Usage example

--- a/docs/src/add-services/network-storage.md
+++ b/docs/src/add-services/network-storage.md
@@ -28,9 +28,6 @@ If your app does this regularly, a local mount is more effective.
 {{< image-versions-legacy "network-storage" >}}
 
 This service is the Platform.sh network storage implementation, not to a version of a third-party application.
-Version 2.0 isn't recommended for the Grid.
-You should use version 1.0 unless you are a [Dedicated Generation 3](../dedicated-gen-3/overview.md) user.
-Dedicated Generation 3 users can use version 2.0 even on their Development environments.
 
 {{< note theme="warning">}}
 


### PR DESCRIPTION
## Why

I'm told that network-storage 2.0 works on Grid. I've tried it, minimally, and this appears to be the case.

It would be painful to have to change versions between Grid and Dedicated Gen 3, so, having the same version on both would be highly preferable.

## What's changed

Versions in `registry.json` and the text describing versions on `/configuration/services/network-storage.html#supported-versions`