### PR TITLE
:rotating_light: Add reinstall to accepted terms in docs

### DIFF
--- a/styles/Vocab/Platform/accept.txt
+++ b/styles/Vocab/Platform/accept.txt
@@ -113,6 +113,7 @@ recache
 recertification
 redeployment
 reindex
+reinstall
 respawn
 [Rr]sync
 runtimes


### PR DESCRIPTION
## Why

Add new term so that the linting check can be passed.

## What's changed

Added "reinstall" to the list of accepted terms in the docs
