### PR TITLE
:bug: Fix codetabs syntax

### DIFF
--- a/contributing/markup-format.md
+++ b/contributing/markup-format.md
@@ -303,23 +303,6 @@ platform project:set-remote --project {{< variable "PROJECT_ID" >}}
 ```
 ````
 
-#### Variables in codetabs
-
-If you want to use the `variable` shortcode in codetabs, you need to use HTML instead of Markdown.
-You can generate the code block outside the codetabs and then copy in the highlighting.
-
-Example:
-
-```markdown
-1. Run the following command:
-   
-   <!-- This is in HTML to get the variable shortcode to work properly -->
-   <div class="highlight">
-     <pre class="chroma"><code class="language-bash" data-lang="bash">platform backup:restore {{< variable "BACKUP_ID" >}}</code></pre>
-   </div>
-1. Press `enter` to agree with the consequences and continue.
-```
-
 ## Refer to the UI and keys
 
 When referring to text in the UI, use bold:

--- a/docs/src/add-services/kafka.md
+++ b/docs/src/add-services/kafka.md
@@ -51,7 +51,8 @@ title=Ruby
 file=none
 highlight=ruby
 markdownify=false
----
++++
+
 ## With the ruby-kafka gem
 
 # Producer
@@ -65,6 +66,5 @@ kafka.each_message(topic: "greetings") do |message|
 end
 
 {{< /codetabs >}}
-
 
 (The specific way to inject configuration into your application varies. Consult your application or framework's documentation.)

--- a/docs/src/add-services/kafka.md
+++ b/docs/src/add-services/kafka.md
@@ -52,7 +52,6 @@ file=none
 highlight=ruby
 markdownify=false
 +++
-
 ## With the ruby-kafka gem
 
 # Producer
@@ -66,5 +65,6 @@ kafka.each_message(topic: "greetings") do |message|
 end
 
 {{< /codetabs >}}
+
 
 (The specific way to inject configuration into your application varies. Consult your application or framework's documentation.)

--- a/docs/src/development/local/tethered.md
+++ b/docs/src/development/local/tethered.md
@@ -5,7 +5,7 @@ weight: 2
 ---
 
 The simplest way to run a project locally is to use a local web server, but keep all other services on Platform.sh and connect to them over an SSH tunnel.
-This approach needs very little setup, but requires an active Internet connection, and depending on the speed of your connection and how I/O intensive your application is, it may not have suitable performance for day-to-day use.
+This approach needs little setup, but requires an active Internet connection, and depending on the speed of your connection and how I/O intensive your application is, it may not have suitable performance for day-to-day use.
 
 ## Quick Start
 
@@ -96,19 +96,22 @@ title=PHP
 file=none
 highlight=php
 markdownify=false
----
++++
+
 <?php
 if ($relationships_encoded = shell_exec('platform tunnel:info --encode')) {
     $relationships = json_decode(base64_decode($relationships_encoded, TRUE), TRUE);
     // ...
 }
 <--->
+
 +++
 title=Python
 file=none
 highlight=python
 markdownify=false
----
++++
+
 import json
 import base64
 import subprocess
@@ -117,19 +120,21 @@ encoded = subprocess.check_output(['platform', 'tunnel:info', '--encode'])
 if (encoded):
     json.loads(base64.b64decode(encoded).decode('utf-8'))
     # ...
+
 <--->
+
 +++
 title=Node.js
 file=none
 highlight=javascript
 markdownify=false
----
++++
+
 const child_process = require("child_process");
 
 const { stdout: encoded } = child_process.spawnSync("platform", ["tunnel:info", "--encode"], { encoding : "utf8" });
 const relationships = encoded ? JSON.parse(Buffer.from(encoded, "base64").toString()) : {};
 
 // ...
+
 {{< /codetabs >}}
-
-

--- a/docs/src/development/local/tethered.md
+++ b/docs/src/development/local/tethered.md
@@ -97,7 +97,6 @@ file=none
 highlight=php
 markdownify=false
 +++
-
 <?php
 if ($relationships_encoded = shell_exec('platform tunnel:info --encode')) {
     $relationships = json_decode(base64_decode($relationships_encoded, TRUE), TRUE);
@@ -111,7 +110,6 @@ file=none
 highlight=python
 markdownify=false
 +++
-
 import json
 import base64
 import subprocess
@@ -129,7 +127,6 @@ file=none
 highlight=javascript
 markdownify=false
 +++
-
 const child_process = require("child_process");
 
 const { stdout: encoded } = child_process.spawnSync("platform", ["tunnel:info", "--encode"], { encoding : "utf8" });
@@ -138,3 +135,5 @@ const relationships = encoded ? JSON.parse(Buffer.from(encoded, "base64").toStri
 // ...
 
 {{< /codetabs >}}
+
+

--- a/docs/src/environments/change-parent.md
+++ b/docs/src/environments/change-parent.md
@@ -29,6 +29,7 @@ highlight=false
 - Click **Save**.
 
 <--->
+
 +++
 title=Using the CLI
 file=none

--- a/docs/src/languages/dotnet.md
+++ b/docs/src/languages/dotnet.md
@@ -10,7 +10,7 @@ description: |
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="dotnet" status="supported" environment="grid" >}} | {{< image-versions image="dotnet" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="dotnet" status="supported" environment="grid" >}} | {{< image-versions image="dotnet" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "dotnet" %}}
 

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -9,7 +9,7 @@ description: Platform.sh supports building and deploying applications written in
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="elixir" status="supported" environment="grid" >}} | {{< image-versions image="elixir" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="elixir" status="supported" environment="grid" >}} | {{< image-versions image="elixir" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "elixir" %}}
 

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -121,6 +121,7 @@ markdownify=false
 
 {{< /codetabs >}}
 
+
 {{% config-reader %}}
 [Config Reader library](https://github.com/platformsh/config-reader-go)
 {{% /config-reader%}}

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -9,7 +9,7 @@ description: Platform.sh supports building and deploying applications written in
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="golang" status="supported" environment="grid" >}} | {{< image-versions image="golang" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="golang" status="supported" environment="grid" >}} | {{< image-versions image="golang" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "golang" %}}
 
@@ -72,7 +72,7 @@ title=Memcached
 file=static/files/fetch/examples/golang/memcached
 highlight=go
 markdownify=false
----
++++
 
 <--->
 
@@ -81,7 +81,7 @@ title=MongoDB
 file=static/files/fetch/examples/golang/mongodb
 highlight=golang
 markdownify=false
----
++++
 
 <--->
 
@@ -90,7 +90,7 @@ title=MySQL
 file=static/files/fetch/examples/golang/mysql
 highlight=golang
 markdownify=false
----
++++
 
 <--->
 
@@ -99,7 +99,7 @@ title=PostgreSQL
 file=static/files/fetch/examples/golang/postgresql
 highlight=golang
 markdownify=false
----
++++
 
 <--->
 
@@ -108,7 +108,7 @@ title=RabbitMQ
 file=static/files/fetch/examples/golang/rabbitmq
 highlight=golang
 markdownify=false
----
++++
 
 <--->
 
@@ -117,10 +117,9 @@ title=Solr
 file=static/files/fetch/examples/golang/solr
 highlight=golang
 markdownify=false
----
++++
 
 {{< /codetabs >}}
-
 
 {{% config-reader %}}
 [Config Reader library](https://github.com/platformsh/config-reader-go)

--- a/docs/src/languages/java/_index.md
+++ b/docs/src/languages/java/_index.md
@@ -12,7 +12,7 @@ layout: single
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="java" status="supported" environment="grid" >}} | {{< image-versions image="java" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="java" status="supported" environment="grid" >}} | {{< image-versions image="java" status="supported" environment="dedicated-gen-2" >}} |
 
 These versions refer to the headless packages of OpenJDK.
 To save space and reduce potential vulnerabilities, they don't contain GUI classes, which can't be used on the server.

--- a/docs/src/languages/lisp.md
+++ b/docs/src/languages/lisp.md
@@ -9,7 +9,7 @@ description: Platform.sh supports building and deploying applications written in
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="lisp" status="supported" environment="grid" >}} | {{< image-versions image="lisp" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="lisp" status="supported" environment="grid" >}} | {{< image-versions image="lisp" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "lisp" %}}
 

--- a/docs/src/languages/nodejs/_index.md
+++ b/docs/src/languages/nodejs/_index.md
@@ -12,7 +12,7 @@ You can also develop a microservice architecture mixing JavaScript and other app
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="nodejs" status="supported" environment="grid" >}} | {{< image-versions image="nodejs" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="nodejs" status="supported" environment="grid" >}} | {{< image-versions image="nodejs" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "nodejs" %}}
 
@@ -24,7 +24,7 @@ To use a specific version in a container with a different language, [use a versi
 
 | Grid | {{% names/dedicated-gen-2 %}} |
 | ---- | ----------------------------- |
-|  {{< image-versions image="nodejs" status="deprecated" environment="grid" >}} | {{< image-versions image="nodejs" status="deprecated" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="nodejs" status="deprecated" environment="grid" >}} | {{< image-versions image="nodejs" status="deprecated" environment="dedicated-gen-2" >}} |
 
 ## Usage example
 

--- a/docs/src/languages/php/_index.md
+++ b/docs/src/languages/php/_index.md
@@ -246,7 +246,6 @@ markdownify=false
 +++
 
 {{< /codetabs >}}
-
 {{% config-reader %}}
 [`platformsh/config-reader` Composer library](https://github.com/platformsh/config-reader-php)
 {{% /config-reader %}}

--- a/docs/src/languages/php/_index.md
+++ b/docs/src/languages/php/_index.md
@@ -8,7 +8,7 @@ layout: single
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="php" status="supported" environment="grid" >}} | {{< image-versions image="php" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="php" status="supported" environment="grid" >}} | {{< image-versions image="php" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "php" %}}
 
@@ -20,7 +20,7 @@ Note that from PHP versions 7.1 to 8.1, the images support the Zend Thread Safe 
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="php" status="deprecated" environment="grid" >}} | {{< image-versions image="php" status="deprecated" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="php" status="deprecated" environment="grid" >}} | {{< image-versions image="php" status="deprecated" environment="dedicated-gen-2" >}} |
 
 ## Usage example
 

--- a/docs/src/languages/python/_index.md
+++ b/docs/src/languages/python/_index.md
@@ -10,7 +10,7 @@ You can deploy Python apps on Platform.sh using a server or a project such as [u
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="python" status="supported" environment="grid" >}} | {{< image-versions image="python" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="python" status="supported" environment="grid" >}} | {{< image-versions image="python" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "python" %}}
 
@@ -126,7 +126,7 @@ title=Elasticsearch
 file=static/files/fetch/examples/python/elasticsearch
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -135,7 +135,7 @@ title=Kafka
 file=static/files/fetch/examples/python/kafka
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -144,7 +144,7 @@ title=Memcached
 file=static/files/fetch/examples/python/memcached
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -153,7 +153,7 @@ title=MongoDB
 file=static/files/fetch/examples/python/mongodb
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -162,7 +162,7 @@ title=MySQL
 file=static/files/fetch/examples/python/mysql
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -171,7 +171,7 @@ title=PostgreSQL
 file=static/files/fetch/examples/python/postgresql
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -180,7 +180,7 @@ title=RabbitMQ
 file=static/files/fetch/examples/python/rabbitmq
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -189,7 +189,7 @@ title=Redis
 file=static/files/fetch/examples/python/redis
 highlight=python
 markdownify=false
----
++++
 
 <--->
 
@@ -198,10 +198,9 @@ title=Solr
 file=static/files/fetch/examples/python/solr
 highlight=python
 markdownify=false
----
++++
 
 {{< /codetabs >}}
-
 
 {{% config-reader %}}
 [`platformshconfig` library](https://github.com/platformsh/config-reader-python)

--- a/docs/src/languages/python/_index.md
+++ b/docs/src/languages/python/_index.md
@@ -202,6 +202,7 @@ markdownify=false
 
 {{< /codetabs >}}
 
+
 {{% config-reader %}}
 [`platformshconfig` library](https://github.com/platformsh/config-reader-python)
 {{% /config-reader%}}

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -12,7 +12,7 @@ description: |
 
 | Grid and {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |----------------------------------------|------------------------------ |
-|  {{< image-versions image="ruby" status="supported" environment="grid" >}} | {{< image-versions image="ruby" status="supported" environment="dedicated-gen-2" >}} |
+| {{< image-versions image="ruby" status="supported" environment="grid" >}} | {{< image-versions image="ruby" status="supported" environment="dedicated-gen-2" >}} |
 
 {{% image-versions-legacy "ruby" %}}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

During a review, I overlooked some code tabs syntax errors.
It broke the codetab [here](https://docs.platform.sh/development/local/tethered.html#local-environment-variables).

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Updated the codetabs to [the right syntax](https://github.com/platformsh/platformsh-docs/blob/main/contributing/markup-format.md#code-tabs) to avoid further issues down the road.
Also fixed a few simple linting errors along the way.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
