### PR TITLE
💚 Fix state being read as multiple strings

### DIFF
--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -59,7 +59,7 @@ jobs:
           STATUS_TRY=0
 
           # Wait until state is complete or 10 minutes has passed
-          until [ $STATE == "complete" ] || [ $STATUS_TRY == 20 ]; do
+          until [ "$STATE" == "complete" ] || [ $STATUS_TRY == 20 ]; do
             sleep 30
             STATE=$(platform activities --format plain --type "environment.push environment.activate environment.redeploy" --no-header --columns "state" --limit 1 --environment ${{ steps.branch_name.outputs.branch_name }})
             ((STATUS_TRY+=1))


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

With #2737, the state was occasionally "in progress", which was being read as two strings and so an error.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added quotes to make it into a single string.
