### PR TITLE
Fixes grammar, punctuation, brevity, and clarity

### DIFF
--- a/docs/src/_index.md
+++ b/docs/src/_index.md
@@ -17,7 +17,7 @@ Finally, you can also get tips for setting up your own **Development** workflow 
 
 ## Git Driven Infrastructure
 
-As a Platform as a Service, or PaaS, Platform.sh automatically manages everything your application needs to run.  That means you can, and should, view your infrastructure needs as part of your application, and version-control it as part of your application files.
+As a Platform as a Service, or PaaS, Platform.sh automatically manages everything your application needs to run.  That means you can, and should, view your infrastructure needs as part of your application and address them under version control.
 
 ### Infrastructure as code
 

--- a/docs/src/_index.md
+++ b/docs/src/_index.md
@@ -25,7 +25,7 @@ Platform.sh covers not only all of your hosting needs but also most of your DevO
 
 You only need to write your code, including a few YAML files that specify your desired infrastructure, commit it to Git, and push.  You don't need to set up anything manually. The web server is already set up and configured, as is any database, search engine, or cache that you specify.
 
-Every branch you push can be made a fully independent environment &mdash; complete with your application code, a copy of your database, a copy of your search index, a copy of your user files, everything.
+Every branch you push can be made a fully independent environment&mdash;complete with your application code, a copy of your database, a copy of your search index, a copy of your user files, everything.
 Its automatically generated URL can be sent to stakeholders or automated CI systems.
 It really is "what would my site look like if I merged this to production?" every time.
 

--- a/docs/src/_index.md
+++ b/docs/src/_index.md
@@ -9,24 +9,24 @@ If you're new to Platform.sh, we recommend starting with the **Big Picture**, in
 
 The main requirement of Platform.sh is that you use Git to manage your application code.
 Your project's configuration is driven almost entirely by a small number of YAML files in your Git repository.
-The **Configuration** section covers those in more detail and can serve as both tutorial and quick-reference.
+The **Configuration** section covers those in more detail and can serve as both a tutorial and a quick reference.
 
-Platform.sh supports a number of different programming **Languages** and environments, and it features recommended optimizations for a number of **Featured Frameworks**.
+Platform.sh supports many different programming **Languages** and environments, and it features recommended optimizations for several **Featured Frameworks**.
 
 Finally, you can also get tips for setting up your own **Development** workflow and **Administering** your Platform.sh account.
 
 ## Git Driven Infrastructure
 
-As a Platform as a Service, or PaaS, Platform.sh automatically manages everything your application needs in order to run.  That means you can, and should, view your infrastructure needs as part of your application, and version-control it as part of your application.
+As a Platform as a Service, or PaaS, Platform.sh automatically manages everything your application needs to run.  That means you can, and should, view your infrastructure needs as part of your application, and version-control it as part of your application files.
 
 ### Infrastructure as code
 
 Platform.sh covers not only all of your hosting needs but also most of your DevOps needs. It is a single tool that covers the application life-cycle from development to production and scaling.
 
-You only need to write your code, including a few YAML files that specify your desired infrastructure, commit it to Git, and push.  You don't need to setup anything manually. The web server is already setup and configured, as is any database, search engine, or cache that you specify.
+You only need to write your code, including a few YAML files that specify your desired infrastructure, commit it to Git and push.  You don't need to set up anything manually. The web server is already set up and configured, as is any database, search engine, or cache that you specify.
 
-Every branch you push can be made a fully independent environment&mdash;complete with your application code, a copy of your database, a copy of your search index, a copy of your user files, everything.
-Its automatically generated URL can be sent to stakeholders or to automated CI systems.
+Every branch you push can be made a fully independent environment &mdash; complete with your application code, a copy of your database, a copy of your search index, a copy of your user files, everything.
+Its automatically generated URL can be sent to stakeholders or automated CI systems.
 It really is "what would my site look like if I merged this to production?" every time.
 
 You can use these concepts to replicate a traditional development/staging/production workflow or even to give every feature its own effective staging environment before merging to production (empowering you to use git-flow like methodologies even better). You could also have an intermediary integration branch for several other branches.
@@ -37,8 +37,8 @@ Platform.sh respects the structure of branches. It's entirely up to you.
 
 Managing your full stack on Platform.sh gives you the following unique features:
 
-1. **Unified Environment:** All of your services (MySQL, ElasticSearch, MongoDB, etc...) are managed inside the cluster and included in the price, with no external single-points-of-failure. When you back up an environment, you get a fully consistent snapshot of your whole application.
-2. **Multi-Services & Multi-App:** You can deploy multiple applications (for example, in a microservice-based architecture), using multiple data backends (MySQL, PostgreSQL, Redis etc..) written in multiple frameworks (Drupal + NodeJS + Flask, for example) in multiple languages, all in the same cluster.
-3. **Full Cluster Cloning Technology:** The full production cluster can be cloned in under a minute&mdash;including all of its data&mdash;to create on-the-fly, ephemeral development environments that are a byte-level copy of production.
+1. **Unified Environment:** All of your services (MySQL, ElasticSearch, MongoDB, etc.) are managed inside the cluster and included in the price, with no external single-points-of-failure. When you back up an environment, you get a fully consistent snapshot of your whole application.
+2. **Multi-Services & Multi-App:** You can deploy multiple applications (for example, in a microservice-based architecture), using multiple data backends (MySQL, PostgreSQL, Redis, etc.) written in multiple frameworks (Drupal + NodeJS + Flask, for example) in multiple languages, all in the same cluster.
+3. **Full Cluster Cloning Technology:** The full production cluster can be cloned in under a minute &mdash; including all of its data &mdash; to create on-the-fly, ephemeral development environments that are a byte-level copy of production.
 4. **Fail-Proof Deployments:** Every time you test a new feature, you also test the deployment process.
-5. **Continuous Deployment from the Start:** Everything is build-oriented, with a consistent, repeatable build process, simplifying the process of keeping your application updated and secure.
+5. **Continuous Deployment from the Start:** Everything is build-oriented, with a consistent, repeatable build process, simplifying the process of keeping your application up-to-date and secure.

--- a/docs/src/_index.md
+++ b/docs/src/_index.md
@@ -23,7 +23,7 @@ As a Platform as a Service, or PaaS, Platform.sh automatically manages everythin
 
 Platform.sh covers not only all of your hosting needs but also most of your DevOps needs. It is a single tool that covers the application life-cycle from development to production and scaling.
 
-You only need to write your code, including a few YAML files that specify your desired infrastructure, commit it to Git and push.  You don't need to set up anything manually. The web server is already set up and configured, as is any database, search engine, or cache that you specify.
+You only need to write your code, including a few YAML files that specify your desired infrastructure, commit it to Git, and push.  You don't need to set up anything manually. The web server is already set up and configured, as is any database, search engine, or cache that you specify.
 
 Every branch you push can be made a fully independent environment &mdash; complete with your application code, a copy of your database, a copy of your search index, a copy of your user files, everything.
 Its automatically generated URL can be sent to stakeholders or automated CI systems.

--- a/docs/src/_index.md
+++ b/docs/src/_index.md
@@ -39,6 +39,6 @@ Managing your full stack on Platform.sh gives you the following unique features:
 
 1. **Unified Environment:** All of your services (MySQL, ElasticSearch, MongoDB, etc.) are managed inside the cluster and included in the price, with no external single-points-of-failure. When you back up an environment, you get a fully consistent snapshot of your whole application.
 2. **Multi-Services & Multi-App:** You can deploy multiple applications (for example, in a microservice-based architecture), using multiple data backends (MySQL, PostgreSQL, Redis, etc.) written in multiple frameworks (Drupal + NodeJS + Flask, for example) in multiple languages, all in the same cluster.
-3. **Full Cluster Cloning Technology:** The full production cluster can be cloned in under a minute &mdash; including all of its data &mdash; to create on-the-fly, ephemeral development environments that are a byte-level copy of production.
+3. **Full Cluster Cloning Technology:** The full production cluster can be cloned in under a minute&mdash;including all of its data&mdash;to create on-the-fly, ephemeral development environments that are a byte-level copy of production.
 4. **Fail-Proof Deployments:** Every time you test a new feature, you also test the deployment process.
 5. **Continuous Deployment from the Start:** Everything is build-oriented, with a consistent, repeatable build process, simplifying the process of keeping your application up-to-date and secure.


### PR DESCRIPTION
## Why

Line 12: tutorial: missing article - change to 'a tutorial'.
Line 12: quick-reference: missing article and unnecessary hyphen - change to 'a quick reference'.
Line 14: a number of: appears twice, and is against your guidelines for brevity - change to 'many' and 'several'.
Line 20: in order to: against your guidelines for brevity - change to 'to'.
Line 20: and version-control it as part of your application: incomplete idea - change to 'and version-control it as part of your application files'.
Line 26: Git,: incorrect punctuation in a compound predicate - remove the comma after Git.
Line 26: setup: verb misspelled twice as a noun - change to 'set up'.
Line 
Line 28: environment-complete: missing space before and after the &mdash - add space before and after the &mdash.
Line 29: or to automated CI systems: redundant preposition - remove 'to'.
Line 40: etc...: extra periods after etc. - change to 'etc.', removing the two extra periods.
Line 41: Redis etc.: missing punctuation - change to 'Redis, etc.', adding comma after Redis.
Line 41: etc..: extra period after etc. - change to 'etc.', removing the extra period.
Line 42: minute-including and data-to create.: missing spaces before and after the &mdash - add spaces before and after each &mdash.
Line 44: updated and secure: contradicting forms of verb - change to 'up-to-date and secure'.

## What's changed

Grammar, punctuation, spelling, brevity, and clarity
