### PR TITLE
🐛 Fix location for PHP access log format settings

### DIFF
--- a/docs/src/increase-observability/logs.md
+++ b/docs/src/increase-observability/logs.md
@@ -124,14 +124,14 @@ The formatting of `php.access.log` is determined by the PHP settings.
 To determine the format, run the following:
 
 ```bash
-platform ssh cat -n /etc/php/<PHP_VERSION>-zts/fpm/pool.d/www.conf | grep "access.format"
+platform ssh cat -n /etc/php/<PHP_VERSION>-zts/fpm/php-fpm.conf | grep "access.format"
 ```
 
 You get a response such as the following:
 
 ```bash
-Connection to ssh.<REGION>.platform.sh closed.
-;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{milli}d %{kilo}M %C%%"
+Connection to ssh.eu.platform.sh closed.
+access.format = "%{%FT%TZ}t %m %s %{mili}d ms %{kilo}M kB %C%% %{REQUEST_URI}e"
 ```
 
 See what [each value in this string means](https://www.php.net/manual/en/install.fpm.configuration.php#access-format).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

We gave the wrong location of the access log format. See context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Fixed the location and response.