### PR TITLE
Fix unneeded quotes for web.locations root

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -951,7 +951,7 @@
           "socket_family": "unix"
         },
         "commands": {
-          "start": "\"unicorn -l $SOCKET -E production config.ru\""
+          "start": "unicorn -l $SOCKET -E production config.ru"
         },
         "locations": {
           "/": {

--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -49,7 +49,7 @@
         },
         "locations": {
           "/": {
-            "root": "\"wwwroot\"",
+            "root": "wwwroot",
             "allow": true,
             "passthru": true
           }
@@ -168,7 +168,7 @@
         "locations": {
           "/": {
             "allow": false,
-            "root": "\"web\"",
+            "root": "web",
             "passthru": true
           }
         }
@@ -695,7 +695,7 @@
       "web": {
         "locations": {
           "/": {
-            "root": "\"web\"",
+            "root": "web",
             "passthru": "/index.php"
           }
         }
@@ -955,7 +955,7 @@
         },
         "locations": {
           "/": {
-            "root": "\"public\"",
+            "root": "public",
             "passthru": true,
             "expires": "1h",
             "allow": true


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Contents of `.platform.app.yaml` is presented wrongly regarding `web.locations` root:

```yaml
web:
  locations: 
    '/': 
      root: "\"web\""
      passthru: "/index.php"
```

Instead of:

```yaml
web:
  locations: 
    '/': 
      root: "web"
      passthru: "/index.php"
```

This PR fixes it in the docs.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
