### PR TITLE
📝 Note Oracle MySQL not available on Gen 3

### DIFF
--- a/docs/src/add-services/mysql/_index.md
+++ b/docs/src/add-services/mysql/_index.md
@@ -34,7 +34,8 @@ MySQL and MariaDB have the same behavior and the rest of this page applies to bo
 
 ### Supported versions on Dedicated environments
 
-`oracle-mysql` is available for {{% names/dedicated-gen-3 %}} environments but not {{% names/dedicated-gen-2 %}} environments.
+`oracle-mysql` is not yet available for {{% names/dedicated-gen-3 %}} environments.
+It also isn't available for {{% names/dedicated-gen-2 %}} environments.
 
 On {{% names/dedicated-gen-3 %}} and {{% names/dedicated-gen-2 %}} environments, MariaDB is available with Galera for replication:
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
Oracle MySQL isn't available in high-availability environments. See Context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changed the note about it.