### PR TITLE
Observability forwarding token fix

### DIFF
--- a/docs/src/increase-observability/logs/forward-logs.md
+++ b/docs/src/increase-observability/logs/forward-logs.md
@@ -55,7 +55,7 @@ file=none
 3. Create the integration with the following command:
 
    ```bash
-   platform integration:add --type newrelic --url {{< variable "API_ENDPOINT" >}} --license_key {{% variable "LICENSE_KEY" %}}
+   platform integration:add --type newrelic --url {{< variable "API_ENDPOINT" >}} --token {{% variable "LICENSE_KEY" %}}
    ```
 
 View your logs in the **Logs** dashboard.

--- a/docs/src/increase-observability/logs/forward-logs.md
+++ b/docs/src/increase-observability/logs/forward-logs.md
@@ -55,7 +55,7 @@ file=none
 3. Create the integration with the following command:
 
    ```bash
-   platform integration:add --type newrelic --url {{< variable "API_ENDPOINT" >}} --token {{% variable "LICENSE_KEY" %}}
+   platform integration:add --type newrelic --url {{< variable "API_ENDPOINT" >}} --license-key {{% variable "LICENSE_KEY" %}}
    ```
 
 View your logs in the **Logs** dashboard.


### PR DESCRIPTION
## Why

This doesn't work when using an underscore, it needs to be a dash. 

## What's changed

`--license_key` vs `--license-key`
