### PR TITLE
Updated HTTP Cache documentation.

### DIFF
--- a/docs/src/define-routes/cache.md
+++ b/docs/src/define-routes/cache.md
@@ -17,7 +17,9 @@ When caching is on...
 * cookies will bypass the cache;
 * responses with the `Cache-Control` header set to `Private`, `No-Cache`, or `No-Store` are not cached.
 
-You should _not_ use the Platform.sh HTTP cache if you are not using Varnish or an external CDN. Mixing cache services together will most likely result in stale and unclearable caches. For more details, see [Best Practices: HTTP caching](../bestpractices/http-caching.md).
+You should _not_ use the Platform.sh HTTP cache if you're using Varnish or an external CDN.
+Mixing cache services together most likely results in caches that are stale and can't be cleared.
+For more details, see [best practices on HTTP caching](../bestpractices/http-caching.md).
 
 ## Basic usage
 

--- a/docs/src/define-routes/cache.md
+++ b/docs/src/define-routes/cache.md
@@ -17,6 +17,8 @@ When caching is on...
 * cookies will bypass the cache;
 * responses with the `Cache-Control` header set to `Private`, `No-Cache`, or `No-Store` are not cached.
 
+You should _not_ use the Platform.sh HTTP cache if you are not using Varnish or an external CDN. Mixing cache services together will most likely result in stale and unclearable caches. For more details, see [Best Practices: HTTP caching](../bestpractices/http-caching.md).
+
 ## Basic usage
 
 The HTTP cache is enabled by default, however you may wish to override this behaviour.


### PR DESCRIPTION
## Why
When referencing the [HTTP cache documentation](https://docs.platform.sh/define-routes/cache.html), I was unaware of the [separate best practices doc](https://docs.platform.sh/bestpractices/http-caching.html) that contains valuable information. I wanted to surface some of that and provide a link on the main page.

## What's changed

Updated HTTP Cache documentation to include reference to HTTP caching best practices documentation.

## Alternative
The contents of the [HTTP Caching Best Practices](https://docs.platform.sh/bestpractices/http-caching.html) page could be moved completely to the [HTTP cache](https://docs.platform.sh/define-routes/cache.html) page.