### PR TITLE
Minor text issue in NodeJS doc

### DIFF
--- a/docs/src/languages/nodejs/_index.md
+++ b/docs/src/languages/nodejs/_index.md
@@ -120,7 +120,7 @@ web:
 ## Dependencies
 
 By default, Platform.sh assumes you're using npm as a package manager.
-If you have a `package.json` file in your code, the default [build flavor is run](../../create-apps/app-reference.md#build):
+If you have a `package.json` file in your code, the default [build flavor is npm](../../create-apps/app-reference.md#build):
 
 ```bash
 npm prune --userconfig .npmrc && npm install --userconfig .npmrc

--- a/docs/src/languages/nodejs/_index.md
+++ b/docs/src/languages/nodejs/_index.md
@@ -120,7 +120,7 @@ web:
 ## Dependencies
 
 By default, Platform.sh assumes you're using npm as a package manager.
-If you have a `package.json` file in your code, the default [build flavor is npm](../../create-apps/app-reference.md#build):
+If your code has a `package.json`, the following command is run as part of the default [build flavor](../../create-apps/app-reference.md#build):
 
 ```bash
 npm prune --userconfig .npmrc && npm install --userconfig .npmrc


### PR DESCRIPTION
## Why
- `If you have a package.json file in your code, the default build flavor is run` sounds a little confusing
- Instead, the doc should say "the default build flavor is `npm`" instead of "the default build flavor is `run`" as it's much more aligned to the expected build behaviour 

## What's changed
- docs/src/languages/nodejs/_index.md
- Impacted URL - https://docs.platform.sh/languages/nodejs.html#dependencies