### PR TITLE
📝 Update supported Vault versions

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -1137,8 +1137,10 @@
     "runtime": false,
     "type": "vault-kms",
     "versions": {
-      "deprecated": [],
       "supported": [
+        "1.12"
+      ],
+      "deprecated": [
         "1.8",
         "1.6"
       ],
@@ -1153,6 +1155,9 @@
     },
     "versions-dedicated-gen-3": {
       "supported": [
+        "1.12"
+      ],
+      "deprecated": [
         "1.8",
         "1.6"
       ]


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Vault 1.12 is available. [Hashicorp support policy](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy) suggests deprecating older ones. See also Context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Updated supported versions for Grid and Gen 2