### PR TITLE
📝 Deprecate old Elixir versions

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -189,10 +189,11 @@
     "runtime": true,
     "type": "elixir",
     "versions": {
-      "deprecated": [],
-      "supported": [
+      "deprecated": [
         "1.9",
-        "1.10",
+        "1.10"
+      ],
+      "supported": [
         "1.11",
         "1.12",
         "1.13"


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Older versions aren't supported anymore. See Context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Moved 1.9 and 1.10 to `deprecated`.