### PR TITLE
Mark geoip as available for PHP 8.0 and 8.1

### DIFF
--- a/docs/src/languages/php/extensions.md
+++ b/docs/src/languages/php/extensions.md
@@ -58,7 +58,7 @@ and turn off those on by default with the `disabled_extensions` key.
 | `ftp`             |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
 | `gd`              | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
 | `gearman`         | Avail | Avail | Avail |       |       |       |       |       |       |       |
-| `geoip`           | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |       |       |
+| `geoip`           | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
 | `gettext`         |       |       |       | Def   | Def   | Def   | Def   | Def   | Def   | Def   |
 | `gmp`             | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail | Avail |
 | `http`            | Avail | Avail |       |       |       |       | Avail | Avail | Avail | Avail |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Geoip is available for PHP 8.x in our images, so we should update the docs to reflect it.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Mark the geoip plugins as available for PHP 8.x.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
