### PR TITLE
🐛 Fix link to logs when environment fails

### DIFF
--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -5,6 +5,7 @@ on:
 
 env:
   PR_NUMBER: ${{ github.event.number }}
+  BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
 
 jobs:
   get_pr_info:
@@ -24,8 +25,6 @@ jobs:
       # Get the URL for the deployed environment
       - name: Get environment URL
         id: get_env_url
-        env:
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
           COMMIT_STATUS="pending"
           COMMIT_SHA=${{ github.event.pull_request.head.sha }}
@@ -87,7 +86,7 @@ jobs:
       - name: Create failure report
         if: steps.get_env_url.outputs.env_status == 'failure'
         run: |
-          echo -e "The environment on Platform.sh failed to deploy. :slightly_frowning_face:\n\nCheck the logs: https://console.platform.sh/projects/652soceglkw4u/pr-$PR_NUMBER" > pr_comment.txt
+          echo -e "The environment on Platform.sh failed to deploy. :slightly_frowning_face:\n\nCheck the logs: https://console.platform.sh/projects/652soceglkw4u/$BRANCH_NAME" > pr_comment.txt
         
       # Create a list of relevant changed pages
       - name: Report environment URL


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

With the recent changes to the GitHub workflow, the link to logs when an environment fails to deploy broke.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Updated the link to the correct environment.
