### PR TITLE
The token needs admin access to the repository

### DIFF
--- a/docs/src/integrations/source/bitbucket.md
+++ b/docs/src/integrations/source/bitbucket.md
@@ -61,7 +61,7 @@ To integrate your Platform.sh project with a repository on a Bitbucket Server in
 you first need to create an access token associated with your account.
 
 [Generate a token](https://confluence.atlassian.com/display/BitbucketServer/HTTP+access+tokens).
-and give it at least read access to projects and write access to repositories.
+and give it at least read access to projects and admin access to repositories.
 Copy the token and make a note of it (temporarily).
 
 ### 2. Enable the Server integration


### PR DESCRIPTION
To set the webhooks, it has to be able to change the settings in the repository.

## Why
Write access to the repository  is not enough to set webhooks because those are under the repository settings.
https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html

## What's changed
"write access" to "admin access"
