### PR TITLE
:pencil2: Fix typo for SSH keys

### DIFF
--- a/docs/src/development/ssh/ssh-keys.md
+++ b/docs/src/development/ssh/ssh-keys.md
@@ -70,7 +70,7 @@ generate a key and have it added to your Platform.sh account automatically.
 1. Run the following commands (replacing `PATH_TO_YOUR_KEY` with the location you copied):
 
    ```bash
-   val $(ssh-agent)
+   eval $(ssh-agent)
    ssh-add 'PATH_TO_YOUR_KEY'
    ```
 

--- a/docs/src/development/ssh/ssh-keys.md
+++ b/docs/src/development/ssh/ssh-keys.md
@@ -71,7 +71,7 @@ generate a key and have it added to your Platform.sh account automatically.
 
    ```bash
    eval $(ssh-agent)
-   ssh-add 'PATH_TO_YOUR_KEY'
+   ssh-add '<PATH_TO_YOUR_KEY>'
    ```
 
 To generate a key otherwise, GitHub has a good [walk-through for creating SSH key pairs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) on various operating systems.

--- a/docs/src/development/ssh/ssh-keys.md
+++ b/docs/src/development/ssh/ssh-keys.md
@@ -67,7 +67,7 @@ generate a key and have it added to your Platform.sh account automatically.
 1. If necessary, log in to a browser.
 1. Press `Y` and `enter` to create a new SSH key.
 1. Copy the location of the generated key.
-1. Run the following commands (replacing `PATH_TO_YOUR_KEY` with the location you copied):
+1. Run the following commands (replacing `<PATH_TO_YOUR_KEY>` with the location you copied):
 
    ```bash
    eval $(ssh-agent)


### PR DESCRIPTION
Correct `val` to `eval` in generate new keys step

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
Fix a typo 


<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed
`val` to `eval` in Generate new keys step
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
