### PR TITLE
Update Custom Redis versions documentation adding support for Relay

### DIFF
--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -10,11 +10,15 @@ weight: 7
 
 The [PhpRedis](https://github.com/phpredis/phpredis) extension is available on Platform.sh's PHP container images.  However, the extension has been known to break its API between versions when removing deprecated functionality.  The version available on each application image is the latest available at the time that PHP version was built, which if your application is very sensitive to PhpRedis versions may not be ideal.
 
-If the version of the PhpRedis extension available for your PHP version is not compatible with your application and upgrading your application is not feasible, you can use the script below as an alternative to download and compile a precise version of the extension on the fly.
+If the version of the PhpRedis extension available for your PHP version is not compatible with your application
+and upgrading your application is not feasible,
+you can use the script linked below as an alternative to download and compile a precise version of the extension.
 
 Do *not* use this approach unless you really need to.  Using the provided PhpRedis extension is preferred in the vast majority of cases.
 
-A [script](https://github.com/platformsh/snippets/blob/main/src/install-phpredis.sh) is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
+To ease the installation of a customer version of PhpRedis, use a [PhpRedis install script](https://github.com/platformsh/snippets/blob/main/src/install-phpredis.sh).
+Invoke this script from your build hook, specifying a version.
+Any tagged version of the library is acceptable:
 
 ```yaml {location=".platform.app.yaml"}
 hooks:
@@ -26,15 +30,23 @@ hooks:
 
 ## Install Relay
 
-Relay is a [Redis](../../add-services/redis.md) client like [PhpRedis](https://github.com/phpredis/phpredis) and [PhpRedis](https://github.com/predis/predis). It intents to be a drop-in replacement of those libraries.
+Relay is a [Redis](../../add-services/redis.md) client
+similar to [PhpRedis](https://github.com/phpredis/phpredis) and
+[Predis](https://github.com/predis/predis).
+It is intended to be a drop-in replacement for those libraries.
 
 That PHP extension is also a shared in-memory cache like APCu. All retrieved keys are held in the PHP master process’ memory, which is shared across all FPM workers.
 
-That means if the FPM Worker #1 fetches the `users:count` key from Redis, the other FPM Workers #2, #3, … will instantaneously retrieve that key from Relay, without having to communicate with Redis.
+That means if the FPM Worker #1 fetches the `users:count` key from Redis,
+all other FPM workers instantaneously retrieve that key from Relay without having to communicate with Redis.
 
-A [script](https://github.com/platformsh/snippets/blob/main/src/install-relay.sh) is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
-## Changing extension of version
-If you ever wish to change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.  The new version will *not* be used until you clear the build cache.
+To ease the installation of a customer version of Relay, use the [Relay install script](https://github.com/platformsh/snippets/blob/main/src/install-relay.sh).
+Invoke this script from your build hook, specifying a version.
+Any tagged version of the library is acceptable:
+## Change extension or version
+
+To change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.
+The new version is *not* be used until you clear the build cache.
 
 There is no need to declare the extension in the `runtime` block.  That is only for pre-built extensions.
 
@@ -46,12 +58,12 @@ hooks:
         curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 0.4.3 ; } 3<&0
 ```
 
-## What those scripts do
+## What these scripts do
 
-1. Downloads the Relay/PhpRedis source code.
-2. Checks out the version specified in the build hook.
-3. Compiles the extension.
-4. Copies the resulting `redis.so` file to [your app root](../../create-apps/app-reference.md#root-directory).
+1. Download the Relay/PhpRedis source code.
+2. Check out the version specified in the build hook.
+3. Compile the extension.
+4. Copy the resulting `redis.so` file to [your app root](../../create-apps/app-reference.md#root-directory).
 5. Adds a line to the `php.ini` file in your app root to enable the extension, creating the file if necessary.
 
 If the script does not find a `$PLATFORM_CACHE_DIR` directory defined, it exits silently.  That means if you run the build hook locally it will have no effect.

--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -6,103 +6,49 @@ weight: 7
 
 [Redis](../../add-services/redis.md) is a popular structured key-value service, supported by Platform.sh.  It's frequently used for caching.
 
+## Install PhpRedis
+
 The [PhpRedis](https://github.com/phpredis/phpredis) extension is available on Platform.sh's PHP container images.  However, the extension has been known to break its API between versions when removing deprecated functionality.  The version available on each application image is the latest available at the time that PHP version was built, which if your application is very sensitive to PhpRedis versions may not be ideal.
 
 If the version of the PhpRedis extension available for your PHP version is not compatible with your application and upgrading your application is not feasible, you can use the script below as an alternative to download and compile a precise version of the extension on the fly.
 
 Do *not* use this approach unless you really need to.  Using the provided PhpRedis extension is preferred in the vast majority of cases.
 
-## Using the Redis builder script
+A script is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
 
-1. Copy the following script into a file named `install-redis.sh` in [your app root](../../create-apps/app-reference.md#root-directory)
-
-```bash
-run() {
-    # Run the compilation process.
-    cd $PLATFORM_CACHE_DIR || exit 1;
-
-    if [ ! -f "${PLATFORM_CACHE_DIR}/phpredis/modules/redis.so" ]; then
-        ensure_source
-        checkout_version "$1"
-        compile_source
-    fi
-
-    copy_lib
-    enable_lib
-}
-
-enable_lib() {
-    # Tell PHP to enable the extension.
-    echo "Enabling PhpRedis extension."
-    echo -e "\nextension=${PLATFORM_APP_DIR}/redis.so" >> $PLATFORM_APP_DIR/php.ini
-}
-
-copy_lib() {
-    # Copy the compiled library to the application directory.
-    echo "Installing PhpRedis extension."
-    cp $PLATFORM_CACHE_DIR/phpredis/modules/redis.so $PLATFORM_APP_DIR
-}
-
-checkout_version () {
-    # Check out the specific Git tag that we want to build.
-    git checkout "$1"
-}
-
-ensure_source() {
-    # Ensure that the extension source code is available and up to date.
-    if [ -d "phpredis" ]; then
-        cd phpredis || exit 1;
-        git fetch --all --prune
-    else
-        git clone https://github.com/phpredis/phpredis.git
-        cd phpredis || exit 1;
-    fi
-}
-
-compile_source() {
-    # Compile the extension.
-    phpize
-    ./configure
-    make
-}
-
-ensure_environment() {
-    # If not running in a Platform.sh build environment, do nothing.
-    if [ -z "${PLATFORM_CACHE_DIR}" ]; then
-        echo "Not running in a Platform.sh build environment.  Aborting Redis installation."
-        exit 0;
-    fi
-}
-
-ensure_arguments() {
-    # If no version was specified, don't try to guess.
-    if [ -z $1 ]; then
-        echo "No version of the PhpRedis extension specified.  You must specify a tagged version on the command line."
-        exit 1;
-    fi
-}
-
-ensure_environment
-ensure_arguments "$1"
-run "$1"
-```
-
-2. Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
-
-```yaml
+```yaml {location=".platform.app.yaml"}
 hooks:
     build: |
         set -e
-        bash install-redis.sh 5.1.1
+        # Install PhpRedis v5.1.1:
+        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-phpredis.sh | { bash /dev/fd/3 5.1.1 ; } 3<&0
 ```
 
-3. If you ever wish to change the version of PhpRedis you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.  The new version will *not* be used until you clear the build cache.
+## Install Relay
+
+Relay is a [Redis](../../add-services/redis.md) client like [PhpRedis](https://github.com/phpredis/phpredis) and [PhpRedis](https://github.com/predis/predis). It intents to be a drop-in replacement of those libraries.
+
+That PHP extension is also a shared in-memory cache like APCu. All retrieved keys are held in the PHP master process’ memory, which is shared across all FPM workers.
+
+That means if the FPM Worker #1 fetches the `users:count` key from Redis, the other FPM Workers #2, #3, … will instantaneously retrieve that key from Relay, without having to communicate with Redis.
+
+A script is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
+## Changing extension of version
+If you ever wish to change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.  The new version will *not* be used until you clear the build cache.
 
 There is no need to declare the extension in the `runtime` block.  That is only for pre-built extensions.
 
-## What the script does
+```yaml {location=".platform.app.yaml"}
+hooks:
+    build: |
+        set -e
+        # Install PhpRedis v0.4.3:
+        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 0.4.3 ; } 3<&0
+```
 
-1. Downloads the PhpRedis source code.
+## What those scripts do
+
+1. Downloads the Relay/PhpRedis source code.
 2. Checks out the version specified in the build hook.
 3. Compiles the extension.
 4. Copies the resulting `redis.so` file to [your app root](../../create-apps/app-reference.md#root-directory).

--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -14,7 +14,7 @@ If the version of the PhpRedis extension available for your PHP version is not c
 
 Do *not* use this approach unless you really need to.  Using the provided PhpRedis extension is preferred in the vast majority of cases.
 
-A script is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
+A [script](https://github.com/platformsh/snippets/blob/main/src/install-phpredis.sh) is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
 
 ```yaml {location=".platform.app.yaml"}
 hooks:
@@ -32,7 +32,7 @@ That PHP extension is also a shared in-memory cache like APCu. All retrieved key
 
 That means if the FPM Worker #1 fetches the `users:count` key from Redis, the other FPM Workers #2, #3, … will instantaneously retrieve that key from Relay, without having to communicate with Redis.
 
-A script is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
+A [script](https://github.com/platformsh/snippets/blob/main/src/install-relay.sh) is provided to ease the installation of a customer version of PhpRedis.  Invoke that script from your build hook, specifying a version.  Any tagged version of the library is acceptable:
 ## Changing extension of version
 If you ever wish to change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.  The new version will *not* be used until you clear the build cache.
 

--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -48,7 +48,7 @@ Any tagged version of the library is acceptable:
 hooks:
     build: |
         set -e
-        # Install PhpRedis v0.4.3:
+        # Install Relay v0.4.3:
         curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 0.4.3 ; } 3<&0
 ```
 ## Change extension or version

--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -43,12 +43,6 @@ all other FPM workers instantaneously retrieve that key from Relay without havin
 To ease the installation of a customer version of Relay, use the [Relay install script](https://github.com/platformsh/snippets/blob/main/src/install-relay.sh).
 Invoke this script from your build hook, specifying a version.
 Any tagged version of the library is acceptable:
-## Change extension or version
-
-To change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.
-The new version is *not* be used until you clear the build cache.
-
-There is no need to declare the extension in the `runtime` block.  That is only for pre-built extensions.
 
 ```yaml {location=".platform.app.yaml"}
 hooks:
@@ -57,6 +51,13 @@ hooks:
         # Install PhpRedis v0.4.3:
         curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 0.4.3 ; } 3<&0
 ```
+## Change extension or version
+
+To change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.
+
+The new version is *not* be used until you clear the build cache.
+
+There is no need to declare the extension in the `runtime` block.  That is only for pre-built extensions.
 
 ## What these scripts do
 

--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -4,17 +4,22 @@ sidebarTitle: Custom Redis
 weight: 7
 ---
 
-[Redis](../../add-services/redis.md) is a popular structured key-value service, supported by Platform.sh.  It's frequently used for caching.
+[Redis](../../add-services/redis.md) is a popular structured key-value service, supported by Platform.sh.
+It's frequently used for caching.
 
 ## Install PhpRedis
 
-The [PhpRedis](https://github.com/phpredis/phpredis) extension is available on Platform.sh's PHP container images.  However, the extension has been known to break its API between versions when removing deprecated functionality.  The version available on each application image is the latest available at the time that PHP version was built, which if your application is very sensitive to PhpRedis versions may not be ideal.
+The [PhpRedis](https://github.com/phpredis/phpredis) extension is available on Platform.sh's PHP container images.
+The extension has been known to break its API between versions when removing deprecated functionality.
+The version available on each application image is the latest available at the time that PHP version was built,
+which if your application is very sensitive to PhpRedis versions may not be ideal.
 
-If the version of the PhpRedis extension available for your PHP version is not compatible with your application
-and upgrading your application is not feasible,
-you can use the script linked below as an alternative to download and compile a precise version of the extension.
+It may happen that the version of the PhpRedis extension available for your PHP version
+isn't compatible with your app and upgrading your app isn't feasible.
+If so, use the following script as an alternative to download and compile a precise version of the extension.
 
-Do *not* use this approach unless you really need to.  Using the provided PhpRedis extension is preferred in the vast majority of cases.
+Do *not* use this approach unless you really need to.
+Using the provided PhpRedis extension is preferred in the vast majority of cases.
 
 To ease the installation of a customer version of PhpRedis, use a [PhpRedis install script](https://github.com/platformsh/snippets/blob/main/src/install-phpredis.sh).
 Invoke this script from your build hook, specifying a version.
@@ -33,7 +38,7 @@ hooks:
 Relay is a [Redis](../../add-services/redis.md) client
 similar to [PhpRedis](https://github.com/phpredis/phpredis) and
 [Predis](https://github.com/predis/predis).
-It is intended to be a drop-in replacement for those libraries.
+It's intended to be a drop-in replacement for those libraries.
 
 That PHP extension is also a shared in-memory cache like APCu. All retrieved keys are held in the PHP master process’ memory, which is shared across all FPM workers.
 
@@ -51,13 +56,15 @@ hooks:
         # Install Relay v0.4.3:
         curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 0.4.3 ; } 3<&0
 ```
+
 ## Change extension or version
 
 To change the Redis extension or the version you are using, update the build hook and clear the build cache: `platform project:clear-build-cache`.
 
 The new version is *not* be used until you clear the build cache.
 
-There is no need to declare the extension in the `runtime` block.  That is only for pre-built extensions.
+There's no need to declare the extension in the `runtime` block.
+That's only for pre-built extensions.
 
 ## What these scripts do
 
@@ -65,6 +72,7 @@ There is no need to declare the extension in the `runtime` block.  That is only 
 2. Check out the version specified in the build hook.
 3. Compile the extension.
 4. Copy the resulting `redis.so` file to [your app root](../../create-apps/app-reference.md#root-directory).
-5. Adds a line to the `php.ini` file in your app root to enable the extension, creating the file if necessary.
+5. Add a line to the `php.ini` file in your app root to enable the extension, creating the file if necessary.
 
-If the script does not find a `$PLATFORM_CACHE_DIR` directory defined, it exits silently.  That means if you run the build hook locally it will have no effect.
+If the script doesn't find a `$PLATFORM_CACHE_DIR` directory defined, it exits silently.
+So if you run the build hook locally, it has no effect.

--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -82,6 +82,7 @@ Payara
 Pixelant
 plaintext
 pngcrush
+Predis
 preprocessor
 preload(?:er|ing)?
 progs


### PR DESCRIPTION
## Why

[Relay](https://relay.so) is a new Redis PHP extension created by the maintainers of PhpRedis and Predis. Functioning as a shared in-memory cache like APCu, it could offer significant performance boosts.

## What's changed

- moved the PhpRedis install script to `platformsh/snippets` to provide a  convenient one-liner script.
- added similar instructions for Relay
