### PR TITLE
:memo: Rework Composer migration update

### DIFF
--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -158,7 +158,8 @@ To do so:
     }
     ```
 
-    After inspecting package metadata, Composer now installs the plugins whose `type` matches `wordpress-plugin` into `wordpress/wp-content/plugins/` instead of `vendor`, and the same goes for themes and must-use plugins. 
+   After inspecting package metadata, Composer now installs plugins with a `type` of `wordpress-plugin` into `wordpress/wp-content/plugins/` instead of `vendor`.
+   And similarly for themes and must-use plugins. 
 
 3. **Launch the installation of plugins and themes with Composer**
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -138,7 +138,9 @@ To do so:
 
 2. **(Optional) Configure theme and plugin destination**
 
-    By default, Composer places installed dependencies in a subdirectory called `vendor` in your repository. But you can configure a different destination for your themes and plugins. For instance, to install them into `wp-content`, add the following block to your `composer.json` file:
+   By default, Composer places installed dependencies in a `vendor` subdirectory.
+   You can configure a different destination for your themes and plugins.
+   For instance, to install them into `wp-content`, add the following configuration:
 
     ```json
     "extra": {

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -13,7 +13,9 @@ To update your WordPress site to use Composer, check that:
 
 - You already have a [vanilla version of WordPress installed locally](./_index.md).
 - Your WordPress core, themes, and plugins are committed to your WordPress repository or committed as submodules.
-- Your project has been set up for deployment on Platform.sh. If you do not have Platform.sh configuration files in your repository, make sure you [deploy WordPress without Composer](/guides/wordpress/vanilla/_index.md) before upgrading to a Composer-based site.
+- Your project has been set up for deployment on Platform.sh.
+  If you do not have Platform.sh configuration files in your repository,
+  make sure you [deploy WordPress without Composer](./_index.md) before upgrading to a Composer-based site.
 
 ## Install WordPress with Composer
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -1,5 +1,5 @@
 ---
-title: "How to upgrade your WordPress site to use Composer"
+title: "Upgrade your WordPress site to use Composer"
 sidebarTitle: Upgrade to use Composer
 weight: 2
 description: |
@@ -56,9 +56,9 @@ To install WordPress with Composer, complete the following steps:
 
 3. Clean up WordPress core.
 
-   If you've been managing managing WordPress and its dependencies as Git submodules, before switching to Composer [remove the submodules](../../../development/submodules.md#removing-submodules).
+   If you've been managing WordPress and its dependencies as Git submodules, [remove the submodules](../../../development/submodules.md#removing-submodules).
 
-   Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
+   Otherwise, your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
    For Composer to manage WordPress, remove this subdirectory: 
 
    ```bash

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -29,9 +29,9 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
     
    To safely make changes to your repository and Platform.sh environment, run the following command:
 
-    ```bash
-    $ git checkout -b composer
-    ```
+   ```bash
+   $ git checkout -b composer
+   ```
 3. **Turn your repository into a Composer repository**
 
    To use Composer, you need:

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -59,9 +59,9 @@ To do so:
 
    Unless you are managing WordPress core as a [submodule](../../../development/submodules.md#removing-submodules), you can now remove the `wordpress` subdirectory: 
 
-    ```bash
-    $ rm -rf wordpress
-    ```
+   ```bash
+   $ rm -rf wordpress
+   ```
 
     Then, you need to overwrite your existing `.gitignore` file with Platform.sh’s template `.gitignore` file, which is then used to complete the setup for Composer. Note that the `wordpress` subdirectory is added to the resulting `.gitignore` file. This way, after Composer reinstalls WordPress, the `wordpress` subdirectory will be ignored in commits:
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -46,7 +46,8 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
     $ composer init
     ```
 
-    When prompted, set metadata attributes for your project (name, license information...). When you get to the part about installing dependencies, type `no`, as you will add them later.
+   When prompted, set metadata attributes for your project (name, license information...).
+   When you get to the part about installing dependencies, type `no`, as you will add them later.
 
 4. **Clean up WordPress core**
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -25,7 +25,7 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
 
     If you do not already have Composer installed, [install it now](https://getcomposer.org/download/).
 
-2. **Switch to a new Git branch** 
+2. Switch to a new Git branch
     
     To safely make changes to your repository and Platform.sh environment, run the command:
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -12,7 +12,7 @@ It allows you to make your WordPress site [more stable, more secure, and easier 
 To update your WordPress site to use Composer, check that:
 
 - You already have a [vanilla version of WordPress installed locally](./_index.md).
-- Your WordPress core, themes and plugins are committed to your WordPress repository or committed as submodules.
+- Your WordPress core, themes, and plugins are committed to your WordPress repository or committed as submodules.
 - Your project has been set up for deployment on Platform.sh. If you do not have Platform.sh configuration files in your repository, make sure you [deploy WordPress without Composer](/guides/wordpress/vanilla/_index.md) before upgrading to a Composer-based site.
 
 ## Install WordPress with Composer

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -19,7 +19,8 @@ To update your WordPress site to use Composer, check that:
 
 ## Install WordPress with Composer
 
-Instead of committing all of WordPress to your repository (or adding it as a submodule), you can install it with Composer. To do so:
+Instead of committing all of WordPress to your repository (or adding it as a submodule), you can install it with Composer.
+To do so:
 
 1. **Download Composer** 
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -6,70 +6,75 @@ description: |
     Everything you need to get started with WordPress on Platform.sh. 
 ---
 
-This guide will take you through the steps to update your [*vanilla*](/guides/wordpress/vanilla/_index.md), fully committed, WordPress repository to one fully managed with Composer. It is assumed that you already have (locally) a vanilla version of WordPress where all of core, themes, and plugins are committed to the repository or committed as submodules, and that it has been set up for deployment on Platform.sh. Because of these assumptions, you should already have Platform.sh configuration files in your repository to deploy the resulting Composer-based WordPress site on Platform.sh. If you do not, follow the [previous guide](/guides/wordpress/vanilla/_index.md) and add them. 
+Composer helps you declare, manage and install all the dependencies needed to run your project. It allows you to make your WordPress site [more stable, secure, and easier to maintain](/guides/wordpress/composer/_index.md).
 
-For more context regarding why Platform.sh recommends Composer-based installations of WordPress, see the ["Using Composer" guide](/guides/wordpress/composer/_index.md).
+To update your WordPress site to use Composer, check that:
+- You already have [a vanilla version of WordPress installed locally](/guides/wordpress/vanilla/_index.md).
+- Your WordPress core, themes and plugins are committed to your WordPress repository or committed as submodules.
+- Your project has been set up for deployment on Platform.sh. If you do not have Platform.sh configuration files in your repository, make sure you [deploy WordPress without Composer](/guides/wordpress/vanilla/_index.md) before upgrading to a Composer-based site.
 
-## WordPress Core
+## Install WordPress with Composer
 
-Instead of committing all of WordPress to your repository (or adding it as a submodule), this section will show you how to install WordPress through Composer. 
+Instead of committing all of WordPress to your repository (or adding it as a submodule), you can install it with Composer. To do so:
 
 1. **Download Composer** 
 
     If you do not already have Composer installed, [install it now](https://getcomposer.org/download/).
 
-2. **Branch** 
+2. **Switch to a new Git branch** 
     
-    Since you are making changes to your repository and Platform.sh environment, branch your codebase:
+    To safely make changes to your repository and Platform.sh environment, run the command:
 
     ```bash
     $ git checkout -b composer
     ```
-3. **Initialize repository as Composer project**
+3. **Turn your repository into a Composer repository**
 
-    You need to have a `composer.json` on your project to use Composer. This file defines the dependencies you want to include (WordPress itself, plugins, and themes). When those dependencies are installed, a matching `composer.lock` file is generated from it that locks each of them down to the minor version, ensuring repeatable builds until you update.
-    
-    Run the command:
+     To use Composer, you need:
+    - A `composer.json` file listing all the dependencies needed for your project to run (WordPress itself, its plugins and themes).
+    - A `composer.lock` file listing the exact versions of all the dependencies installed on your project. Generated from the `composer.json` file, it ensures repeatable builds until you update.
+
+    To turn your repository into a Composer repository and generate those files, run the command:
 
     ```bash
     $ composer init
     ```
 
-    This will prompt you to set some metadata attributes for the project, such as its name and license information. When you get to the part about installing dependencies, type `no`, as you will add them in a later step.
+    When prompted, set metadata attributes for your project (name, license information...). When you get to the part about installing dependencies, type `no`, as you will add them later.
 
-4. **Cleanup WordPress core**
+4. **Clean up WordPress core**
 
-    Your existing installation of WordPress core is assumed to be in some subdirectory of your repository, such as `wordpress`. When we start managing WordPress with Composer in the next step, *all code in this subdirectory is overwritten*. The [previous guide](/guides/wordpress/vanilla/_index.md) instructs you to move all plugins and themes out of WordPress core and into a separate `plugins` subdirectory, so if you have not already done so consult that guide and do so now. 
+     Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`). For Composer to manage WordPress, **this subdirectory needs to be overwritten**. Make sure that you move all your important data to another subdirectory. For instance, add your plugins and themes to a separate `plugins` subdirectory. 
 
-    Inspect WordPress core carefully, and ensure that their isn't any data in that subdirectory you would not like to lose specific to your site. Unless you are managing WordPress core as a [submodule](/development/submodules.md#removing-submodules), you can now remove that subdirectory 
+    Unless you are managing WordPress core as a [submodule](/development/submodules.md#removing-submodules), you can now remove the `wordpress` subdirectory: 
 
     ```bash
     $ rm -rf wordpress
     ```
 
-    Add `wordpress` to your `.gitignore`, by adding our standard WordPress `.gitignore` to the bottom of your existing file. Platform.sh's template `.gitignore` will complete the setup for Composer, but also include other files specific to Platform.sh and developing locally with  Lando. 
+    Then, you need to overwrite your existing `.gitignore` file with Platform.sh’s template `.gitignore` file, which is then used to complete the setup for Composer. Note that the `wordpress` subdirectory is added to the resulting `.gitignore` file. This way, after Composer reinstalls WordPress, the `wordpress` subdirectory will be ignored in commits:
 
     ```bash
     $ curl https://raw.githubusercontent.com/platformsh/template-builder/master/templates/wordpress-composer/files/.gitignore >> .gitignore
     ```
     
-    Then, remove WordPress from the repository:
+    You can now remove WordPress from the repository:
 
     ```bash
     $ git rm -rf --cached wordpress && rm -rf wordpress
     $ git add . && git commit -m "Remove WordPress"
     ```
 
-4. **Install WordPress with Composer**
+4. **Launch the installation of WordPress with Composer**
 
-    Now that you have made your WordPress site into a Composer project, you can download packages via Composer. So, let's download WordPress itself. 
+    Now that you have made your WordPress site into a Composer project, you can download packages via Composer. To download WordPress itself, run the commands:
 
     ```bash
     $ composer require johnpbloch/wordpress-core-installer
     $ composer require johnpbloch/wordpress-core
     ```
 
-    You will notice that these two dependencies have been added to your `composer.json` file:
+    The two dependencies are now listed in your `composer.json` file:
 
     ```json
     {
@@ -80,31 +85,32 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
     }
     ```
 
-    Run `composer install`. WordPress will now reinstall into the `wordpress` subdirectory, although it will now be ignored in commits.
+    Complete the installation:
+    
+    ```bash
+     $ composer install
+     ```
+     
+     Composer reinstalls WordPress into the `wordpress` subdirectory.
 
-## Platform.sh configuration
+## Install WordPress Themes and Plugins with Composer
 
-Switching to Composer-based installation will not require any modifications to your Platform.sh configuration files added in the The [previous guide](/guides/wordpress/vanilla/_index.md). Again, add them now if you would like to deploy your WordPress site on Platform.sh if you have not already.
+Just like WordPress core, you can install themes and plugins with the `composer require` command. To do so:
 
-## Themes and Plugins
+1. **Configure the WPackagist repository**
 
-Like WordPress core itself, themes and plugins can be installed as dependencies with Composer with the same `composer require` command used above. 
-
-1. **Configure the WPPackagist repository**
-
-    When you download dependencies using Composer, you by default retrieve them through [Packagist](https://packagist.org),
+    By default, when you download dependencies using Composer, you retrieve them through [Packagist](https://packagist.org),
     which is the primary Composer repository for public PHP packages.
-    In the previous section, you installed WordPress core through this repository.
     Some themes and plugins for WordPress are also on Packagist,
     but most of them are accessible through a similar service specific to WordPress called [WPackagist](https://wpackagist.org). 
 
-    To pull from this repository, you need to add WPackagist to your `composer.json` file so that Composer knows to look for packages there. Run the command: 
+    To allow Composer to download packages from the WPackagist repository, add it to your `composer.json` file: 
 
     ```bash
     $ composer config repositories.wppackagist composer https://wpackagist.org
     ```
 
-    You will see that this will add WPackagist to `composer.json`:
+    WPackagist is now listed in your `composer.json`:
 
     ```json
     {
@@ -117,9 +123,9 @@ Like WordPress core itself, themes and plugins can be installed as dependencies 
     }
     ```
 
-2. **Configure theme and plugin destination**
+2. **(Optional) Configure theme and plugin destination**
 
-    Typically, Composer places installed dependencies in a subdirectory called `vendor` in your repository. But as shown already with WordPress core, this can be configured to install elsewhere if desired (since core installed to `wordpress` instead). To get themes and plugins to install into `wp-content`, add the following block to your `composer.json` file:
+    By default, Composer places installed dependencies in a subdirectory called `vendor` in your repository. But you can configure a different destination for your themes and plugins. For instance, to install them into `wp-content`, add the following block to your `composer.json` file:
 
     ```json
     "extra": {
@@ -137,36 +143,54 @@ Like WordPress core itself, themes and plugins can be installed as dependencies 
     }
     ```
 
-    Now any plugin that contains as a part of its package metadata a `type` of `wordpress-plugin` is installed into `wordpress/wp-content/plugins/` instead of `vendor`, and the same goes for themes and must-use plugins. 
+    After inspecting package metadata, Composer now installs the plugins whose `type` matches `wordpress-plugin` into `wordpress/wp-content/plugins/` instead of `vendor`, and the same goes for themes and must-use plugins. 
 
-3. **Install themes and modules**
+3. **Launch the installation of plugins and themes with Composer**
 
-    Search for your existing themes and plugins [WPackagist](https://wpackagist.org) and install them through Composer with `composer require`:
+    To search for themes and plugins in [WPackagist](https://wpackagist.org) and install them through Composer, run a `composer require` command:
 
     ```bash
     # Plugin
-    composer require wpackagist-plugin/wordpress-seo
+    $ composer require wpackagist-plugin/wordpress-seo
 
     # Theme
-    composer require wpackagist-theme/hueman
+    $ composer require wpackagist-theme/hueman
     ```
 
-    You'll see those dependencies added to `composer.json`, and after running `composer install` their subdirectories within `wordpress/wp-content/`.
+    The two dependencies are now listed in your `composer.json` file.
 
-## Deploying to Platform.sh
+    Complete the installation:
+    
+    ```bash
+     $ composer install 
+     ````
 
-So long as you already have the [three Platform.sh configuration files from the previous guide](/guides/wordpress/vanilla/_index.md), you can now commit these changes and deploy your new Composer-based WordPress site to Platform.sh.
+    Each dependency is now installed and has a subdirectory in `wordpress/wp-content/`.
+
+
+## Deploy to Platform.sh
+
+Switching to a Composer-based installation doesn't require any modifications to the Platform.sh configuration files created when [you deployed your vanilla version](/guides/wordpress/vanilla/_index.md). Make sure that your project contains those three files. You can then commit all your changes and deploy your new Composer-based WordPress site to Platform.sh:
 
 ```bash
 $ git add . && git commit -m "Composerify plugins and themes."
 $ git push platform composer
 ```
 
-## Updating
+## Update your Composer-based WordPress site
 
-Updating WordPress and your themes and plugins becomes a lot simpler now that you're using Composer. Create a new branch and update any time a new version becomes available.
+### Perform a standard update with Composer
+
+Updating WordPress, your themes and plugins becomes a lot simpler with Composer. When a new version becomes available, create a new branch and launch the update:
 
 ```bash
 $ git checkout -b updates
 $ composer update
 ```
+
+### Automate your updates with a source operation
+
+{{< tiered-feature "Elite and Enterprise" >}}
+
+[Source operations](/create-apps/source-operations.md) allow you to automate the maintenance of your Composer-based WordPress site. 
+For instance, you can [update all the dependencies in your project with a single command](/create-apps/source-operations#update-dependencies).

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -69,7 +69,7 @@ To do so:
     $ curl https://raw.githubusercontent.com/platformsh/template-builder/master/templates/wordpress-composer/files/.gitignore >> .gitignore
     ```
     
-    You can now remove WordPress from the repository:
+   Now remove WordPress from the repository:
 
     ```bash
     $ git rm -rf --cached wordpress && rm -rf wordpress

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -208,5 +208,5 @@ $ composer update
 
 {{< tiered-feature "Elite and Enterprise" >}}
 
-[Source operations](/create-apps/source-operations.md) allow you to automate the maintenance of your Composer-based WordPress site. 
+[Source operations](../../../create-apps/source-operations.md) allow you to automate the maintenance of your Composer-based WordPress site. 
 For instance, you can [update all the dependencies in your project with a single command](/create-apps/source-operations#update-dependencies).

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -43,9 +43,9 @@ To do so:
 
    To turn your repository into a Composer repository and generate those files, run the following command:
 
-    ```bash
-    $ composer init
-    ```
+   ```bash
+   $ composer init
+   ```
 
    When prompted, set metadata attributes for your project (name, license information...).
    When you get to the part about installing dependencies, type `no`, as you will add them later.

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -57,7 +57,7 @@ To do so:
    Make sure that you move all your important data to another subdirectory.
    For instance, add your plugins and themes to a separate `plugins` subdirectory. 
 
-    Unless you are managing WordPress core as a [submodule](/development/submodules.md#removing-submodules), you can now remove the `wordpress` subdirectory: 
+   Unless you are managing WordPress core as a [submodule](../../../development/submodules.md#removing-submodules), you can now remove the `wordpress` subdirectory: 
 
     ```bash
     $ rm -rf wordpress

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -13,8 +13,8 @@ To update your WordPress site to use Composer, check that:
 
 - You already have a [vanilla version of WordPress installed locally](../vanilla/_index.md).
 - Your project has been set up for deployment on Platform.sh.
-  If you do not have Platform.sh configuration files in your repository,
-  make sure you [deploy WordPress without Composer](../vanilla/_index.md) before upgrading to a Composer-based site.
+  If you don't have Platform.sh configuration files in your repository,
+  [deploy WordPress without Composer](../vanilla/_index.md) before upgrading to a Composer-based site.
 - You have [downloaded and installed Composer](https://getcomposer.org/download/).
 
 ## Install WordPress with Composer

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -9,6 +9,11 @@ description: |
 Composer helps you declare, manage, and install all the dependencies needed to run your project.
 It allows you to make your WordPress site [more stable, more secure, and easier to maintain](./_index.md).
 
+With Composer, you don't need to commit all of WordPress core, its themes and plugins to your project's Git repository. 
+You also don't need to manage any of these elements as Git submodules. 
+
+## Before you begin
+
 To update your WordPress site to use Composer, check that:
 
 - You already have a [vanilla version of WordPress installed locally](../vanilla/_index.md).
@@ -17,16 +22,9 @@ To update your WordPress site to use Composer, check that:
   [deploy WordPress without Composer](../vanilla/_index.md) before upgrading to a Composer-based site.
 - You have [downloaded and installed Composer](https://getcomposer.org/download/).
 
-## Install WordPress with Composer
+## 1. Install WordPress with Composer
 
-Managing WordPress with Composer makes installing and updating WordPress and its dependencies much more lightweight.
-With Composer, you don't need to commit all of WordPress core, its themes and plugins to your project's Git repository. 
-You also don't need to manage any of these elements as Git submodules. 
-
-If you were managing WordPress and its dependencies as Git submodules, 
-see [how to remove them](../../../development/submodules.md#removing-submodules) before switching to Composer.
-
-To install WordPress with Composer:
+To install WordPress with Composer, complete the following steps:
 
 1. Switch to a new Git branch.
     
@@ -57,6 +55,8 @@ To install WordPress with Composer:
    as you add them in step 5.
 
 3. Clean up WordPress core.
+
+   If you've been managing managing WordPress and its dependencies as Git submodules, before switching to Composer [remove the submodules](../../../development/submodules.md#removing-submodules).
 
    Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
    For Composer to manage WordPress, remove this subdirectory: 
@@ -110,7 +110,7 @@ To install WordPress with Composer:
      
    Composer reinstalls WordPress into the `wordpress` subdirectory.
 
-## Install WordPress themes and plugins with Composer
+## 2. Install WordPress themes and plugins with Composer
 
 Just like with WordPress core, you can install themes and plugins with the `composer require` command.
 To do so, complete the following steps:
@@ -193,7 +193,7 @@ To do so, complete the following steps:
    Each dependency is now installed.
 
 
-## Deploy to Platform.sh
+## 3. Deploy to Platform.sh
 
 Switching to a Composer-based installation doesn't require any modifications to the Platform.sh configuration files 
 created when [you deployed your vanilla version](../vanilla/_index.md). 
@@ -206,7 +206,7 @@ $ git add . && git commit -m "Composerify plugins and themes."
 $ git push platform composer
 ```
 
-## Update your Composer-based WordPress site
+## 4. Update your Composer-based WordPress site
 
 ### Perform a standard update with Composer
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -40,7 +40,7 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
    - A `composer.lock` file listing the exact versions of all the dependencies installed on your project.
      Generated from the `composer.json` file, it ensures repeatable builds until you update.
 
-    To turn your repository into a Composer repository and generate those files, run the command:
+   To turn your repository into a Composer repository and generate those files, run the following command:
 
     ```bash
     $ composer init

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -1,9 +1,9 @@
 ---
-title: "How to update your WordPress site to use Composer"
+title: "How to upgrade your WordPress site to use Composer"
 sidebarTitle: Upgrade to use Composer
 weight: 2
 description: |
-    Everything you need to get started with WordPress on Platform.sh. 
+    Learn how to use WordPress with Composer on Platform.sh.
 ---
 
 Composer helps you declare, manage, and install all the dependencies needed to run your project.
@@ -19,8 +19,14 @@ To update your WordPress site to use Composer, check that:
 
 ## Install WordPress with Composer
 
-Instead of committing all of WordPress to your repository (or [adding it as a Git submodule](../../../development/submodules.md)), you can install it with Composer.
-To do so:
+Managing WordPress with Composer makes installing and updating WordPress and its dependencies much more lightweight.
+With Composer, you don't need to commit all of WordPress core, its themes and plugins to your project's Git repository. 
+You also don't need to manage any of these elements as Git submodules. 
+
+If you were managing WordPress and its dependencies as Git submodules, 
+see [how to remove them](../../../development/submodules.md#removing-submodules) before switching to Composer.
+
+To install WordPress with Composer:
 
 1. Switch to a new Git branch.
     
@@ -53,11 +59,7 @@ To do so:
 3. Clean up WordPress core.
 
    Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
-   For Composer to manage WordPress, this subdirectory needs to be overwritten.
-   Make sure that you move all your important data to another subdirectory.
-   For instance, add your plugins and themes to a separate `plugins` subdirectory. 
-
-   You can now remove the `wordpress` subdirectory: 
+   For Composer to manage WordPress, remove this subdirectory: 
 
    ```bash
    $ rm -rf wordpress
@@ -91,7 +93,7 @@ To do so:
 
    The two dependencies are now listed in your `composer.json` file:
 
-   ```json {location="composer.json"}
+   ```json
     {
         "require": {
             "johnpbloch/wordpress-core-installer": "^2.0",
@@ -111,7 +113,7 @@ To do so:
 ## Install WordPress themes and plugins with Composer
 
 Just like with WordPress core, you can install themes and plugins with the `composer require` command.
-To do so:
+To do so, complete the following steps:
 
 1. Configure the WPackagist repository.
 
@@ -128,7 +130,7 @@ To do so:
 
    WPackagist is now listed in your `composer.json` file:
 
-   ```json {location="composer.json"}
+   ```json
     {
         "repositories": {
             "wppackagist": {

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -37,7 +37,8 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
    To use Composer, you need:
 
    - A `composer.json` file listing all the dependencies needed for your project to run (WordPress itself, its plugins, and its themes).
-    - A `composer.lock` file listing the exact versions of all the dependencies installed on your project. Generated from the `composer.json` file, it ensures repeatable builds until you update.
+   - A `composer.lock` file listing the exact versions of all the dependencies installed on your project.
+     Generated from the `composer.json` file, it ensures repeatable builds until you update.
 
     To turn your repository into a Composer repository and generate those files, run the command:
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -34,7 +34,7 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
     ```
 3. **Turn your repository into a Composer repository**
 
-     To use Composer, you need:
+   To use Composer, you need:
     - A `composer.json` file listing all the dependencies needed for your project to run (WordPress itself, its plugins and themes).
     - A `composer.lock` file listing the exact versions of all the dependencies installed on your project. Generated from the `composer.json` file, it ensures repeatable builds until you update.
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -50,7 +50,7 @@ To do so:
    When you get to the part about installing dependencies, type `no`, 
    as you add them in step 5.
 
-3. Clean up WordPress core
+3. Clean up WordPress core.
 
    Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
    For Composer to manage WordPress, this subdirectory needs to be overwritten.

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -48,7 +48,7 @@ To do so:
    When prompted, set metadata attributes for your project, 
    such as its name and license information.
    When you get to the part about installing dependencies, type `no`, 
-   as you will add them later.
+   as you add them in step 5.
 
 3. Clean up WordPress core
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -10,7 +10,8 @@ Composer helps you declare, manage, and install all the dependencies needed to r
 It allows you to make your WordPress site [more stable, more secure, and easier to maintain](./_index.md).
 
 To update your WordPress site to use Composer, check that:
-- You already have [a vanilla version of WordPress installed locally](/guides/wordpress/vanilla/_index.md).
+
+- You already have a [vanilla version of WordPress installed locally](./_index.md).
 - Your WordPress core, themes and plugins are committed to your WordPress repository or committed as submodules.
 - Your project has been set up for deployment on Platform.sh. If you do not have Platform.sh configuration files in your repository, make sure you [deploy WordPress without Composer](/guides/wordpress/vanilla/_index.md) before upgrading to a Composer-based site.
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -123,9 +123,9 @@ To do so:
     $ composer config repositories.wppackagist composer https://wpackagist.org
     ```
 
-    WPackagist is now listed in your `composer.json`:
+   WPackagist is now listed in your `composer.json`:
 
-    ```json
+   ```json {location="composer.json"}
     {
         "repositories": {
             "wppackagist": {

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -136,7 +136,7 @@ To do so:
     }
     ```
 
-2. **(Optional) Configure theme and plugin destination**
+2. Optional: Configure theme and plugin destination
 
    By default, Composer places installed dependencies in a `vendor` subdirectory.
    You can configure a different destination for your themes and plugins.

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -65,7 +65,7 @@ To do so:
 
    Then, at the end of your existing `.gitignore` file, add the content of Platform.sh’s template `.gitignore` file. 
    This adds the `wordpress` subdirectory to the resulting `.gitignore` file. 
-   This way, after Composer reinstalls WordPress, the `wordpress` subdirectory will be ignored in commits:
+   This way, after Composer reinstalls WordPress, the `wordpress` subdirectory is ignored in commits:
 
    ```bash
    $ curl https://raw.githubusercontent.com/platformsh/template-builder/master/templates/wordpress-composer/files/.gitignore >> .gitignore

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -27,7 +27,7 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
 
 2. Switch to a new Git branch
     
-    To safely make changes to your repository and Platform.sh environment, run the command:
+   To safely make changes to your repository and Platform.sh environment, run the following command:
 
     ```bash
     $ git checkout -b composer

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -52,7 +52,10 @@ To do so:
 
 4. **Clean up WordPress core**
 
-     Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`). For Composer to manage WordPress, **this subdirectory needs to be overwritten**. Make sure that you move all your important data to another subdirectory. For instance, add your plugins and themes to a separate `plugins` subdirectory. 
+   Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
+   For Composer to manage WordPress, **this subdirectory needs to be overwritten**.
+   Make sure that you move all your important data to another subdirectory.
+   For instance, add your plugins and themes to a separate `plugins` subdirectory. 
 
     Unless you are managing WordPress core as a [submodule](/development/submodules.md#removing-submodules), you can now remove the `wordpress` subdirectory: 
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -107,7 +107,8 @@ To do so:
 
 ## Install WordPress themes and plugins with Composer
 
-Just like WordPress core, you can install themes and plugins with the `composer require` command. To do so:
+Just like with WordPress core, you can install themes and plugins with the `composer require` command.
+To do so:
 
 1. **Configure the WPackagist repository**
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -35,7 +35,8 @@ Instead of committing all of WordPress to your repository (or adding it as a sub
 3. **Turn your repository into a Composer repository**
 
    To use Composer, you need:
-    - A `composer.json` file listing all the dependencies needed for your project to run (WordPress itself, its plugins and themes).
+
+   - A `composer.json` file listing all the dependencies needed for your project to run (WordPress itself, its plugins, and its themes).
     - A `composer.lock` file listing the exact versions of all the dependencies installed on your project. Generated from the `composer.json` file, it ensures repeatable builds until you update.
 
     To turn your repository into a Composer repository and generate those files, run the command:

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -11,33 +11,31 @@ It allows you to make your WordPress site [more stable, more secure, and easier 
 
 To update your WordPress site to use Composer, check that:
 
-- You already have a [vanilla version of WordPress installed locally](./_index.md).
-- Your WordPress core, themes, and plugins are committed to your WordPress repository or committed as submodules.
+- You already have a [vanilla version of WordPress installed locally](../vanilla/_index.md).
 - Your project has been set up for deployment on Platform.sh.
   If you do not have Platform.sh configuration files in your repository,
-  make sure you [deploy WordPress without Composer](./_index.md) before upgrading to a Composer-based site.
+  make sure you [deploy WordPress without Composer](../vanilla/_index.md) before upgrading to a Composer-based site.
+- You have [downloaded and installed Composer](https://getcomposer.org/download/).
 
 ## Install WordPress with Composer
 
-Instead of committing all of WordPress to your repository (or adding it as a submodule), you can install it with Composer.
+Instead of committing all of WordPress to your repository (or [adding it as a Git submodule](../../../development/submodules.md)), you can install it with Composer.
 To do so:
 
-1. **Download Composer** 
-
-    If you do not already have Composer installed, [install it now](https://getcomposer.org/download/).
-
-2. Switch to a new Git branch
+1. Switch to a new Git branch.
     
    To safely make changes to your repository and Platform.sh environment, run the following command:
 
    ```bash
    $ git checkout -b composer
    ```
-3. **Turn your repository into a Composer repository**
+
+2. Turn your repository into a Composer repository.
 
    To use Composer, you need:
 
-   - A `composer.json` file listing all the dependencies needed for your project to run (WordPress itself, its plugins, and its themes).
+   - A `composer.json` file listing all the dependencies needed for your project to run 
+     (WordPress itself, its plugins, and its themes).
    - A `composer.lock` file listing the exact versions of all the dependencies installed on your project.
      Generated from the `composer.json` file, it ensures repeatable builds until you update.
 
@@ -47,83 +45,88 @@ To do so:
    $ composer init
    ```
 
-   When prompted, set metadata attributes for your project (name, license information...).
-   When you get to the part about installing dependencies, type `no`, as you will add them later.
+   When prompted, set metadata attributes for your project, 
+   such as its name and license information.
+   When you get to the part about installing dependencies, type `no`, 
+   as you will add them later.
 
-4. **Clean up WordPress core**
+3. Clean up WordPress core
 
    Your existing installation of WordPress core is assumed to be in a subdirectory of your repository (often named `wordpress`).
-   For Composer to manage WordPress, **this subdirectory needs to be overwritten**.
+   For Composer to manage WordPress, this subdirectory needs to be overwritten.
    Make sure that you move all your important data to another subdirectory.
    For instance, add your plugins and themes to a separate `plugins` subdirectory. 
 
-   Unless you are managing WordPress core as a [submodule](../../../development/submodules.md#removing-submodules), you can now remove the `wordpress` subdirectory: 
+   You can now remove the `wordpress` subdirectory: 
 
    ```bash
    $ rm -rf wordpress
    ```
 
-    Then, you need to overwrite your existing `.gitignore` file with Platform.sh’s template `.gitignore` file, which is then used to complete the setup for Composer. Note that the `wordpress` subdirectory is added to the resulting `.gitignore` file. This way, after Composer reinstalls WordPress, the `wordpress` subdirectory will be ignored in commits:
+   Then, at the end of your existing `.gitignore` file, add the content of Platform.sh’s template `.gitignore` file. 
+   This adds the `wordpress` subdirectory to the resulting `.gitignore` file. 
+   This way, after Composer reinstalls WordPress, the `wordpress` subdirectory will be ignored in commits:
 
-    ```bash
-    $ curl https://raw.githubusercontent.com/platformsh/template-builder/master/templates/wordpress-composer/files/.gitignore >> .gitignore
-    ```
+   ```bash
+   $ curl https://raw.githubusercontent.com/platformsh/template-builder/master/templates/wordpress-composer/files/.gitignore >> .gitignore
+   ```
     
    Now remove WordPress from the repository:
 
-    ```bash
-    $ git rm -rf --cached wordpress && rm -rf wordpress
-    $ git add . && git commit -m "Remove WordPress"
-    ```
+   ```bash
+   $ git rm -rf --cached wordpress && rm -rf wordpress
+   $ git add . && git commit -m "Remove WordPress"
+   ```
 
-4. **Launch the installation of WordPress with Composer**
+4. Launch the installation of WordPress with Composer.
 
    Now that you have made your WordPress site into a Composer project, you can download packages via Composer.
+   
    To download WordPress itself, run the following commands:
 
-    ```bash
-    $ composer require johnpbloch/wordpress-core-installer
-    $ composer require johnpbloch/wordpress-core
-    ```
+   ```bash
+   $ composer require johnpbloch/wordpress-core-installer
+   $ composer require johnpbloch/wordpress-core
+   ```
 
-    The two dependencies are now listed in your `composer.json` file:
+   The two dependencies are now listed in your `composer.json` file:
 
-    ```json
+   ```json {location="composer.json"}
     {
         "require": {
             "johnpbloch/wordpress-core-installer": "^2.0",
-            "johnpbloch/wordpress-core": "^5.5"
+            "johnpbloch/wordpress-core": "^6.0"
         }
     }
-    ```
+   ```
 
-    Complete the installation:
+5. Complete the installation:
     
-    ```bash
-     $ composer install
-     ```
+   ```bash
+   $ composer install
+   ```
      
-     Composer reinstalls WordPress into the `wordpress` subdirectory.
+   Composer reinstalls WordPress into the `wordpress` subdirectory.
 
 ## Install WordPress themes and plugins with Composer
 
 Just like with WordPress core, you can install themes and plugins with the `composer require` command.
 To do so:
 
-1. **Configure the WPackagist repository**
+1. Configure the WPackagist repository.
 
-    By default, when you download dependencies using Composer, you retrieve them through [Packagist](https://packagist.org),
-    which is the primary Composer repository for public PHP packages.
-    Some themes and plugins for WordPress are also on Packagist,
-    but most of them are accessible through a similar service specific to WordPress called [WPackagist](https://wpackagist.org). 
+   By default, when you download dependencies using Composer, you retrieve them through [Packagist](https://packagist.org),
+   which is the primary Composer repository for public PHP packages.
+   Some themes and plugins for WordPress are also on Packagist,
+   but most of them are accessible through a similar service specific to WordPress called [WPackagist](https://wpackagist.org). 
 
-    To allow Composer to download packages from the WPackagist repository, add it to your `composer.json` file: 
+   To allow Composer to download packages from the WPackagist repository, run the following command: 
 
-    ```bash
-    $ composer config repositories.wppackagist composer https://wpackagist.org
-    ```
+   ```bash
+   $ composer config repositories.wppackagist composer https://wpackagist.org
+   ```
 
-   WPackagist is now listed in your `composer.json`:
+   WPackagist is now listed in your `composer.json` file:
 
    ```json {location="composer.json"}
     {
@@ -134,15 +137,16 @@ To do so:
             }
         }
     }
-    ```
+   ```
 
-2. Optional: Configure theme and plugin destination
+2. Optional: Configure theme and plugin destination.
 
    By default, Composer places installed dependencies in a `vendor` subdirectory.
+
    You can configure a different destination for your themes and plugins.
    For instance, to install them into `wp-content`, add the following configuration:
 
-    ```json
+   ```json {location="composer.json"}
     "extra": {
         "installer-paths": {
             "wordpress/wp-content/plugins/{$name}": [
@@ -156,37 +160,44 @@ To do so:
             ]
         }
     }
-    ```
+   ```
+   
+   Make sure you add the new destination subdirectories to your `.gitignore` file.
 
    After inspecting package metadata, Composer now installs plugins with a `type` of `wordpress-plugin` into `wordpress/wp-content/plugins/` instead of `vendor`.
-   And similarly for themes and must-use plugins. 
+   And similarly for themes and must-use plugins.
 
-3. **Launch the installation of plugins and themes with Composer**
 
-    To search for themes and plugins in [WPackagist](https://wpackagist.org) and install them through Composer, run a `composer require` command:
+3. Launch the installation of plugins and themes with Composer.
 
-    ```bash
-    # Plugin
-    $ composer require wpackagist-plugin/wordpress-seo
+   To search for themes and plugins in [WPackagist](https://wpackagist.org) and install them through Composer, run a `composer require` command:
 
-    # Theme
-    $ composer require wpackagist-theme/hueman
-    ```
+   ```bash
+   # Plugin
+   $ composer require wpackagist-plugin/wordpress-seo
 
-    The two dependencies are now listed in your `composer.json` file.
+   # Theme
+   $ composer require wpackagist-theme/hueman
+   ```
 
-    Complete the installation:
+   The two dependencies are now listed in your `composer.json` file.
+
+4. Complete the installation:
     
-    ```bash
-     $ composer install 
-     ````
+   ```bash
+   $ composer install 
+   ````
 
-    Each dependency is now installed and has a subdirectory in `wordpress/wp-content/`.
+   Each dependency is now installed.
 
 
 ## Deploy to Platform.sh
 
-Switching to a Composer-based installation doesn't require any modifications to the Platform.sh configuration files created when [you deployed your vanilla version](/guides/wordpress/vanilla/_index.md). Make sure that your project contains those three files. You can then commit all your changes and deploy your new Composer-based WordPress site to Platform.sh:
+Switching to a Composer-based installation doesn't require any modifications to the Platform.sh configuration files 
+created when [you deployed your vanilla version](../vanilla/_index.md). 
+Make sure that your project contains those three files. 
+You can then commit all your changes 
+and deploy your new Composer-based WordPress site to Platform.sh:
 
 ```bash
 $ git add . && git commit -m "Composerify plugins and themes."
@@ -197,7 +208,8 @@ $ git push platform composer
 
 ### Perform a standard update with Composer
 
-Updating WordPress, your themes and plugins becomes a lot simpler with Composer. When a new version becomes available, create a new branch and launch the update:
+Updating WordPress, your themes and plugins becomes a lot simpler with Composer. 
+When a new version becomes available, create a new branch and launch the update:
 
 ```bash
 $ git checkout -b updates
@@ -209,4 +221,4 @@ $ composer update
 {{< tiered-feature "Elite and Enterprise" >}}
 
 [Source operations](../../../create-apps/source-operations.md) allow you to automate the maintenance of your Composer-based WordPress site. 
-For instance, you can [update all the dependencies in your project with a single command](/create-apps/source-operations#update-dependencies).
+For instance, you can [update all the dependencies in your project with a single command](../../../create-apps/source-operations.md#update-dependencies).

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -6,7 +6,8 @@ description: |
     Everything you need to get started with WordPress on Platform.sh. 
 ---
 
-Composer helps you declare, manage and install all the dependencies needed to run your project. It allows you to make your WordPress site [more stable, secure, and easier to maintain](/guides/wordpress/composer/_index.md).
+Composer helps you declare, manage, and install all the dependencies needed to run your project.
+It allows you to make your WordPress site [more stable, more secure, and easier to maintain](./_index.md).
 
 To update your WordPress site to use Composer, check that:
 - You already have [a vanilla version of WordPress installed locally](/guides/wordpress/vanilla/_index.md).

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -105,7 +105,7 @@ To do so:
      
      Composer reinstalls WordPress into the `wordpress` subdirectory.
 
-## Install WordPress Themes and Plugins with Composer
+## Install WordPress themes and plugins with Composer
 
 Just like WordPress core, you can install themes and plugins with the `composer require` command. To do so:
 

--- a/docs/src/guides/wordpress/composer/migrate.md
+++ b/docs/src/guides/wordpress/composer/migrate.md
@@ -78,7 +78,8 @@ To do so:
 
 4. **Launch the installation of WordPress with Composer**
 
-    Now that you have made your WordPress site into a Composer project, you can download packages via Composer. To download WordPress itself, run the commands:
+   Now that you have made your WordPress site into a Composer project, you can download packages via Composer.
+   To download WordPress itself, run the following commands:
 
     ```bash
     $ composer require johnpbloch/wordpress-core-installer

--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -113,6 +113,7 @@ recache
 recertification
 redeployment
 reindex
+reinstall
 respawn
 [Rr]sync
 runtimes


### PR DESCRIPTION
## Why

Closes [#2316](https://github.com/platformsh/platformsh-docs/issues/2316)

## What's changed

- Highlighted the advantages of updating to a Composer-based WP site in introduction.
- Reworked the whole page to better stick to style guide.
- Added a subsection about source operations in Update section at the end.
