### PR TITLE
Fix integration command to use token instead of license_key

### DIFF
--- a/docs/src/increase-observability/logs/forward-logs.md
+++ b/docs/src/increase-observability/logs/forward-logs.md
@@ -55,7 +55,7 @@ file=none
 3. Create the integration with the following command:
 
    ```bash
-   platform integration:add --type newrelic --url {{< variable "API_ENDPOINT" >}} --license_key {{% variable "LICENSE_KEY" %}}
+   platform integration:add --type newrelic --url {{< variable "API_ENDPOINT" >}} --token {{% variable "LICENSE_KEY" %}}
    ```
 
 View your logs in the **Logs** dashboard.


### PR DESCRIPTION
## Why

```
platform integration:add --type newrelic --url https://log-api.newrelic.com/log/v1 --license_key <REDACTED>

                                              
  [RuntimeException]                          
  The "--license_key" option does not exist.  
```

## What's changed

Use `--token` instead of `--license_key`
