### PR TITLE
rename gitlab to github in integration:add

### DIFF
--- a/docs/src/integrations/source/github.md
+++ b/docs/src/integrations/source/github.md
@@ -47,7 +47,7 @@ highlight=false
 Run the following command:
 
 ```bash
-platform integration:add --type=gitlab --token={{< variable "GITHUB_ACCESS_TOKEN" >}} --server-project={{< variable "OWNER/REPOSITORY" >}} --project={{< variable "PLATFORM_SH_PROJECT_ID" >}}
+platform integration:add --type=github --token={{< variable "GITHUB_ACCESS_TOKEN" >}} --server-project={{< variable "OWNER/REPOSITORY" >}} --project={{< variable "PLATFORM_SH_PROJECT_ID" >}}
 ```
 
 * `GITHUB_ACCESS_TOKEN` is the token you generated.


### PR DESCRIPTION
## Why

Hi ! I think you added the wrong type in the following command

```
platform integration:add --type=gitlab
```

## What's changed

I think what was changed is clear