### PR TITLE
🐛 Don't wait for environment activation

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -30,5 +30,5 @@ jobs:
 
           # If the environment isn't active, activate it
           if [ $(platform api:curl /projects/652soceglkw4u/environments/pr-${{ github.event.number }} | jq -r .status) == "inactive" ]; then
-            platform environment:activate -y pr-${{ github.event.number }}
+            platform environment:activate --no-wait -y pr-${{ github.event.number }}
           fi

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - env:
           PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
-        run: platform environment:activate -p 652soceglkw4u -y ${{ github.event.pull_request.head.ref }}
+        run: platform environment:activate --no-wait -p 652soceglkw4u -y ${{ github.event.pull_request.head.ref }}
 
   deactivate_environment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The CLI was often timing out for environment activation.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Set the CLI not to wait for environment activation. We have a separate workflow that checks the result.
