### PR TITLE
🏗️ Move Gen 2 below Gen 3

### DIFF
--- a/docs/src/dedicated-gen-2/_index.md
+++ b/docs/src/dedicated-gen-2/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "{{% names/dedicated-gen-2 %}}"
-weight: -20
+weight: -18
 description: |
   {{% names/dedicated-gen-2 %}} is a robust, redundant layer. This section contains all resources concerning the {{% names/dedicated-gen-2 %}} product.
 aliases:


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Dedicated Gen 2 is listed above Gen 3, although we're trying to move forward with Gen 3

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Moved Gen 2 down