### PR TITLE
:bug: Fix links pointing to API Tokens page headers

### DIFF
--- a/docs/src/create-apps/source-operations.md
+++ b/docs/src/create-apps/source-operations.md
@@ -162,7 +162,7 @@ You can use cron to automatically run your source operations.
 {{< note >}}
 
 To run automated source operations using cron, you need to use [an API token](../administration/cli/api-tokens.md)
-with the [CLI installed](../administration/cli/api-tokens.md#on-a-platformsh-environment) in your app container.
+with the [CLI installed](../administration/cli/api-tokens.md#authenticate-in-a-platformsh-environment) in your app container.
 
 {{< /note >}}
 

--- a/docs/src/development/local/ddev.md
+++ b/docs/src/development/local/ddev.md
@@ -48,7 +48,7 @@ Your project should start running, though without any of the data from your Plat
 
 To connect DDEV with your Platform.sh account, use a Platform.sh API token.
 
-1. [Create an API token](../../administration/cli/api-tokens.md#get-a-token) in the Console.
+1. [Create an API token](../../administration/cli/api-tokens.md#2-create-a-platformsh-api-token) in the Console.
 2. Add the token to your DDEV configuration.
    You can do so globally (easiest for most people):
 

--- a/docs/src/development/local/docksal.md
+++ b/docs/src/development/local/docksal.md
@@ -33,7 +33,7 @@ See all [restrictions on the projects directory](https://docs.docksal.io/getting
 
 To connect Docksal with your Platform.sh account, use a Platform.sh API token.
 
-1. [Create an API token](../../administration/cli/api-tokens.md#get-a-token) in the Console.
+1. [Create an API token](../../administration/cli/api-tokens.md#2-create-a-platformsh-api-token) in the Console.
 2. Add the token to your Docksal configuration by running this command:
 
    ```bash

--- a/docs/src/development/local/lando.md
+++ b/docs/src/development/local/lando.md
@@ -35,7 +35,7 @@ Follow the [Lando installation instructions](https://docs.lando.dev/getting-star
 
 ## 2. Create an access token
 
-To authorize Lando to communicate with Platform.sh, create an [API token](../../administration/cli/api-tokens.md#get-a-token).
+To authorize Lando to communicate with Platform.sh, create an [API token](../../administration/cli/api-tokens.md#2-create-a-platformsh-api-token).
 Copy the value.
 
 ## 3. Initialize Lando

--- a/docs/src/environments/backup.md
+++ b/docs/src/environments/backup.md
@@ -163,7 +163,7 @@ highlight=false
 
 You can also automate the process of creating manual backups through [cron jobs](../create-apps/app-reference.md#crons).
 The cron job uses the CLI command to back up the environment.
-It requires you to [set up the CLI on the environment with an API token](../administration/cli/api-tokens.md#on-a-platformsh-environment).
+It requires you to [set up the CLI on the environment with an API token](../administration/cli/api-tokens.md#authenticate-in-a-platformsh-environment).
 
 Although this process is automated,
 backups created in this way count as manual for the [backup schedule](#backup-schedule).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Relates to  #2213 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Fixed all the broken links that were expected to point to headers on the API tokens page.
