### PR TITLE
🔍️ Make .environment section more visible

### DIFF
--- a/docs/src/development/variables/set-variables.md
+++ b/docs/src/development/variables/set-variables.md
@@ -1,6 +1,8 @@
 ---
 title: Set variables
 description: See how to set variables that you can later use to take control over your app's environment.
+keywords:
+  - .environment
 ---
 
 To set variables, determine which [type of variable](./_index.md#variable-types) to use.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Searching for `.environment` brought up pages for specific frameworks, but nothing generic.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added a keyword.

The remaining issue is that periods are removed. So a search for `.environment` actually searches for `environment`. This makes the results not ideal if people are looking for environment-related ideas. But that's already an issue and I didn't find a way to solve it quickly, so this way at least gets the generic result higher.
