### PR TITLE
📝 Clarify HTTP access covers entire environment

### DIFF
--- a/docs/src/environments/http-access-control.md
+++ b/docs/src/environments/http-access-control.md
@@ -8,6 +8,7 @@ keywords:
 When developing your site, you might want to hide your development environments from outside viewers.
 Or you may find you have performance issues from [excessive bot access](https://community.platform.sh/t/diagnosing-and-resolving-issues-with-excessive-bot-access/792).
 You can control access either with a username and password or by allowing/denying specific IP addresses or networks.
+This setting applies to the entire environment.
 
 The settings for a specific environment are inherited by all of its children.
 So if you have a `staging` environment and you [branch environments from it](../other/glossary.md#branch),


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
It wasn't clear that HTTP access control covered an entire environment and couldn't be set by URL. See Context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Clarified that.