### PR TITLE
♻️ Standardize Console and CLI as administration

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -112,6 +112,8 @@ https://{default}/:
       # Changelog removal in June 2022
       "/other/changelog.html": { "to": "https://portal.productboard.com/platformsh/2-platform-sh-portal", "code": 301 }
 
+      # Move CLI from Development to Administration in August 2022
+      "/development/cli(.*)":  { "to": "/administration/cli$1", "code": 301, "regexp": true }
 
 "https://search.{default}/":
     type: upstream

--- a/docs/layouts/shortcodes/cli-installation-requirements.md
+++ b/docs/layouts/shortcodes/cli-installation-requirements.md
@@ -3,7 +3,7 @@ Before you install it, there are some requirements that must be met first.
 You need to have:
 
 * [PHP 5.5.9+](https://www.php.net/manual/en/install.php) with the following extensions installed: `curl`, `json`, `mbstring`, `pcre`, and `phar`.
-* [Git](https://git-scm.com/downloads) is the open source version control system used to manage your project. Any change you make to your codebase needs to be committed via Git. You can see all the Git commit messages of an environment in the `Environment Activity` feed of the [management console](/administration/web/_index.md) for each project you create.
+* [Git](https://git-scm.com/downloads) is the open source version control system used to manage your project. Any change you make to your codebase needs to be committed via Git. You can see all the Git commit messages of an environment in the `Environment Activity` feed of the [Console](/administration/web/_index.md) for each project you create.
 * A Bash-like shell.
 
 On Windows, the best way to get Bash is through [Windows Subsystem for Linux](https://msdn.microsoft.com/en-gb/commandline/wsl/about).

--- a/docs/layouts/shortcodes/guides/signup.md
+++ b/docs/layouts/shortcodes/guides/signup.md
@@ -106,7 +106,7 @@ platform integration:add --type=<service> ... --build-pull-requests=false
 
 You can then go through this guide and activate the environment when you're ready to deploy
 
-\* You can purchase additional development environments at any time in the management console.
+\* You can purchase additional development environments at any time in the Console.
 Open your {{ .Get "name" }} project and select **Edit plan**.
 Add additional **Environments**, view a cost estimate, and confirm your changes.
 

--- a/docs/layouts/shortcodes/guides/tools.md
+++ b/docs/layouts/shortcodes/guides/tools.md
@@ -5,6 +5,6 @@ Next, you need a couple tools to interact with your project, one of which you li
   Every commit pushed results in a new deployment, and all of your configuration is driven almost entirely by a small number of YAML files in your Git repository (which we will get to in the steps below).
   Your infrastructure, described in these files, becomes part of your application itself - completely transparent and version-controlled.
 
-* The [Platform.sh CLI](/development/cli/_index.md).
+* The [Platform.sh CLI](/administration/cli/_index.md).
   This lets you interact with your project from the command line.
   You can also use your browser, but the CLI is the tool you use the most in this guide.

--- a/docs/src/administration/_index.md
+++ b/docs/src/administration/_index.md
@@ -2,5 +2,5 @@
 title: "Administration"
 weight: -60
 description: |
-  Administration tasks for your Platform.sh projects is accessible from within the management console, as well as through the CLI.
+  Administration tasks for your Platform.sh projects is accessible from within the Console and through the CLI.
 ---

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -2,7 +2,7 @@
 title: "Backup and restore"
 weight: 2
 description: |
-  Backups are triggered directly via the management console or via the CLI. The backup creates a complete snapshot of the environment's data. It includes all persistent data from all running services (MySQL, Solr,...) and any files stored on the mounted volumes. Please note that the snapshot is stored internally and cannot be downloaded.
+  Backups are triggered directly via the Console or via the CLI. The backup creates a complete snapshot of the environment's data. It includes all persistent data from all running services (MySQL, Solr,...) and any files stored on the mounted volumes. Please note that the snapshot is stored internally and cannot be downloaded.
 ---
 
 {{% description %}}
@@ -131,7 +131,7 @@ and you are unable to deploy new versions of the site until the backup creation 
 
 ## Restore
 
-You can see the backup in the activity feed of your environment in the Platform.sh management console.
+You can see the backup in the activity feed of your environment in the Platform.sh Console.
 You can trigger the restore by clicking on the `restore` link.
 You can also restore the backup to a different environment using the CLI.
 
@@ -183,5 +183,5 @@ The next redeploy of the environment uses the current commit from git.
 {{% legacy-regions featureIntro="Restoring backups to different environments" featureShort="to restore to different environments" %}}
 
 You can also open a support ticket to ask that a backup be restored to a different environment for you.
-Older regions may not appear in the management console in the same way that newer regions do.
+Older regions may not appear in the Console in the same way that newer regions do.
 You can check your project's region with the CLI command `platform project:info -p PROJECT_ID`.

--- a/docs/src/administration/backup-and-restore.md
+++ b/docs/src/administration/backup-and-restore.md
@@ -93,7 +93,7 @@ or by installing the CLI tool into your application container and triggering the
 
 {{< note >}}
 
-Automated backups using cron requires you to [get an API token and install the CLI in your application container](/development/cli/api-tokens.md).
+Automated backups using cron requires you to [get an API token and install the CLI in your application container](./cli/api-tokens.md).
 
 {{< /note >}}
 

--- a/docs/src/administration/cli/_index.md
+++ b/docs/src/administration/cli/_index.md
@@ -37,7 +37,7 @@ platform
 ```
 
 This process opens a browser tab for you to log in.
-It also creates certificates on your computer for [SSH](../ssh/_index.md).
+It also creates certificates on your computer for [SSH](../../development/ssh/_index.md).
 
 Once you are logged in, a list of your projects appears, along with some tips for getting started.
 If you experience authentication issues or want to force a login, run the command `platform login`.

--- a/docs/src/administration/cli/api-tokens.md
+++ b/docs/src/administration/cli/api-tokens.md
@@ -18,7 +18,7 @@ We also strongly recommend creating a unique machine user for each project to be
 
 Like human users, every machine user account needs its own unique email address.
 
-The machine user can be given a very restrictive set of [access permissions](/administration/users.md) limited to just its needed tasks.
+The machine user can be given a very restrictive set of [access permissions](../users.md) limited to just its needed tasks.
 For example, backups require `Admin` access but no SSH key,
 while checking out code from a CI server to run tests on it would require an SSH key but only `Viewer` access.
 
@@ -73,8 +73,8 @@ we urge you to use the `--no-wait` flag on any commands that may take more than 
 To allow the Platform.sh CLI to be run on an app container, such as via a cron hook, use the API token.
 The CLI is able to auto-detect the current project and environment.
 
-Set the token as the [top-level](../variables/_index.md#top-level-environment-variables) environment variable `env:PLATFORMSH_CLI_TOKEN`
-either [through the Console](/administration/web/configure-environment.html#variables) or via the CLI, like so:
+Set the token as the [top-level](../../development/variables/_index.md#top-level-environment-variables) environment variable `env:PLATFORMSH_CLI_TOKEN`
+either [through the Console](../web/configure-environment.md#variables) or via the CLI, like so:
 
 ```bash
 platform variable:create -e <BRANCH_NAME> --level environment --name env:PLATFORMSH_CLI_TOKEN --sensitive true --value '<YOUR_API_TOKEN>'

--- a/docs/src/administration/organizations.md
+++ b/docs/src/administration/organizations.md
@@ -136,7 +136,7 @@ which takes the form `https://console.platform.sh/<ORGANIZATION_NAME>`.
 They can only access projects they've been explicit invited to by a project admin.
 
 To see all the projects that you have access to,
-go to the [main console page](https://console.platform.sh) or click **All projects** within the console.
+go to the [main Console page](https://console.platform.sh) or click **All projects** within the Console.
 For more information on project access control, see [user administration](./users.md).
 
 ## Create a new organization

--- a/docs/src/administration/users.md
+++ b/docs/src/administration/users.md
@@ -20,7 +20,7 @@ These control who has access to projects.
 Users can still see projects that they can't access if they're a member of an organization.
 See more on access control for [organizations](./organizations.md).
 
-To see all projects you have a role in, from the main console page
+To see all projects you have a role in, from the main Console page
 click **All projects&nbsp;<span aria-label="and then">></span> All projects**.
 
 ## Environment types
@@ -62,7 +62,7 @@ To add a user to a project or an environment, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---
@@ -94,7 +94,7 @@ platform user:add user1@example.com -r admin
 
 The user has to create an account before they can contribute to the project.
 Once you add a user to a project, they receive an email with instructions.
-For SSH access changes to apply after you add a user to a project, you have to redeploy each environment by either clicking **Redeploy** in the console or running `platform redeploy`.
+For SSH access changes to apply after you add a user to a project, you have to redeploy each environment by either clicking **Redeploy** in the Console or running `platform redeploy`.
 
 ### Delete a user from a project
 
@@ -105,7 +105,7 @@ To delete a user from a project, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---
@@ -147,7 +147,7 @@ To change user permissions, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/administration/web/_index.md
+++ b/docs/src/administration/web/_index.md
@@ -10,7 +10,7 @@ description: |
 
 ![Overview of projects in the Console](/images/management-console/all-projects.png "0.5")
 
-This Console offers you ways to manage projects and environments other than the [command line interface (CLI))](../../development/cli/_index.md).
+This Console offers you ways to manage projects and environments other than the [command line interface (CLI))](../cli/_index.md).
 
 ## Project list
 

--- a/docs/src/administration/web/_index.md
+++ b/docs/src/administration/web/_index.md
@@ -1,20 +1,20 @@
 ---
-title: "Management console"
+title: "Console"
 weight: 4
 layout: single
 description: |
-  Platform.sh provides a web management console so you can interact with your projects and manage your environments.
+  Platform.sh provides a web console so you can interact with your projects and manage your environments.
 ---
 
 {{% description %}}
 
-![Overview of projects in the console](/images/management-console/all-projects.png "0.5")
+![Overview of projects in the Console](/images/management-console/all-projects.png "0.5")
 
-This console offers you ways to manage projects and environments other than the [command line interface (CLI))](../../development/cli/_index.md).
+This Console offers you ways to manage projects and environments other than the [command line interface (CLI))](../../development/cli/_index.md).
 
 ## Project list
 
-The [main console page](https://console.platform.sh) gives you an overview of all your projects.
+The [main Console page](https://console.platform.sh) gives you an overview of all your projects.
 You can narrow the list down by searching for specific projects or choosing a specific organization from the menu.
 
 Once you select a project, you can [configure the project settings](./configure-project.md).
@@ -24,7 +24,7 @@ You can also create a new project by clicking **+ Create project**.
 
 ## Display settings
 
-You can personalize the display settings for the management console.
+You can personalize the display settings for the Console.
 To do so:
 
 1. Open the user menu (your name or profile picture).
@@ -32,7 +32,7 @@ To do so:
 3. Choose the mode you want.
 4. Click **Save**.
 
-The console can be displayed in three ways:
+The Console can be displayed in three ways:
 
 * Light mode (default)
 * High contrast mode

--- a/docs/src/administration/web/configure-environment.md
+++ b/docs/src/administration/web/configure-environment.md
@@ -39,7 +39,7 @@ There are also additional options:
 * **URLs** to access the deployed environment from the web.
 * **SSH** to access your project using SSH.
 * **Code**
-  * **CLI** for the command to get your project set up locally with the [Platform.sh CLI](../../development/cli/_index.md).
+  * **CLI** for the command to get your project set up locally with the [Platform.sh CLI](../cli/_index.md).
   * **Git** for the command to clone the codebase via Git.
   
     If you're using Platform.sh as your primary remote repository, the command clones from the project.

--- a/docs/src/create-apps/app-reference.md
+++ b/docs/src/create-apps/app-reference.md
@@ -629,7 +629,7 @@ The following table shows the properties for each job:
 | Name               | Type      | Required | Description |
 | ------------------ | --------- | -------- | ----------- |
 | `start`            | `string`  | Yes      | The command that's run. It's run in [Dash](https://en.wikipedia.org/wiki/Almquist_shell). |
-| `stop`             | `string`  | No       | The command that's issued to give the cron command a chance to shutdown gracefully, such as to finish an active item in a list of tasks. Issued when a cron task is interrupted by a user through the CLI or management console. If not specified, a `SIGTERM` signal is sent to the process. |
+| `stop`             | `string`  | No       | The command that's issued to give the cron command a chance to shutdown gracefully, such as to finish an active item in a list of tasks. Issued when a cron task is interrupted by a user through the CLI or Console. If not specified, a `SIGTERM` signal is sent to the process. |
 
 ```yaml {location=".platform.app.yaml"}
 crons:
@@ -719,7 +719,7 @@ The following table shows how long without a deployment an environment goes befo
 Environments with deployments within the given time have crons with the status `running`.
 If there haven't been any deployments within the given time, the status is `paused`.
 
-You can see the status in the management console
+You can see the status in the Console
 or using the CLI by running `platform environment:info` and looking under `deployment_state`.
 
 #### Restarting paused crons
@@ -732,12 +732,12 @@ To restart crons without changing anything:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---
 
-1. In the console, navigate to your project.
+1. In the Console, navigate to your project.
 1. Open the environment where you'd like the crons to run.
 1. Click `Redeploy` next to the cron status of `Paused`.
 

--- a/docs/src/create-apps/source-operations.md
+++ b/docs/src/create-apps/source-operations.md
@@ -8,7 +8,7 @@ tier:
 A source operation is an operation defined in an application to apply and automate changes to its source code.
 
 To use source operations, first define them in your [app configuration](./_index.md).
-Then run them in the [Platform.sh CLI](../development/cli/_index.md) or [Console](https://console.platform.sh).
+Then run them in the [Platform.sh CLI](../administration/cli/_index.md) or [Console](https://console.platform.sh).
 
 ## 1. Define a source operation
 
@@ -167,8 +167,8 @@ You can use cron to automatically run your source operations.
 
 {{< note >}}
 
-To run automated source operations using cron, you need to use [an API token](../development/cli/api-tokens.md)
-with the [CLI installed](../development/cli/api-tokens.md#on-a-platformsh-environment) in your app container.
+To run automated source operations using cron, you need to use [an API token](../administration/cli/api-tokens.md)
+with the [CLI installed](../administration/cli/api-tokens.md#on-a-platformsh-environment) in your app container.
 
 {{< /note >}}
 

--- a/docs/src/create-apps/source-operations.md
+++ b/docs/src/create-apps/source-operations.md
@@ -8,7 +8,7 @@ tier:
 A source operation is an operation defined in an application to apply and automate changes to its source code.
 
 To use source operations, first define them in your [app configuration](./_index.md).
-Then run them in the [Platform.sh CLI](../development/cli/_index.md) or [console](https://console.platform.sh).
+Then run them in the [Platform.sh CLI](../development/cli/_index.md) or [Console](https://console.platform.sh).
 
 ## 1. Define a source operation
 
@@ -46,11 +46,11 @@ For more possibilities, see other [operation examples](#source-operation-example
 
 ## 2. Run a source operation
 
-To run a source operation, you can use the CLI or console.
+To run a source operation, you can use the CLI or Console.
 
 {{< codetabs >}}
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---
@@ -117,7 +117,7 @@ Run the operation with the variable:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/dedicated/overview/grid.md
+++ b/docs/src/dedicated/overview/grid.md
@@ -16,7 +16,7 @@ These differences should be gone with [Dedicated Gen 3](../../dedicated-gen-3/ov
 Because of the differences between Dedicated and Grid environments,
 basic [syncs](../../other/glossary.md#sync) and [merges](../../other/glossary.md#merge)
 aren't available between Development environments and Production/Staging environments.
-So you don't see working buttons with those options in the management console.
+So you don't see working buttons with those options in the Console.
 
 To transfer data between environments, backup your Production/Staging data and then synchronize Development data.
 See how to [back up and transfer data](../../development/transfer-dedicated.md#synchronize-files-from-development-to-stagingproduction).

--- a/docs/src/define-routes/_index.md
+++ b/docs/src/define-routes/_index.md
@@ -419,7 +419,7 @@ You can configure each route separately with the following properties:
 
 ## CLI access
 
-The [Platform.sh CLI](../development/cli/_index.md) can show you the routes you have configured for an environment.
+The [Platform.sh CLI](../administration/cli/_index.md) can show you the routes you have configured for an environment.
 These are the routes as defined in the `.platform/routes.yaml` file with the [placeholders](#route-placeholders)
 plus the default redirect from HTTP to HTTPS.
 They aren't the final generated routes.

--- a/docs/src/development/access-site.md
+++ b/docs/src/development/access-site.md
@@ -2,7 +2,7 @@
 title: "Accessing your site"
 weight: 6
 description: |
-  Once you have an environment running, there are many ways to access it to perform needed tasks. The most straightforward way is to view it in a web browser; the available URLs are shown in the Platform.sh management console and on the command line after every Git push.
+  Once you have an environment running, there are many ways to access it to perform needed tasks. The most straightforward way is to view it in a web browser; the available URLs are shown in the Platform.sh Console and on the command line after every Git push.
 ---
 
 {{% description %}}
@@ -17,7 +17,7 @@ To find the URLs to access your site, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/development/cli/_index.md
+++ b/docs/src/development/cli/_index.md
@@ -2,7 +2,7 @@
 title: "Use the command line interface (CLI)"
 weight: 3
 description: |
-  See how to use and manage your Platform.sh projects directly from your terminal. Anything you can do within the management console can be done with the CLI.
+  See how to use and manage your Platform.sh projects directly from your terminal. Anything you can do within the Console can be done with the CLI.
 sidebarTitle: "Use the CLI"
 layout: single
 keywords:
@@ -142,7 +142,7 @@ platform project:set-remote <PROJECT_ID>
 ```
 
 Replace `<PROJECT_ID>` with the ID of your project.
-You can find that in the management console or by running `platform projects` to list all accessible projects.
+You can find that in the Console or by running `platform projects` to list all accessible projects.
 
 ### Choose between the CLI and Git commands
 

--- a/docs/src/development/cli/api-tokens.md
+++ b/docs/src/development/cli/api-tokens.md
@@ -40,12 +40,12 @@ Once you have a machine user in place, you want to assign an API token to it.
 
 To get an API token:
 
-1. As the machine user, open the management console.
+1. As the machine user, open the Console.
 2. Open the user menu (your name or profile picture).
 3. Click **My profile**.
 4. Go to the **API Tokens** tab.
 5. Click **Create API Token**.
-   ![The Create API Token button in the console](/images/management-console/api-tokens-new.png "0.6")
+   ![The Create API Token button in the Console](/images/management-console/api-tokens-new.png "0.6")
 6. Enter a name to identify your token in the future if you have multiple tokens.
    ![Creating an API token with the name 'CI tests'](/images/management-console/api-tokens-name.png "0.6")
 7. Click **Copy** to copy the token to your clipboard.
@@ -74,7 +74,7 @@ To allow the Platform.sh CLI to be run on an app container, such as via a cron h
 The CLI is able to auto-detect the current project and environment.
 
 Set the token as the [top-level](../variables/_index.md#top-level-environment-variables) environment variable `env:PLATFORMSH_CLI_TOKEN`
-either [through the management console](/administration/web/configure-environment.html#variables) or via the CLI, like so:
+either [through the Console](/administration/web/configure-environment.html#variables) or via the CLI, like so:
 
 ```bash
 platform variable:create -e <BRANCH_NAME> --level environment --name env:PLATFORMSH_CLI_TOKEN --sensitive true --value '<YOUR_API_TOKEN>'

--- a/docs/src/development/email.md
+++ b/docs/src/development/email.md
@@ -20,7 +20,7 @@ To turn it on for a specific environment, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/development/email.md
+++ b/docs/src/development/email.md
@@ -90,7 +90,7 @@ The `TXT` record looks similar to the following:
 
 ## 4. Test the email service
 
-To test the email service, use the [CLI](./cli/_index.md) to connect to your app by running `platform ssh`.
+To test the email service, use the [CLI](../administration/cli/_index.md) to connect to your app by running `platform ssh`.
 Run the following command:
 
 ```bash

--- a/docs/src/development/faq.md
+++ b/docs/src/development/faq.md
@@ -29,7 +29,7 @@ If you have multiple projects, your subscription continues until you don't have 
 ## How do I delete my Platform.sh account?
 
 If you would like to delete your Platform.sh account,
-log in and select **Support** from the dropdown options when you click your name in the management console.
+log in and select **Support** from the dropdown options when you click your name in the Console.
 Create a new ticket, and request for your account to be deleted in the form provided there.
 A support agent receives your request and deletes your account shortly thereafter. 
 
@@ -101,7 +101,7 @@ It ends with a description of what was just deployed and the URLs that are now a
 
 To suppress the output, run `platform push -W`.
 The `-W` means `--no-wait` and disconnects the connection once the commits are pushed so that you can continue to use your local terminal.
-The exact same output is also available in the Web Management Console.
+The exact same output is also available in the Console.
 
 ## What Linux distribution is Platform.sh using?
 
@@ -173,5 +173,5 @@ you need to point the document root to the symlink again so that it refreshes th
 ## Do you support MFA/2FA/TFA authentication?
 
 Yes. We support multi-factor authentication (MFA) and encourage its use.
-To use it, in the management console, go to **My profile** under your name.
+To use it, in the Console, go to **My profile** under your name.
 Then click **Security**, where you can set up an **MFA Application**.

--- a/docs/src/development/local/_index.md
+++ b/docs/src/development/local/_index.md
@@ -9,7 +9,7 @@ layout: single
 
 {{% description %}}
 
-You need to have both [Git](/development/tools.md#git) and the [Platform.sh CLI](/development/cli/_index.md) installed before continuing.
+You need to have both [Git](/development/tools.md#git) and the [Platform.sh CLI](/administration/cli/_index.md) installed before continuing.
 
 ## Download the code
 

--- a/docs/src/development/local/ddev.md
+++ b/docs/src/development/local/ddev.md
@@ -48,7 +48,7 @@ Your project should start running, though without any of the data from your Plat
 
 To connect DDEV with your Platform.sh account, use a Platform.sh API token.
 
-1. [Create an API token](./../cli/api-tokens.md#get-a-token) in the Console.
+1. [Create an API token](../../administration/cli/api-tokens.md#get-a-token) in the Console.
 2. Add the token to your global DDEV configuration:
 
    ```yaml {location="~/.ddev/global_config.yaml"}

--- a/docs/src/development/local/ddev.md
+++ b/docs/src/development/local/ddev.md
@@ -48,7 +48,7 @@ Your project should start running, though without any of the data from your Plat
 
 To connect DDEV with your Platform.sh account, use a Platform.sh API token.
 
-1. [Create an API token](./../cli/api-tokens.md#get-a-token) in the console.
+1. [Create an API token](./../cli/api-tokens.md#get-a-token) in the Console.
 2. Add the token to your global DDEV configuration:
 
    ```yaml {location="~/.ddev/global_config.yaml"}

--- a/docs/src/development/local/docksal.md
+++ b/docs/src/development/local/docksal.md
@@ -33,7 +33,7 @@ See all [restrictions on the projects directory](https://docs.docksal.io/getting
 
 To connect Docksal with your Platform.sh account, use a Platform.sh API token.
 
-1. [Create an API token](./../cli/api-tokens.md#get-a-token) in the console.
+1. [Create an API token](./../cli/api-tokens.md#get-a-token) in the Console.
 2. Add the token to your Docksal configuration by running this command:
 
    ```bash

--- a/docs/src/development/local/docksal.md
+++ b/docs/src/development/local/docksal.md
@@ -33,7 +33,7 @@ See all [restrictions on the projects directory](https://docs.docksal.io/getting
 
 To connect Docksal with your Platform.sh account, use a Platform.sh API token.
 
-1. [Create an API token](./../cli/api-tokens.md#get-a-token) in the Console.
+1. [Create an API token](../../administration/cli/api-tokens.md#get-a-token) in the Console.
 2. Add the token to your Docksal configuration by running this command:
 
    ```bash

--- a/docs/src/development/private-repository.md
+++ b/docs/src/development/private-repository.md
@@ -15,7 +15,7 @@ you need to add the project's public SSH key to the deploy keys of your Git repo
 
 To get your project's public key:
 
-1. In the console, open the project you want.
+1. In the Console, open the project you want.
 2. Click **{{< icon settings >}} Settings**.
 3. Click **Deploy Key**.
 4. Click **{{< icon copy >}} Copy**.

--- a/docs/src/development/sanitize-db.md
+++ b/docs/src/development/sanitize-db.md
@@ -21,7 +21,7 @@ You need:
 - A project with a [MySQL database](../add-services/mysql/_index.md).
 - A command interface installed:
   - With Drupal: [Drush](https://www.drush.org/latest/install/)
-  - Without Drupal: the [Platform CLI](../development/cli/_index.md)
+  - Without Drupal: the [Platform CLI](../administration/cli/_index.md)
 
 This guide is about sanitizing MySQL databases.
 

--- a/docs/src/development/ssh/_index.md
+++ b/docs/src/development/ssh/_index.md
@@ -22,7 +22,7 @@ To connect to an app securely with SSH, follow two steps.
 
 To authenticate with the CLI:
 
-1. Install the [Platform.sh CLI](/development/cli/_index.md).
+1. Install the [Platform.sh CLI](/administration/cli/_index.md).
 1. Run `platform login`.
 1. In the open browser window, log in with your Platform.sh account credentials.
    (This webpage is encrypted with HTTPS [HTTP over TLS], making it secure.)
@@ -131,7 +131,7 @@ There are three basic ways to authenticate with Platform.sh:
   * Represents only a single authentication method.
   * Requires you to regularly change the keys to maintain security.
   * Useful for checking out code as part of an automated process.
-* [Using API tokens](../cli/api-tokens.md)
+* [Using API tokens](../../administration/cli/api-tokens.md)
   * Good for letting automation tools use the CLI.
   * Requires you to regularly change the tokens to maintain security.
 

--- a/docs/src/development/ssh/ssh-keys.md
+++ b/docs/src/development/ssh/ssh-keys.md
@@ -89,16 +89,16 @@ in a terminal run the following command (replacing `<PATH_TO_YOUR_KEY>` with the
 platform ssh-key:add '<PATH_TO_YOUR_KEY>'
 ```
 
-You can also add it in the management console,
+You can also add it in the Console,
 similar to this [video](https://docs.platform.sh/videos/management-console/add-ssh-mc.mp4).
 
 Now you are ready to use the key to [connect to an environment](./_index.md#2-connect-to-an-app-with-ssh).
 
 ### 3. Connect to your server with SSH keys
 
-To connect to a server using SSH keys, find the details in the management console:
+To connect to a server using SSH keys, find the details in the Console:
 
-1. Open the [Platform.sh console](https://console.platform.sh/).
+1. Open the [Platform.sh Console](https://console.platform.sh/).
 1. Select a project.
 1. In the **Environment** dropdown, select the environment you want to access.
 1. Click the **SSH** dropdown.

--- a/docs/src/development/ssh/troubleshoot-ssh.md
+++ b/docs/src/development/ssh/troubleshoot-ssh.md
@@ -15,11 +15,11 @@ There are several places to check to try to solve such issues.
 If your environment is [inactive](../../other/glossary.md#inactive-environment) or the deployment has failed,
 you can't log in to it.
 To make sure the environment is active and the deployment has succeeded,
-check it using `platform environment:list` or in the [management console](https://console.platform.sh/) .
+check it using `platform environment:list` or in the [Console](https://console.platform.sh/) .
 
 ## Redeploy your environment
 
-If you have just added your SSH key or made changes to [access rules](/administration/users.md), you need to redeploy your environment before you can access it using SSH keys. You can do this in the [management console](https://console.platform.sh/), by running `platform redeploy`, or by pushing an empty git commit:
+If you have just added your SSH key or made changes to [access rules](/administration/users.md), you need to redeploy your environment before you can access it using SSH keys. You can do this in the [Console](https://console.platform.sh/), by running `platform redeploy`, or by pushing an empty git commit:
 
 ```bash
 git commit --allow-empty -m 'chore: force redeploy'
@@ -28,7 +28,7 @@ git push origin main
 
 ## Check your public key
 
-Make sure your public key has been uploaded to your user account. Check it in the [Platform.sh console](https://console.platform.sh/).
+Make sure your public key has been uploaded to your user account. Check it in the [Platform.sh Console](https://console.platform.sh/).
 
 ## SSH key can not be duplicated
 
@@ -104,7 +104,7 @@ Log in using the browser by running `platform login`.
 <--->
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/development/templates.md
+++ b/docs/src/development/templates.md
@@ -9,7 +9,7 @@ description: |
 
 {{% template-intro %}}
 
-You can click the **Deploy on Platform.sh** button to launch a new project using a template, or you can visit and clone the repository and push to an empty project you have created using the CLI or in the management console.
+You can click the **Deploy on Platform.sh** button to launch a new project using a template, or you can visit and clone the repository and push to an empty project you have created using the CLI or in the Console.
 
 ## C#/.NET Core
 

--- a/docs/src/development/tools.md
+++ b/docs/src/development/tools.md
@@ -8,7 +8,7 @@ sidebarTitle: "Tools"
 
 Git is the open source version control system that is utilized by Platform.sh.
 
-Any change you make to your Platform.sh project will need to be committed via Git. You can see all the Git commit messages of an environment in the activity feed of the management console.
+Any change you make to your Platform.sh project will need to be committed via Git. You can see all the Git commit messages of an environment in the activity feed of the Console.
 
 Before getting started, make sure you have it installed on your computer to be able to interact with Platform.sh.
 

--- a/docs/src/development/tools.md
+++ b/docs/src/development/tools.md
@@ -21,6 +21,6 @@ Before getting started, make sure you have it installed on your computer to be a
 
 Secure Shell (SSH) is a secure, encrypted connection between your computer and the Platform.sh environment.  That includes connecting to your Git repository.  SSH offers two secure types of authentication, based on keys or certificates.  We support both.
 
-Certificates are used automatically when you use the [Platform.sh CLI](./cli/_index.md) and run almost any command.  You may force a login using `platform login -f` on the command line, provided you have a web browser available.
+Certificates are used automatically when you use the [Platform.sh CLI](../administration/cli/_index.md) and run almost any command.  You may force a login using `platform login -f` on the command line, provided you have a web browser available.
 
 To use key pairs, see the [SSH keys](./ssh/ssh-keys.md).

--- a/docs/src/development/troubleshoot.md
+++ b/docs/src/development/troubleshoot.md
@@ -106,7 +106,7 @@ The next build for each environment is likely to take longer as the cache rebuil
 In most cases, issues accessing a project are caused by missing permissions for a given user.
 For more information see how to [manage user permissions](../administration/users.md).
 
-If you are using the CLI, make sure that [you are authenticated](../development/cli/_index.md#2-authenticate).
+If you are using the CLI, make sure that [you are authenticated](../administration/cli/_index.md#2-authenticate).
 
 If you are using SSH, see how to [troubleshoot SSH access](../development/ssh/troubleshoot-ssh.md).
 

--- a/docs/src/development/troubleshoot.md
+++ b/docs/src/development/troubleshoot.md
@@ -18,7 +18,7 @@ To trigger a redeploy, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/development/variables/_index.md
+++ b/docs/src/development/variables/_index.md
@@ -126,12 +126,12 @@ While in the `feature-x` environment, it looks like this:
 ```
 
 To get a visual overview of which variables are overridden in an environment,
-navigate in the management console to that environment's variables settings.
+navigate in the Console to that environment's variables settings.
 This example shows how it looks within the `feature-x` environment:
 
 <!-- vale Vale.Spelling = NO -->
 <!-- spelling turned off because of the "api_key" -->
-![The console showing the variables split into environment and project ones, with the environment variables `api_key` and `system_version` labeled as overridden and `debug_mode` as inherited the project variable `system_version` labeled as inactive.](/images/management-console/variables-overridden.png "0.5")
+![The Console showing the variables split into environment and project ones, with the environment variables `api_key` and `system_version` labeled as overridden and `debug_mode` as inherited the project variable `system_version` labeled as inactive.](/images/management-console/variables-overridden.png "0.5")
 <!-- vale Vale.Spelling = YES -->
 
 Project variables that conflict with environment variables are labeled as **Inactive**.

--- a/docs/src/development/variables/set-variables.md
+++ b/docs/src/development/variables/set-variables.md
@@ -21,7 +21,7 @@ Application variables are available at both build time and runtime.
 ## Create project variables
 
 Add secrets for all environments in project variables
-using [the management console](../../administration/web/configure-project.md#variables) or the CLI.
+using [the Console](../../administration/web/configure-project.md#variables) or the CLI.
 
 For example, to create the project variable `foo` with the value `bar`, run:
 
@@ -37,12 +37,12 @@ When naming variables, be sure to take [variable prefixes](./_index.md#variable-
 
 ### Variable options
 
-Variables have several Boolean options you can set in the console or the CLI:
+Variables have several Boolean options you can set in the Console or the CLI:
 
 | Option    | CLI flag            | Default | Description |
 | --------- | ------------------- | ------- | ----------- |
 | JSON      | `--json`            | `false` | Whether the variable is a JSON-serialized value (`true`) or a string (`false`). |
-| Sensitive | `--sensitive`       | `false` | If set to `true`, the variable's value is hidden in the console and in CLI responses for added security. It's still readable within the app container. |
+| Sensitive | `--sensitive`       | `false` | If set to `true`, the variable's value is hidden in the Console and in CLI responses for added security. It's still readable within the app container. |
 | Runtime   | `--visible-runtime` | `true`  | Whether the variable is available at runtime. |
 | Build     | `--visible-build`   | `true`  | Whether the variable is available at build time. |
 
@@ -63,7 +63,7 @@ you need to [redeploy](../troubleshoot.md#force-a-redeploy) your environments.
 
 ## Create environment-specific variables
 
-Set variables for specific environments using [the management console](../../administration/web/configure-environment.md#variables) or the CLI.
+Set variables for specific environments using [the Console](../../administration/web/configure-environment.md#variables) or the CLI.
 Variables can be inherited or overridden from parent environments and project variables.
 See [more on overriding values](./_index.md#overrides)
 
@@ -80,7 +80,7 @@ When naming variables, be sure to take [variable prefixes](./_index.md#variable-
 ### Environment variable options
 
 Environment variables share all of the [options available for project variables](#variable-options),
-with the exception that visibility in the build and runtime can be set only with the CLI (not in the console).
+with the exception that visibility in the build and runtime can be set only with the CLI (not in the Console).
 Environment variables have one additional option:
 
 | Option      | CLI flag        | Default | Description |

--- a/docs/src/development/variables/use-variables.md
+++ b/docs/src/development/variables/use-variables.md
@@ -3,7 +3,7 @@ title: Use variables
 description: See how to use variables that have already been set so you can take control over your app's environment.
 ---
 
-Get a list of all variables defined on a given environment in [the management console](../../administration/web/configure-environment.md#variables)
+Get a list of all variables defined on a given environment in [the Console](../../administration/web/configure-environment.md#variables)
 or use the CLI:
 
 ```bash
@@ -392,7 +392,7 @@ If your application depends on whether it's running on a Dedicated Generation 3 
 
 While both production and staging Dedicated environments have `enterprise` for the `PLATFORM_MODE` variable,
 you can distinguish them by environment type.
-Make sure that the environment type is set correctly via the CLI or management console.
+Make sure that the environment type is set correctly via the CLI or Console.
 Then run different code based on the type:
 
 ```bash

--- a/docs/src/domains/cdn/cloudflare.md
+++ b/docs/src/domains/cdn/cloudflare.md
@@ -65,7 +65,7 @@ Let's Encrypt expects the `.well-known` endpoint on all domains added.
 You have 2 options:
 
 * Remove all domains pointing to Cloudflare from your Platform.sh project
-* Follow these steps in your Cloudflare console:
+* Follow these steps in your Cloudflare Console:
 
   1. On the SSL page, turn off **Always Use HTTPS**.
   2. Create a page rule for `/.well-known/acme-challenge/` with SSL set to **off**.

--- a/docs/src/domains/quick-start.md
+++ b/docs/src/domains/quick-start.md
@@ -38,7 +38,7 @@ Now, add a single domain to your Platform.sh project for `mysite.com`:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/domains/steps/_index.md
+++ b/docs/src/domains/steps/_index.md
@@ -3,7 +3,7 @@ title: "Custom Domains - Step by step guide"
 weight: 2
 sidebarTitle: "Step by step guide"
 description: |
-  Configuring custom domains on Platform.sh is a simple two or three step process. You can either use the Platform.sh management console or the CLI to configure your project for production. Once you are familiar with it the whole process usually takes a couple of minutes.
+  Configuring custom domains on Platform.sh is a simple two or three step process. You can either use the Platform.sh Console or the CLI to configure your project for production. Once you are familiar with it the whole process usually takes a couple of minutes.
 layout: single
 ---
 
@@ -25,7 +25,7 @@ However, the domain used for non-production environments will always be generate
 even if your project is on a Production plan.
 {{< /note >}}
 
-In the [console](https://console.platform.sh), click the **More** button for your project and select **Edit plan**.
+In the [Console](https://console.platform.sh), click the **More** button for your project and select **Edit plan**.
 
 ![Edit Plan](/images/management-console/edit-plan.png "0.3")
 
@@ -82,7 +82,7 @@ The CDN should already have been configured in advance to point to Platform.sh a
 
 This step will tell the Platform.sh edge layer where to route requests for your web site.
 You can do this through the CLI with `platform domain:add example.com`
-or [using the management console](/administration/web/configure-project.md#domains).
+or [using the Console](/administration/web/configure-project.md#domains).
 
 You can add multiple domains to point to your project.
 Each domain can have its own custom SSL certificate, or use the default one provided.

--- a/docs/src/domains/steps/_index.md
+++ b/docs/src/domains/steps/_index.md
@@ -130,5 +130,5 @@ Notifications can be sent via email, Slack, or PagerDuty.
 
 ### Configure automatic backups
 
-It's strongly recommended that you set up an [API token](/development/cli/api-tokens.md) and install the CLI
+It's strongly recommended that you set up an [API token](/administration/cli/api-tokens.md) and install the CLI
 to define [an automatic backup](/administration/backup-and-restore.md#automated-backups) cron task.

--- a/docs/src/domains/steps/tls.md
+++ b/docs/src/domains/steps/tls.md
@@ -28,13 +28,13 @@ openTLS rsa -in private.key -out private.rsa.key
 
 ### Add a custom certificate
 
-You can add a custom certificate in the [management console](/administration/web/_index.md)
+You can add a custom certificate in the [Console](/administration/web/_index.md)
 or using the [command line interface](../../development/cli/_index.md).
 
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/domains/steps/tls.md
+++ b/docs/src/domains/steps/tls.md
@@ -29,7 +29,7 @@ openTLS rsa -in private.key -out private.rsa.key
 ### Add a custom certificate
 
 You can add a custom certificate in the [Console](/administration/web/_index.md)
-or using the [command line interface](../../development/cli/_index.md).
+or using the [command line interface](../../administration/cli/_index.md).
 
 {{< codetabs >}}
 

--- a/docs/src/environments/_index.md
+++ b/docs/src/environments/_index.md
@@ -20,7 +20,7 @@ If you have a live site, you have at least a production environment.
 You may also have additional environments for development, testing, staging, review, and so on.
 
 New environments can be created by branching existing environments using the [command line interface (CLI)](/development/cli/_index.md),
-or in the [web console](../administration/web/_index.md).
+or in the [Console](../administration/web/_index.md).
 Each created environment is an exact replica of its parent environment.
 This means new environments have all of the data and services from the parent
 (like databases, network storage, queues, routing).
@@ -150,7 +150,7 @@ Your environments can have one of two statuses:
 
 You can see an environment's status in multiple ways:
 
-* [In the console](../administration/web/configure-environment.md):
+* [In the Console](../administration/web/configure-environment.md):
   * Inactive environments are lighter in the environment list and don't appear in the environment selector.
   * Open an environment to see its status in the information panel.
 * Using the CLI:

--- a/docs/src/environments/_index.md
+++ b/docs/src/environments/_index.md
@@ -19,7 +19,7 @@ often divided into [environment types](../administration/users.md#environment-ty
 If you have a live site, you have at least a production environment.
 You may also have additional environments for development, testing, staging, review, and so on.
 
-New environments can be created by branching existing environments using the [command line interface (CLI)](/development/cli/_index.md),
+New environments can be created by branching existing environments using the [command line interface (CLI)](/administration/cli/_index.md),
 or in the [Console](../administration/web/_index.md).
 Each created environment is an exact replica of its parent environment.
 This means new environments have all of the data and services from the parent

--- a/docs/src/environments/change-parent.md
+++ b/docs/src/environments/change-parent.md
@@ -16,7 +16,7 @@ To change the environment's parent, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/environments/deactivate-environment.md
+++ b/docs/src/environments/deactivate-environment.md
@@ -9,7 +9,7 @@ To deactivate an environment, you need to be an admin for the project or the giv
 {{< note >}}
 
 Your default environment is protected.
-It can't be deactivated through the management console or the CLI.
+It can't be deactivated through the Console or the CLI.
 To change which environment is the default, see how to [rename the default branch](./default-environment.md).
 
 {{< /note >}}
@@ -29,7 +29,7 @@ To deactivate an environment, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---
@@ -78,7 +78,7 @@ To reactivate an inactive environment, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/environments/default-environment.md
+++ b/docs/src/environments/default-environment.md
@@ -9,7 +9,7 @@ aliases:
 You can set the name of your default/production branch when creating a project.
 To change it after project creation, follow the steps below.
 
-You can complete some of these steps through the management console,
+You can complete some of these steps through the Console,
 but since all can be completed with the CLI those commands alone are listed.
 Be sure to [install the CLI](../development/cli/_index.md) if you haven't already done so.
 It's assumed you are changing the default branch of your project on Platform.sh from `master` to `main`.
@@ -99,7 +99,7 @@ $ platform create --title='Main Project' --region=us-3.platform.sh --plan=develo
 This creates a new project with `master` as the default branch by default.
 Modify the flags to fit your use case, or skip them and the CLI will ask you to set them individually during creation.
 Copy the `Project ID` provided when the command completes, and substitute the value in the steps below.
-You can also visit the provided management console URL for the project (`https://console.platform.sh/<USER>/<PROJECT_ID>`)
+You can also visit the provided Console URL for the project (`https://console.platform.sh/<USER>/<PROJECT_ID>`)
 to verify the steps as you go along.
 
 The project you just created is empty, with no code initialized in its `master` environment.

--- a/docs/src/environments/default-environment.md
+++ b/docs/src/environments/default-environment.md
@@ -11,7 +11,7 @@ To change it after project creation, follow the steps below.
 
 You can complete some of these steps through the Console,
 but since all can be completed with the CLI those commands alone are listed.
-Be sure to [install the CLI](../development/cli/_index.md) if you haven't already done so.
+Be sure to [install the CLI](../administration/cli/_index.md) if you haven't already done so.
 It's assumed you are changing the default branch of your project on Platform.sh from `master` to `main`.
 If using another name for the default branch, update the commands accordingly.
 

--- a/docs/src/environments/http-access-control.md
+++ b/docs/src/environments/http-access-control.md
@@ -24,7 +24,7 @@ To add a username and password, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---
@@ -81,7 +81,7 @@ To control access based on IP address, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/environments/search-engine-visibility.md
+++ b/docs/src/environments/search-engine-visibility.md
@@ -16,7 +16,7 @@ To change the environment's visibility to search engines, follow these steps:
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/gettingstarted/introduction/own-code/create-project.md
+++ b/docs/src/gettingstarted/introduction/own-code/create-project.md
@@ -32,7 +32,7 @@ you can create a new project from the command line and connect it to your applic
 
       For now, press Enter to select the default number of environments.
 
-    * `Storage`: You can modify the amount of storage your application can use from the CLI and from the management console
+    * `Storage`: You can modify the amount of storage your application can use from the CLI and from the Console
       as well as upgrade that storage later once your project starts growing.
 
       For now, press Enter to select the default amount of storage.

--- a/docs/src/gettingstarted/introduction/own-code/next-steps.md
+++ b/docs/src/gettingstarted/introduction/own-code/next-steps.md
@@ -6,7 +6,7 @@ aliases:
   - "/gettingstarted/own-code/next-steps.html"
 ---
 
-In this guide you created a project using the [CLI](/development/cli/_index.md) and configured your project to run on Platform.sh using a few configuration files.
+In this guide you created a project using the [CLI](/administration/cli/_index.md) and configured your project to run on Platform.sh using a few configuration files.
 
 Don't stop now! There are far more features that make Platform.sh profoundly helpful to developers that you have left to explore.
 

--- a/docs/src/gettingstarted/introduction/own-code/project-configuration.md
+++ b/docs/src/gettingstarted/introduction/own-code/project-configuration.md
@@ -55,9 +55,9 @@ In the previous step, you created a new project on Platform.sh using the CLI. No
     touch .platform/services.yaml
     ```
 
-3. **(Optional) Follow the Project Setup Wizard instructions in the management console**
+3. **(Optional) Follow the Project Setup Wizard instructions in the Console**
 
-    All of the steps in this guide are also available in the Project Setup Wizard in your management console. Once you have created your project, the Wizard will appear at the top of your project page with detailed steps to help you properly configure your applications on Platform.sh.
+    All of the steps in this guide are also available in the Project Setup Wizard in your Console. Once you have created your project, the Wizard will appear at the top of your project page with detailed steps to help you properly configure your applications on Platform.sh.
 
     ![Project Setup Wizard](/images/management-console/setup-wizard.png "0.5")
 

--- a/docs/src/gettingstarted/introduction/own-code/push-project.md
+++ b/docs/src/gettingstarted/introduction/own-code/push-project.md
@@ -33,7 +33,7 @@ With your configuration files complete, all that's left is to commit the changes
     This returns a list of your routes.
     Pick the primary route `0` and press Enter, which opens your application in a browser window.
 
-    Alternatively, you can also log back into the management console in your new project.
+    Alternatively, you can also log back into the Console in your new project.
     Select your production environment from the `Environments` list
     and click the link in the Overview.
 

--- a/docs/src/gettingstarted/introduction/template/check-status.md
+++ b/docs/src/gettingstarted/introduction/template/check-status.md
@@ -48,7 +48,7 @@ Once you have configured the template application in the previous step, Platform
 In these few steps you created a free trial account, configured a template application on a project,
 and deployed it using the Console entirely from your browser.
 
-Using the [Platform.sh CLI](/development/cli/_index.md), you get even more control over your project configurations,
+Using the [Platform.sh CLI](/administration/cli/_index.md), you get even more control over your project configurations,
 including the ability to migrate your own applications to Platform.sh.
 Move to the next step to install it.
 

--- a/docs/src/gettingstarted/introduction/template/check-status.md
+++ b/docs/src/gettingstarted/introduction/template/check-status.md
@@ -10,10 +10,10 @@ Once you have configured the template application in the previous step, Platform
 
 {{< video src="videos/management-console/check-status.mp4" >}}
 
-1. **Explore the management console**
+1. **Explore the Console**
 
-   When the build screen has cleared, Platform.sh returns you to the management console.
-   Since you now have a project on your account, a version of this page is what you see each time you visit the console.
+   When the build screen has cleared, Platform.sh returns you to the Console.
+   Since you now have a project on your account, a version of this page is what you see each time you visit the Console.
 
    You start on the main page for your new project, `My First Project`.
    From here, you can control the settings of this project and monitor its status.
@@ -46,7 +46,7 @@ Once you have configured the template application in the previous step, Platform
 
 
 In these few steps you created a free trial account, configured a template application on a project,
-and deployed it using the management console entirely from your browser.
+and deployed it using the Console entirely from your browser.
 
 Using the [Platform.sh CLI](/development/cli/_index.md), you get even more control over your project configurations,
 including the ability to migrate your own applications to Platform.sh.

--- a/docs/src/gettingstarted/introduction/template/cli-install.md
+++ b/docs/src/gettingstarted/introduction/template/cli-install.md
@@ -25,7 +25,7 @@ platform
 ```
 
 That's it!
-Now that you have the management console set up and the CLI installed on your computer,
+Now that you have the Console set up and the CLI installed on your computer,
 you're well on your way to exploring all of the ways that Platform.sh can improve your development workflow.
 
 {{< guide-buttons next="I've installed the CLI" >}}

--- a/docs/src/gettingstarted/introduction/template/cli-requirements.md
+++ b/docs/src/gettingstarted/introduction/template/cli-requirements.md
@@ -7,7 +7,7 @@ aliases:
   - "/gettingstarted/template/cli-requirements.html"
 ---
 
-With the [management console](/administration/web/_index.md), you can start new projects from templates just as you did in the previous steps, but deploying your own applications requires you to also use the [Platform.sh CLI](/development/cli/_index.md).
+With the [Console](/administration/web/_index.md), you can start new projects from templates just as you did in the previous steps, but deploying your own applications requires you to also use the [Platform.sh CLI](/development/cli/_index.md).
 
 {{% cli-installation-requirements %}}
 

--- a/docs/src/gettingstarted/introduction/template/cli-requirements.md
+++ b/docs/src/gettingstarted/introduction/template/cli-requirements.md
@@ -7,7 +7,7 @@ aliases:
   - "/gettingstarted/template/cli-requirements.html"
 ---
 
-With the [Console](/administration/web/_index.md), you can start new projects from templates just as you did in the previous steps, but deploying your own applications requires you to also use the [Platform.sh CLI](/development/cli/_index.md).
+With the [Console](/administration/web/_index.md), you can start new projects from templates just as you did in the previous steps, but deploying your own applications requires you to also use the [Platform.sh CLI](/administration/cli/_index.md).
 
 {{% cli-installation-requirements %}}
 

--- a/docs/src/gettingstarted/introduction/template/create-project.md
+++ b/docs/src/gettingstarted/introduction/template/create-project.md
@@ -6,7 +6,7 @@ aliases:
   - "/gettingstarted/template/create-project.html"
 ---
 
-In the previous step, you set up a free trial account with Platform.sh. Now you have access to the Platform.sh [management console](/administration/web/_index.md).
+In the previous step, you set up a free trial account with Platform.sh. Now you have access to the Platform.sh [Console](/administration/web/_index.md).
 
 From here you can create projects, adjust account settings, and a lot more that you will explore throughout these Getting Started guides.
 
@@ -38,7 +38,7 @@ Since you do not yet have any projects on Platform.sh, the first thing you will 
 
 4. **Plan & Pricing**
 
-  Under your free trial, your project will be created under a "Development" plan size. The management console will tell you how many users, development environments, and the price of that plan after your trial has completed. After you have read through the features, click `Continue`.
+  Under your free trial, your project will be created under a "Development" plan size. The Console will tell you how many users, development environments, and the price of that plan after your trial has completed. After you have read through the features, click `Continue`.
 
 With these few selections Platform.sh will create the project and build the template in less than two minutes.
 

--- a/docs/src/gettingstarted/introduction/template/next-steps.md
+++ b/docs/src/gettingstarted/introduction/template/next-steps.md
@@ -6,7 +6,7 @@ aliases:
   - "/gettingstarted/template/next-steps.html"
 ---
 
-In this guide you created a project using the [management console](/administration/web/_index.md) and installed the [Platform.sh CLI](/development/cli/_index.md). Now you can explore some of the next steps for working with Platform.sh.
+In this guide you created a project using the [Console](/administration/web/_index.md) and installed the [Platform.sh CLI](/development/cli/_index.md). Now you can explore some of the next steps for working with Platform.sh.
 
 ## Import your own code
 

--- a/docs/src/gettingstarted/introduction/template/next-steps.md
+++ b/docs/src/gettingstarted/introduction/template/next-steps.md
@@ -6,7 +6,7 @@ aliases:
   - "/gettingstarted/template/next-steps.html"
 ---
 
-In this guide you created a project using the [Console](/administration/web/_index.md) and installed the [Platform.sh CLI](/development/cli/_index.md). Now you can explore some of the next steps for working with Platform.sh.
+In this guide you created a project using the [Console](/administration/web/_index.md) and installed the [Platform.sh CLI](/administration/cli/_index.md). Now you can explore some of the next steps for working with Platform.sh.
 
 ## Import your own code
 

--- a/docs/src/gettingstarted/next-steps/going-live/set-domain.md
+++ b/docs/src/gettingstarted/next-steps/going-live/set-domain.md
@@ -6,9 +6,9 @@ aliases:
   - "/gettingstarted/going-live/set-domain.html"
 ---
 
-You will need to configure your registered domain on your Platform.sh project before going live, and you can do that either through the management console or by using the CLI.
+You will need to configure your registered domain on your Platform.sh project before going live, and you can do that either through the Console or by using the CLI.
 
-## Through the management console
+## Through the Console
 
 {{< video src="videos/management-console/set-domain-mc.mp4" >}}
 

--- a/docs/src/gettingstarted/next-steps/going-live/upgrade-plan.md
+++ b/docs/src/gettingstarted/next-steps/going-live/upgrade-plan.md
@@ -8,7 +8,7 @@ aliases:
 
 "Development" plan projects can't be assigned a domain name,
 so you can't go live until you upgrade to at least a Standard plan.
-This can be done using the management console.
+This can be done using the Console.
 
 {{< video src="videos/management-console/upgrade-plan.mp4" >}}
 

--- a/docs/src/guides/drupal9/faq.md
+++ b/docs/src/guides/drupal9/faq.md
@@ -15,7 +15,7 @@ drush -y config-import
 
 That will automatically run `update.php` and import configuration on every new deploy.
 
-The above configuration is included by default if you used our Drupal example repository or created a project through the management console.
+The above configuration is included by default if you used our Drupal example repository or created a project through the Console.
 
 ## I'm getting a PDO Exception 'MySQL server has gone away'
 

--- a/docs/src/guides/ibexa/deploy.md
+++ b/docs/src/guides/ibexa/deploy.md
@@ -141,7 +141,7 @@ The main ones are:
 * **Downstream database synchronization**: Getting it from the remote to the local.
 * **Downstream file storage synchronization**: Getting it from the remote to the local.
 
-To help you with that, Platform.sh provides a CLI that you can [install](../../development/cli/_index.md).
+To help you with that, Platform.sh provides a CLI that you can [install](../../administration/cli/_index.md).
 
 #### Database and storage synchronization
 

--- a/docs/src/increase-observability/integrate-observability/blackfire.md
+++ b/docs/src/increase-observability/integrate-observability/blackfire.md
@@ -87,7 +87,7 @@ Blackfire Monitoring is [enabled by default](https://blackfire.io/docs/monitorin
 
 To disable Blackfire Monitoring, create an [environment variable](../../development/variables/set-variables.md#create-environment-specific-variables).
 
-In the management console, view the environment where you would like to disable Blackfire Monitoring
+In the Console, view the environment where you would like to disable Blackfire Monitoring
 and add the variable `env:BLACKFIRE_APM_ENABLED` with the value `0`.
 Otherwise, you can use the CLI command `platform variable:create --level environment --prefix env: --name BLACKFIRE_APM_ENABLED --value 0`
 

--- a/docs/src/increase-observability/logs.md
+++ b/docs/src/increase-observability/logs.md
@@ -12,12 +12,12 @@ aliases:
 
 Changes to your environments, such as deployments, cron jobs, and code or variable updates,
 are each logged as activities.
-You can access the logs either in the console or using the CLI:
+You can access the logs either in the Console or using the CLI:
 
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 highlight=false
 file=none
 ---

--- a/docs/src/increase-observability/metrics/_index.md
+++ b/docs/src/increase-observability/metrics/_index.md
@@ -8,7 +8,7 @@ aliases:
 
 Platform.sh projects are accompanied by live infrastructure metrics that provide an overview of resource usage for environments.  
 
-Within the console, metrics can be found for an environment under **Metrics**.
+Within the Console, metrics can be found for an environment under **Metrics**.
 
 The information under **Metrics** shows usage metrics for:
 

--- a/docs/src/increase-observability/metrics/grid.md
+++ b/docs/src/increase-observability/metrics/grid.md
@@ -24,7 +24,7 @@ The graphs switch to an overview of the average resource utilization for the sel
 ## Start metrics collection
 
 To start collecting metrics on Grid environments, you need to redeploy the environment.
-If a redeploy is required for the specific environment, you see a note in the console:
+If a redeploy is required for the specific environment, you see a note in the Console:
 
 ![Screenshot showing the text "Your metrics are almost here" and a prompt to redeploy](/images/metrics/metrics-redeploy-prompt.png "0.3")
 

--- a/docs/src/integrations/activity/_index.md
+++ b/docs/src/integrations/activity/_index.md
@@ -15,7 +15,7 @@ Activity scripts are configured as integrations.
 That means they're at the *project level*, not at the level of an individual environment.
 While you can store the scripts in your Git repository for access, they have no effect there.
 
-To install a new activity script, use the [Platform.sh CLI](/development/cli/_index.md).
+To install a new activity script, use the [Platform.sh CLI](/administration/cli/_index.md).
 
 ```bash
 platform integration:add --type script --file ./my_script.js

--- a/docs/src/integrations/activity/discord.md
+++ b/docs/src/integrations/activity/discord.md
@@ -84,4 +84,4 @@ sendDiscordMessage(activity.text, activity.log);
 Common properties you may want to send to Discord (in the last line of the script) include:
 
 * `activity.text`: A brief, one-line statement of what happened.
-* `activity.log`: The complete build and deploy log output, as it would be seen in the Management Console log screen.
+* `activity.log`: The complete build and deploy log output, as it would be seen in the Console log screen.

--- a/docs/src/integrations/activity/reference.md
+++ b/docs/src/integrations/activity/reference.md
@@ -47,22 +47,22 @@ Its value is one of:
 * `environment.backup.delete`: A user deleted a [backup](/administration/backup-and-restore.md)
 ---
 * `environment.push`: A user has pushed code to a branch, either existing or new.
-* `environment.branch`: A new branch has been created via the management console.
+* `environment.branch`: A new branch has been created via the Console.
   (A branch created via a push will show up only as an `environment.push`.)
 * `environment.activate`: A branch has been "activated", and an environment created for it.
 * `environment.initialize`: The default branch of the project has just been initialized with its first commit.
 * `environment.deactivate`: A branch has been "deactivated". The code is still there, but the environment was destroyed.
 * `environment.synchronize`: An environment has had its data and/or code re-copied from its parent environment.
-* `environment.merge`: A branch was merged through the management console or Platform.sh API.
+* `environment.merge`: A branch was merged through the Console or Platform.sh API.
   A basic Git merge will not trigger this event.
 * `environment.redeploy`: An environment was redeployed.
 * `environment.delete`: A branch was deleted.
 ---
-* `environment.route.create`: A new route has been created through the management console.
+* `environment.route.create`: A new route has been created through the Console.
   This will not fire for route edits made to the `routes.yaml` file directly.
-* `environment.route.delete`: A route has been deleted through the management console.
+* `environment.route.delete`: A route has been deleted through the Console.
   This will not fire for route edits made to the `routes.yaml` file directly.
-* `environment.route.update`: A route has been modified through the management console.
+* `environment.route.update`: A route has been modified through the Console.
   This will not fire for route edits made to the `routes.yaml` file directly.
 ---
 * `environment.variable.create`: A new variable has been created.

--- a/docs/src/integrations/activity/slack.md
+++ b/docs/src/integrations/activity/slack.md
@@ -96,4 +96,4 @@ sendSlackMessage(activity.text, activity.log);
 Common properties you may want to send to Slack (in the last line of the script) include:
 
 * `activity.text`: A brief, one-line statement of what happened.
-* `activity.log`: The complete build and deploy log output, as it would be seen in the Management Console log screen.
+* `activity.log`: The complete build and deploy log output, as it would be seen in the Console log screen.

--- a/docs/src/integrations/notifications.md
+++ b/docs/src/integrations/notifications.md
@@ -33,7 +33,7 @@ Notifications are generated every 5 minutes, so there may be a brief delay betwe
 
 ## Configuring notifications
 
-Health notifications can be set up via the [Platform.sh CLI](/development/cli/_index.md), through a number of different channels.
+Health notifications can be set up via the [Platform.sh CLI](/administration/cli/_index.md), through a number of different channels.
 
 ### Email notifications
 

--- a/docs/src/integrations/source/bitbucket.md
+++ b/docs/src/integrations/source/bitbucket.md
@@ -8,7 +8,7 @@ description: |
 
 It's possible to integrate a Platform.sh project with either the freely available Bitbucket Cloud product
 or with the self-hosted [Bitbucket Server](https://confluence.atlassian.com/bitbucketserver/).
-In both cases, you need to [install the Platform.sh CLI](../../development/cli/_index.md),
+In both cases, you need to [install the Platform.sh CLI](../../administration/cli/_index.md),
 if you haven't already done so, to set up the integration.
 
 ## Bitbucket Cloud

--- a/docs/src/languages/php/composer-auth.md
+++ b/docs/src/languages/php/composer-auth.md
@@ -32,7 +32,7 @@ For this example, consider that there are several packages we want to install fr
 
 Set the Composer authentication by adding a project level variable called `env:COMPOSER_AUTH` as JSON and available only during build time.
 
-That can be done through the [management console](/administration/web/_index.md) or via the command line, like so:
+That can be done through the [Console](/administration/web/_index.md) or via the command line, like so:
 
 ```bash
 platform variable:create --level project --name env:COMPOSER_AUTH \

--- a/docs/src/overview/get-support.md
+++ b/docs/src/overview/get-support.md
@@ -15,7 +15,7 @@ the proper functioning of the Platform.sh infrastructure, application container 
 have found possible bugs; or have general questions,
 open a support ticket:
 
-1. [Open the Management Console](https://console.platform.sh/)
+1. [Open the Console](https://console.platform.sh/)
 2. Select **User menu** (your name) > **Support**.
 3. Click **+ New ticket**.
 4. Fill in the ticket fields and click **Submit**.

--- a/docs/src/projects/delete-project.md
+++ b/docs/src/projects/delete-project.md
@@ -12,7 +12,7 @@ To delete a Platform.sh project, including all data, code, and active environmen
 {{< codetabs >}}
 
 ---
-title=In the console
+title=In the Console
 file=none
 highlight=false
 ---

--- a/docs/src/security/encryption.md
+++ b/docs/src/security/encryption.md
@@ -4,7 +4,7 @@ title: Encryption
 
 ## Data in transit
 
-Data in transit between the World and Platform.sh is always encrypted as all of the sites and tools which Platform.sh supports and maintains require TLS or SSH to access. This includes the Platform.sh management console, Accounts site, git repositories, documentation, and help desk.
+Data in transit between the World and Platform.sh is always encrypted as all of the sites and tools which Platform.sh supports and maintains require TLS or SSH to access. This includes the Platform.sh Console, Accounts site, git repositories, documentation, and help desk.
 
 Data in transit between the world and customer applications is encrypted by default.  Only SSH and HTTPS connections are generally accepted, with HTTP requests redirected to HTTPS.  Users may opt-out of that redirect and accept HTTP requests via `routes.yaml` configuration, although that is not recommended.  By default HTTPS connections use an automatically generated Let's Encrypt certificate or users may provide their own TLS certificate.
 

--- a/docs/src/tutorials/exporting.md
+++ b/docs/src/tutorials/exporting.md
@@ -66,7 +66,7 @@ To download data from persistent services ([MySQL](../add-services/mysql/_index.
 
 If your project uses some environment variable (tokens, ...) it can be helpful to backup them if you didn't store them separately.
 
-As stated in the management console, several possibilities exist for the environment variables.
+As stated in the Console, several possibilities exist for the environment variables.
 
 * Variables beginning with `env:` will be exposed as Unix environment variables
 * Variables beginning with `php:` will be interpreted as `php.ini` directives.
@@ -74,7 +74,7 @@ As stated in the management console, several possibilities exist for the environ
 
 More details can be found [on the environment page](https://docs.platform.sh/administration/web/configure-environment.html#variables)
 
-You can access the content of the environment variable through the management console unless the `--sensitive true` flag was set.
+You can access the content of the environment variable through the Console unless the `--sensitive true` flag was set.
 
 In that case, you can run:
 `platform ssh -p <project id> -e <environment>`


### PR DESCRIPTION


<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The console was referred to in various ways. So it's probably best to standardize as a proper noun.

And also to think of it as a valid option on the same level as the CLI.

See also Context.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
- Standardized as Console.
- Moved CLI under administration.
