### PR TITLE
:ruby: remove deployed env options

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -39,10 +39,6 @@ A complete example is included at the end of this section.
     ```yaml
     variables:
         env:
-            BUNDLE_CACHE_ALL: '1' # default
-            BUNDLE_CLEAN: '1' # /!\ if you are working with Ruby <2.7, this doesn't work well
-            BUNDLE_DEPLOYMENT: '1' # default
-            BUNDLE_ERROR_ON_STDERR: '1' # default
             BUNDLE_WITHOUT: 'development:test'
             DEFAULT_BUNDLER_VERSION: "2.2.26" # in case none is mentioned in Gemfile.lock
             EXECJS_RUNTIME: 'Node'
@@ -51,8 +47,6 @@ A complete example is included at the end of this section.
             NVM_VERSION: v0.38.0
             RACK_ENV: 'production'
             RAILS_ENV: 'production'
-            RAILS_LOG_TO_STDOUT: '1' # default (log to /var/log/app.log)
-            RAILS_TMP: '/tmp' # default
     ```
 
     The `SECRET_KEY_BASE` variable is generated automatically based on the [`PLATFORM_PROJECT_ENTROPY` variable](../development/variables/use-variables.md#use-platformsh-provided-variables).
@@ -202,10 +196,6 @@ disk: 2048
 
 variables:
     env:
-        BUNDLE_CACHE_ALL: '1'
-        BUNDLE_CLEAN: '1' # /!\ if you are working with Ruby<2.7 this doesn't work well
-        BUNDLE_DEPLOYMENT: '1'
-        BUNDLE_ERROR_ON_STDERR: '1'
         BUNDLE_WITHOUT: 'development:test'
         DEFAULT_BUNDLER_VERSION: "2.2.26" # in case none is mentioned in Gemfile.lock
         EXECJS_RUNTIME: 'Node'
@@ -214,8 +204,6 @@ variables:
         NVM_VERSION: v0.38.0
         RACK_ENV: 'production'
         RAILS_ENV: 'production'
-        RAILS_LOG_TO_STDOUT: '1'
-        RAILS_TMP: '/tmp'
 
 hooks:
     build: |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Those options are deployed and available per default

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

They can still be overridden on the .platform.app.yml file