### PR TITLE
Bump Redis and Relay versions

### DIFF
--- a/docs/src/languages/php/redis.md
+++ b/docs/src/languages/php/redis.md
@@ -29,8 +29,8 @@ Any tagged version of the library is acceptable:
 hooks:
     build: |
         set -e
-        # Install PhpRedis v5.1.1:
-        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-phpredis.sh | { bash /dev/fd/3 5.1.1 ; } 3<&0
+        # Install PhpRedis v5.3.7:
+        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-phpredis.sh | { bash /dev/fd/3 5.3.7 ; } 3<&0
 ```
 
 ## Install Relay
@@ -53,8 +53,8 @@ Any tagged version of the library is acceptable:
 hooks:
     build: |
         set -e
-        # Install Relay v0.4.3:
-        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 v0.4.3 ; } 3<&0
+        # Install Relay v0.4.6:
+        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install-relay.sh | { bash /dev/fd/3 v0.4.6 ; } 3<&0
 ```
 
 ## Change extension or version


### PR DESCRIPTION
- PhpRedis 5.1.1 is quite outdated (Nov 10, 2019).
- Relay had some performance and reliability improvements since 0.4.3

Related to https://github.com/platformsh/snippets/pull/8.