### PR TITLE
💄 Keep tables inside content wrapper

### DIFF
--- a/docs/config/_default/params.yaml
+++ b/docs/config/_default/params.yaml
@@ -1,6 +1,6 @@
 
 # Basics
-version: "1.0.8"
+version: "1.0.9"
 description: Platform.sh User Documentation
 author: Platform.sh
 title: User documentation

--- a/docs/static/styles/user-customizations.css
+++ b/docs/static/styles/user-customizations.css
@@ -404,3 +404,7 @@ kbd {
   padding: 1em;
   margin-bottom: 1em;
 }
+
+table {
+  table-layout: fixed; /* Keep tables inside the content wrapper */
+}

--- a/docs/themes/avocadocs/static/styles/customizations.css
+++ b/docs/themes/avocadocs/static/styles/customizations.css
@@ -101,10 +101,6 @@ code {
   display: inline-block;
 }
 
-table code {
-  white-space: nowrap;
-}
-
 .chroma {
   background-color: var(--primary) !important;
   /* word-wrap: normal !important;


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

At smaller widths, the table of contents overlapped with tables that took up more space than the content wrapper (the width of content other than tables).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Made tables stay inside the wrapper and code inside tables back to wrapping when appropriate.

Some pages to compare at smaller widths to see if the change is a positive one:
| Old | New|
|----| ----|
| https://docs.platform.sh/add-services/vault.html#policies | https://toc-overlap-inet3ea-652soceglkw4u.eu-3.platformsh.site/add-services/vault.html#policies |
| https://docs.platform.sh/add-services.html#service-options | https://toc-overlap-inet3ea-652soceglkw4u.eu-3.platformsh.site/add-services.html#service-options |
| https://docs.platform.sh/development/regions.html#europe | https://toc-overlap-inet3ea-652soceglkw4u.eu-3.platformsh.site/development/regions.html#europe |
