### PR TITLE
Fix CLI typo `to active` -> `to activate`

### DIFF
--- a/docs/src/administration/cli/_index.md
+++ b/docs/src/administration/cli/_index.md
@@ -139,7 +139,7 @@ You can find that in the Console or by running `platform projects` to list all a
 
 Some CLI commands (especially many within the `environment` namespace) have some overlap with Git commands.
 Generally, they offer more options than the Git commands alone.
-For example, `platform push` offers options such as `--activate` (to active an environment before pushing)
+For example, `platform push` offers options such as `--activate` (to activate an environment before pushing)
 and `--no-wait` (so you can continue working without waiting for the push to complete).
 
 For all of them, you don't need to configure a Git remote.


### PR DESCRIPTION
Fix CLI typo noticed by Mary:  `to active` -> `to activate`

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
