### PR TITLE
Use platform-compatible app names in example code

### DIFF
--- a/docs/src/add-services/varnish.md
+++ b/docs/src/add-services/varnish.md
@@ -248,7 +248,7 @@ To access the stats, create a **separate app** with a relationship *to* Varnish,
 Define an [app configuration](../create-apps/app-reference.md) similar to the following:
 
 ```yaml {location=".platform.app.yaml"}
-name: statsApp
+name: stats-app
 type: "php:8.1"
 
 build:
@@ -269,7 +269,7 @@ The following paths are available:
 
 To access the Varnish stats endpoint from the command line:
 
-1. Connect to your stats app [using SSH](../development/ssh/_index.md): `platform ssh --app statsApp`
-   (replace `statsApp` with the name you gave the app).
+1. Connect to your stats app [using SSH](../development/ssh/_index.md): `platform ssh --app stats-app`
+   (replace `stats-app` with the name you gave the app).
 2. Display the [relationships array](../create-apps/app-reference.md#relationships) with `echo $PLATFORM_RELATIONSHIPS | base64 -d | jq .`,
 3. Query Varnish with `curl <HOST>:<PORT>/stats`, replacing `<HOST>` and `<PATH>` with the values from Step 2.


### PR DESCRIPTION
Platform.sh does not allow uppercase app names. Updating examples on this page.

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
