### PR TITLE
Make the CLI consistent with other Administration components

### DIFF
--- a/docs/src/administration/cli/_index.md
+++ b/docs/src/administration/cli/_index.md
@@ -1,13 +1,12 @@
 ---
-title: "Command Line Interface (CLI)"
+title: Command line interface (CLI)
 weight: -10
 description: |
   See how to use and manage your Platform.sh projects directly from your terminal. Anything you can do within the Console can be done with the CLI.
-sidebarTitle: "Command Line Interface (CLI)"
 layout: single
 keywords:
   - CLI
-  - Command Line Interface
+  - Command line interface
   - Terminal
 ---
 

--- a/docs/src/administration/cli/_index.md
+++ b/docs/src/administration/cli/_index.md
@@ -1,12 +1,14 @@
 ---
-title: "Use the command line interface (CLI)"
+title: "Command Line Interface (CLI)"
 weight: -10
 description: |
   See how to use and manage your Platform.sh projects directly from your terminal. Anything you can do within the Console can be done with the CLI.
-sidebarTitle: "Use the CLI"
+sidebarTitle: "Command Line Interface (CLI)"
 layout: single
 keywords:
   - CLI
+  - Command Line Interface
+  - Terminal
 ---
 
 {{% description %}}


### PR DESCRIPTION
Under `Administration`, we document the CLI as `Use the CLI`.

However, our other components simply say: `Console`, `Organizations`, `Users`. 

We should be consistent.
