### PR TITLE
🐛 Fix info on PR workflow

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -22,4 +22,6 @@ jobs:
       # Create an environment and activate it
       - env:
           PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
-        run: platform environment:push -p 652soceglkw4u --activate --parent=main --target=pr-${{ github.event.number }} -y
+        run: |
+          platform project:set-remote 652soceglkw4u
+          platform environment:push --activate --parent=main --target=pr-${{ github.event.number }} -y

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -2,6 +2,7 @@ name: Get info on PR
 on:
   pull_request_target:
     branches: [main]
+    types: [labeled,opened,reopened,synchronize]
 
 env:
   PR_NUMBER: ${{ github.event.number }}
@@ -10,6 +11,13 @@ jobs:
   get_pr_info:
     runs-on: ubuntu-latest
     steps: 
+      - uses: actions/checkout@v3
+        # Run only for PRs from default repo and approved PRs from forks
+        if: ${{ github.event.pull_request.head.repo.id == 21975579 }} || contains(github.event.pull_request.labels.*.name, 'build-fork')
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set branch name
         id: branch_name
         run: |


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Git wasn't checked out on the workflow for security reasons (and it wasn't necessary for most steps). But it's needed for the step to get the differences in files.

Also, the CLI [complained] about the project not being set for a PR from a fork.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Check out Git for PRs from default repo and approved PRs

Added a step to building from forks to set the remote.