### PR TITLE
Update ibexa/fastly.md TRUSTED_PROXIES

### DIFF
--- a/docs/src/guides/ibexa/fastly.md
+++ b/docs/src/guides/ibexa/fastly.md
@@ -13,7 +13,7 @@ description: |
 In Ibexa DXP, Varnish is enabled by default when deploying on Platform.sh.
 In order to use Fastly, Varnish must be disabled:
 
- - Remove environment variable `SYMFONY_TRUSTED_PROXIES: "TRUST_REMOTE"` in [`.platform.app.yaml`](https://github.com/ezsystems/ezplatform/blob/master/.platform.app.yaml)
+ - Remove environment variable `TRUSTED_PROXIES: "REMOTE_ADDR"` in [`.platform.app.yaml`](https://github.com/ezsystems/ezplatform/blob/master/.platform.app.yaml)
  - Remove the Varnish service in [.platform/services.yaml](https://github.com/ezsystems/ezplatform/blob/master/.platform/services.yaml)
  - In [.platform/routes.yaml](https://github.com/ezsystems/ezplatform/blob/master/.platform/routes.yaml),
    change routes to use `app` instead of the `varnish` service you removed in previous step:


### PR DESCRIPTION
## Why

Ibexa Cloud configuration has chance circa Ibexa DXP 3.0 when upgrading to Symfony 5, still true with recent Ibexa DXP 4.2.

## What's changed

- [`SYMFONY_TRUSTED_PROXIES` as been renamed `TRUSTED_PROXIES`](https://github.com/ezsystems/ezplatform/commit/24274e0848feb7fe394ac4d9fb598e3a03adabc6#diff-ba5689cf015e5c8c54d2c5365e1d09d6e5a829628e12e3ec6134104d23c1e3fcR42)
- [`TRUST_REMOTE` as been replaced by `REMOTE_ADDR `](https://github.com/ezsystems/ezplatform/commit/345c00d3108cbe46fc3814b69985418aebd7f41f#diff-ba5689cf015e5c8c54d2c5365e1d09d6e5a829628e12e3ec6134104d23c1e3fcR47)
