### PR TITLE
🐛 Fix bugs in search

### DIFF
--- a/docs/config/_default/params.yaml
+++ b/docs/config/_default/params.yaml
@@ -1,6 +1,6 @@
 
 # Basics
-version: "1.0.1"
+version: "1.0.2"
 description: Platform.sh User Documentation
 author: Platform.sh
 title: User documentation

--- a/docs/static/scripts/xss/src/containers/Search.js
+++ b/docs/static/scripts/xss/src/containers/Search.js
@@ -90,7 +90,15 @@ const Search = ({ fullPage }) => {
     <div className="suggestions suggestions-primary">
       <h4 className="section">Documentation</h4>
       <div className="hits">
-        <ul>Sorry, no documentation matched your search.</ul>
+        <ul>No documentation matched your search, but you can try the other resources below.</ul>
+      </div>
+    </div>
+  ) : ''
+  const noResults = (hits.docs.length === 0 && summedSecondary === 0) ? (
+    <div className="suggestions suggestions-primary">
+      <h4 className="section">No results</h4>
+      <div className="hits">
+        <ul>No documentation matched your search.</ul>
       </div>
     </div>
   ) : ''
@@ -98,6 +106,7 @@ const Search = ({ fullPage }) => {
 
   const allResults = (
     <div className={fullPage ? 'search-page-results' : 'search-all-results'}>
+      {noResults}
       {docs}
       {noPrimaryResults}
       {secondaryResults}

--- a/docs/static/scripts/xss/src/containers/Search.js
+++ b/docs/static/scripts/xss/src/containers/Search.js
@@ -14,7 +14,7 @@ const getConfig = async () => {
   // Webpack isn't a fan of reading from `config-reader-nodejs` or environment variables
   // here if they are not yet set, but a file works just fine.
   // The mount `public/scripts/xss/dist/config` has been defined to support this.
-  const response = await fetch('/scripts/xss/dist/config/config.json');
+  const response = await fetch(`/scripts/xss/dist/config/config.json?version=${Date.now().toString()}`);
   return response.json();
 }
 


### PR DESCRIPTION


<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Search config was being cached
This was leading to outdated API keys
because the script was updated but not the config.

Also, nothing was returned when no results, so it wasn't clear that the search was working

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Now always looks for the newest config version.
It's a small file, so the lack of cache shouldn't be a problem.

Also added a note for when no results are found.
