### PR TITLE
🐛 Make sidebar IDs unique

### DIFF
--- a/docs/themes/avocadocs/layouts/partials/navigation/sidebar/list.html
+++ b/docs/themes/avocadocs/layouts/partials/navigation/sidebar/list.html
@@ -1,7 +1,7 @@
 <!-- SECTION HEADING -->
-{{ $sectionHeading := printf "section-%s" .Context.Title | urlize }}
+{{ $sectionId := printf "section-%s-sidebar-id" .Context.Title | urlize }}
 <!-- Get rid of dots like in Platform.sh -->
-{{ $sectionHeading = replace $sectionHeading "." "" }}
+{{ $sectionId = replace $sectionId "." "" }}
 
 {{ $isCurrentSection := false }}
 {{ $currentSection := .Context.Section }}
@@ -45,9 +45,9 @@
       </a>
     </h4>
     <!-- Add button for expanding -->
-    {{ partial "navigation/sidebar/expand-button" (dict "itemID" $sectionHeading "isCurrentSection" $isCurrentSection )}}
+    {{ partial "navigation/sidebar/expand-button" (dict "itemID" $sectionId "isCurrentSection" $isCurrentSection )}}
   </div>
-  <ul class="duik-sidebar__nav dropdown-menu{{ if eq $isCurrentSection true }} show{{ end }}" aria-labelledby="nav-expand-{{ $sectionHeading }}" id="{{ $sectionHeading }}">
+  <ul class="duik-sidebar__nav dropdown-menu{{ if eq $isCurrentSection true }} show{{ end }}" aria-labelledby="nav-expand-{{ $sectionId }}" id="{{ $sectionId }}">
 
   <!-- Add the homepage as the first entry of the first section -->
   {{ if eq "overview" $currentSection }}
@@ -69,7 +69,7 @@
       {{ $itemTitle = . }}
     {{ end }}
     <!-- Create a machine readable ID with no dots (as in node.js) -->
-    {{ $itemId := ( replace ($itemTitle | urlize) "." "" ) }}
+    {{ $itemId := printf "%s-sidebar-id" ( replace ($itemTitle | urlize) "." "" ) }}
 
 
     <!-- FIRST LEVEL ITEM -->


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The sidebar navigation items has items that sometimes were in conflict with heading IDs.
This causes the table of contents not to work properly.
Example: https://docs.platform.sh/development/templates.html#nodejs

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added a string to the end of the IDs for the sidebar items so they don't conflict with heading IDs.
