### PR TITLE
Fix the typo in the shell example

### DIFF
--- a/docs/src/development/variables/use-variables.md
+++ b/docs/src/development/variables/use-variables.md
@@ -67,8 +67,8 @@ highlight=false
 ---
 
 ```bash
-export PROJECT_ID = "$PLATFORM_PROJECT"
-export VARIABLES = "$(echo "$PLATFORM_VARIABLES" | base64 --decode)"
+export PROJECT_ID="$PLATFORM_PROJECT"
+export VARIABLES="$(echo "$PLATFORM_VARIABLES" | base64 --decode)"
 ```
 
 <--->


### PR DESCRIPTION
When assigning variables, we can not have space(s) between the variable name, the equal sign and the value assigned to the variable.

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
