### PR TITLE
📝 Clarify use of tunnel:single

### DIFF
--- a/docs/src/add-services/influxdb.md
+++ b/docs/src/add-services/influxdb.md
@@ -51,16 +51,11 @@ InfluxDB includes its own [export mechanism](https://docs.influxdata.com/influxd
 To gain access to the server from your local machine open an SSH tunnel with the Platform.sh CLI:
 
 ```bash
-platform tunnel:open
+platform tunnel:single --relationship {{< variable "RELATIONSHIP_NAME" >}}
 ```
 
-That opens an SSH tunnel to all services on your current environment and produce output like the following:
+By default, this opens a tunnel at `127.0.0.1:30000`.
 
-```bash
-SSH tunnel opened on port 30000 to relationship: influxtimedb
-```
-
-The port may vary in your case.
 Then run InfluxDB's export commands as desired.
 
 ```bash

--- a/docs/src/add-services/solr.md
+++ b/docs/src/add-services/solr.md
@@ -224,22 +224,14 @@ The configuration directory is a collection of configuration data, like a data d
 Because Solr uses HTTP for both its API and admin interface it's possible to access the admin interface over an SSH tunnel.
 
 ```bash
-platform tunnel:open
+platform tunnel:open --relationship {{< variable "RELATIONSHIP_NAME" >}}
 ```
 
-That opens an SSH tunnel to all services on the current environment and gives an output similar to:
+By default, this opens a tunnel at `127.0.0.1:30000`.
 
-```bash
-SSH tunnel opened on port 30000 to relationship: solrsearch
-SSH tunnel opened on port 30001 to relationship: database
-Logs are written to: /home/myuser/.platformsh/tunnels.log
-
-List tunnels with: platform tunnels
-View tunnel details with: platform tunnel:info
-Close tunnels with: `platform tunnel:close`
-```
-
-In this example, you can now open `http://localhost:30000/solr/` in a browser to access the Solr admin interface. Note that you can't create indexes or users this way, but you can browse the existing indexes and manipulate the stored data.
+You can now open `http://localhost:30000/solr/` in a browser to access the Solr admin interface.
+Note that you can't create indexes or users this way,
+but you can browse the existing indexes and manipulate the stored data.
 
 {{< note >}}
 

--- a/docs/src/development/ssh/_index.md
+++ b/docs/src/development/ssh/_index.md
@@ -94,7 +94,10 @@ Use the returned host (in this case `http://127.0.0.1:30000`) for your connectio
 and fill in the details with the rest of your [service credentials](../../add-services/_index.md#1-obtain-service-credentials).
 
 The `tunnel:open` command connects all relationships defined in your [app configuration](../../create-apps/_index.md).
+
 To open only one connection when you have multiple relationships defined, run `tunnel:single`.
+By default, this opens a tunnel at `http://127.0.0.1:30000`.
+You can specify the port for the connection using the `--port` flag.
 
 ### Use an app tunnel
 

--- a/docs/src/guides/strapi/local-development/local-development-v4.md
+++ b/docs/src/guides/strapi/local-development/local-development-v4.md
@@ -159,7 +159,7 @@ To run your Strapi v4 app locally with all of its services, follow these steps:
    If you get the error `The pcntl PHP extension is required` error, use this command instead:
 
    ```bash
-   platform single:open -A <APP_NAME> -e updates
+   platform tunnel:single -A <APP_NAME> -e updates
    ```
 
 5. Add an environment variable that contains the service credentials:


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2701

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Clarified instructions on service pages to connect only to the one tunnel.
Made generic service instructions clearer, splitting app and tunnel instructions.
