### PR TITLE
📝 Specify Java runtimes are headless

### DIFF
--- a/docs/src/languages/java/_index.md
+++ b/docs/src/languages/java/_index.md
@@ -14,6 +14,9 @@ layout: single
 |----------------------------------------|------------------------------ |
 |  {{< image-versions image="java" status="supported" environment="grid" >}} | {{< image-versions image="java" status="supported" environment="dedicated-gen-2" >}} |
 
+These versions refer to the headless packages of OpenJDK.
+To save space and reduce potential vulnerabilities, they don't contain GUI classes, which can't be used on the server.
+
 {{% image-versions-legacy "java" %}}
 
 {{% language-specification type="java" display_name="Java" %}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Someone was confused why some GUI classes weren't available for Java. See Context

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Made it clear the headless packages are used so GUI classes aren't available.