### PR TITLE
📝 Match permission names with console

### DIFF
--- a/docs/src/administration/organizations.md
+++ b/docs/src/administration/organizations.md
@@ -71,16 +71,17 @@ highlight=false
 As an organization owner or an organization user with the **Users** permission,
 you can invite other users to your organization and grant them the following permissions:
 
-* **Manage plans** (`plans`):
-  Add, remove, and edit plans and plan options for your existing projects.
-  (Change plan, change storage, change the number of environments, change the number of user licenses)
-* **Manage billing** (`billing`):
+* **Billing** (`billing`):
   Add, remove and edit billing information.
   Access invoices and vouchers.
-* **Create projects** (`projects:create`):
-  Create new projects within the organization.
+* **Plans** (`plans`):
+  Add, remove, and edit plans and plan options for your existing projects.
+  (Change plan, change storage, change the number of environments, change the number of user licenses)
 * **Users** (`members`):
   Add, remove, and edit organization-level users and permissions, including your own.
+* **Create projects** (`projects:create`):
+  Create new projects within the organization.
+
 
 {{< note theme="warning" >}}
 


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2345 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Updates `Manage your organization users` [section](https://docs.platform.sh/administration/organizations.html#manage-your-organization-users) to be consistent with what is displayed in console when working with organization users' permissions.
