### PR TITLE
:memo: Added missing requirement for meilisearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ hugo serve
 In addition to the above requirements, search also requires:
 
 * [Poetry](https://python-poetry.org/docs/)
+* [jq](https://stedolan.github.io/jq/)
 * [MeiliSearch](https://www.meilisearch.com/) (see below for installation)
 
 If you would like to test the search server, follow these steps:


### PR DESCRIPTION
`jq` is used in the [`deploy.sh` script](https://github.com/platformsh/platformsh-docs/blob/main/docs/deploy.sh#L12).

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Additional requirement was missing
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added `jq` to the list of additional requirements.
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
