### PR TITLE
💚 Fix environment URL in GitHub comments

### DIFF
--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -67,8 +67,6 @@ jobs:
 
           # Get the URL of the environment
           ENV_URL=$(platform url --primary --pipe --environment ${{ steps.branch_name.outputs.branch_name }})
-          
-          ENV_URL="https://$ENV_URL/"
 
           # Get the status of the build activity
           COMMIT_STATUS=$(platform activities --format plain --type "environment.push environment.activate environment.redeploy" --no-header --columns "result" --limit 1 --environment ${{ steps.branch_name.outputs.branch_name }})


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

With the switch to the Platform command, the workaround for the environment URL was causing duplication and errors
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Fixed the errro
