### PR TITLE
🚚 Deprecate Hugo aliases

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -132,6 +132,28 @@ https://{default}/:
       # Removal of the pre-launch checklist in Custom Domains section in December 2022
       "/domains/checklist.html":  { "to": "/domains/steps.html", "code": 301 }
 
+      # Deprecate Hugo aliases
+      "/guides/general/mysql-replication.html":  { "to": "/add-services/mysql/mysql-replication.html", "code": 301 }
+      "/dedicated.html":  { "to": "/dedicated-gen-2.html", "code": 301 }
+      "/dedicated/(.*)":  { "to": "/dedicated-gen-2/$1", "code": 301, "regexp": true }
+      "/guides/general/deploy-button.html":  { "to": "/development/deploy-button.html", "code": 301 }
+      "/frameworks/deploy-button.html":  { "to": "/development/deploy-button.html", "code": 301 }
+      "/development/public-ips.html":  { "to": "/development/regions.html", "code": 301 }
+      "/golive/steps/cloudflare.html":  { "to": "/domains/cdn/cloudflare.html", "code": 301 }
+      "/golive/steps/fastly.html":  { "to": "/domains/cdn/fastly.html", "code": 301 }
+      "/domains/quick-start.html":  { "to": "/domains/steps.html", "code": 301 }
+      "/administration/web/environments.html":  { "to": "/environments.html", "code": 301 }
+      "/guides/general/default-branch.html":  { "to": "/environments/default-environment.html", "code": 301 }
+      "/development/logs.html":  { "to": "/increase-observability/access-logs.html", "code": 301 }
+      "/languages/nodejs/nvm.html":  { "to": "/languages/nodejs/node-version.html", "code": 301 }
+      "/guides/general/composer-auth.htmll":  { "to": "/languages/php/composer-auth.html", "code": 301 }
+      "/GLOSSARY.html":  { "to": "/other/glossary.html", "code": 301 }
+      "/glossary.html":  { "to": "/other/glossary.html", "code": 301 }
+      "/configuration/yaml.html":  { "to": "/overview/yaml.html", "code": 301 }
+      "/administration/web/delete.html":  { "to": "/projects/delete-project.html", "code": 301 }
+      "/guides/general/region-migration.html":  { "to": "/projects/region-migration.html", "code": 301 }
+
+
 "https://search.{default}/":
     type: upstream
     upstream: "search:http"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,18 @@ To add a security transparency report for a new year (after receiving the data):
 
 The report text is in `docs/data/transparency-reports.yaml`.
 
+## Redirect pages
+
+You sometimes need to move pages around to new locations.
+To keep links from other sites working, set up redirects from the old URL to the new one.
+
+Although Hugo has a built-in `aliases` property for this purpose,
+it uses meta refresh tags and so you shouldn't use it.
+Instead, prefer redirects that return 301 codes (Moved Permanently).
+
+Set them up in the [Platform.sh routes configuration](./.platform/routes.yaml).
+For more information, see how to [redirect routes](https://docs.platform.sh/define-routes/redirects.html).
+
 ## Commit messages
 
 To help understand why changes happened and not repeat work already done,

--- a/docs/src/add-services/mysql/mysql-replication.md
+++ b/docs/src/add-services/mysql/mysql-replication.md
@@ -1,10 +1,7 @@
 ---
 title: "MariaDB/MySQL External Replication"
 sidebarTitle: "MariaDB/MySQL Replication"
-description: |
-  In rare cases, it may be useful to maintain a replica instance of your MySQL/MariaDB database outside of Platform.sh.
-aliases:
-  - /guides/general/mysql-replication.html
+description: In rare cases, it may be useful to maintain a replica instance of your MySQL/MariaDB database outside of Platform.sh.
 ---
 
 {{% description %}}

--- a/docs/src/dedicated-gen-2/_index.md
+++ b/docs/src/dedicated-gen-2/_index.md
@@ -1,8 +1,5 @@
 ---
 title: "{{% names/dedicated-gen-2 %}}"
 weight: -18
-description: |
-  {{% names/dedicated-gen-2 %}} is a robust, redundant layer. This section contains all resources concerning the {{% names/dedicated-gen-2 %}} product.
-aliases:
-  - /dedicated.html
+description: "{{% names/dedicated-gen-2 %}} is a robust, redundant layer. This section contains all resources concerning the {{% names/dedicated-gen-2 %}} product."
 ---

--- a/docs/src/dedicated-gen-2/architecture/_index.md
+++ b/docs/src/dedicated-gen-2/architecture/_index.md
@@ -3,10 +3,7 @@ title: "{{% names/dedicated-gen-2 %}} cluster specifications"
 weight: 2
 layout: single
 sidebarTitle: "Features"
-description: |
-  {{% names/dedicated-gen-2 %}} clusters are launched into a Triple Redundant configuration consisting of 3 virtual machines (VMs). This is an N+1 configuration that is sized to withstand the total loss of any one of the 3 members of the cluster without incurring any downtime.
-aliases:
-  - /dedicated/architecture.html
+description: "{{% names/dedicated-gen-2 %}} clusters are launched into a Triple Redundant configuration consisting of 3 virtual machines (VMs). This is an N+1 configuration that's sized to withstand the total loss of any one of the 3 members of the cluster without incurring any downtime."
 ---
 
 {{% description %}}

--- a/docs/src/dedicated-gen-2/architecture/deploying.md
+++ b/docs/src/dedicated-gen-2/architecture/deploying.md
@@ -2,8 +2,6 @@
 title: "Deployment"
 weight: 1
 sidebarTitle: "Deploying"
-aliases:
-  - /dedicated/architecture/deploying.html
 ---
 
 ## Deploying to Production and Staging

--- a/docs/src/dedicated-gen-2/architecture/development.md
+++ b/docs/src/dedicated-gen-2/architecture/development.md
@@ -2,10 +2,7 @@
 title: "Platform.sh development environments"
 weight: 2
 sidebarTitle: "Dev environments"
-description: |
-  {{% names/dedicated-gen-2 %}} customers have a development environment for their project that consists of a Platform.sh Grid project, typically provisioned by the Platform.sh team to reflect the amount of storage in your contract. This environment provides you with all the DevOps, Continuous Integration, Continuous Deployment, and other workflow tooling of the professional product, but segregates the performance impacts from your production hardware.
-aliases:
-  - /dedicated/architecture/development.html
+description: "{{% names/dedicated-gen-2 %}} customers have a development environment for their project that consists of a Platform.sh Grid project, typically provisioned by the Platform.sh team to reflect the amount of storage in your contract. This environment provides you with all the DevOps, Continuous Integration, Continuous Deployment, and other workflow tooling of the professional product, but segregates the performance impacts from your production hardware."
 ---
 
 ## Architecture (Development Environments)

--- a/docs/src/dedicated-gen-2/architecture/options.md
+++ b/docs/src/dedicated-gen-2/architecture/options.md
@@ -1,8 +1,6 @@
 ---
 title: "Options"
 weight: 4
-aliases:
-  - /dedicated/architecture/options.html
 ---
 
 ## Staging environments

--- a/docs/src/dedicated-gen-2/architecture/scalability.md
+++ b/docs/src/dedicated-gen-2/architecture/scalability.md
@@ -1,10 +1,7 @@
 ---
 title: "Scalability"
 weight: 5
-description: |
-  Part of the original design goal of Platform.sh’s Triple Redundant Architecture was to ensure scalability in times of load spikes outside of the bounds of the original traffic specs.  Because the cluster is configured as an N+1 architecture, we can respond to legitimate traffic events by removing a node from the cluster, upsizing it, returning it into rotation, and then repeating the process on the next node in turn.
-aliases:
-  - /dedicated/architecture/scalability.html
+description: Part of the original design goal of Platform.sh’s Triple Redundant Architecture was to ensure scalability in times of load spikes outside of the bounds of the original traffic specs.  Because the cluster is configured as an N+1 architecture, we can respond to legitimate traffic events by removing a node from the cluster, upsizing it, returning it into rotation, and then repeating the process on the next node in turn.
 ---
 
 {{% description %}}

--- a/docs/src/dedicated-gen-2/overview/_index.md
+++ b/docs/src/dedicated-gen-2/overview/_index.md
@@ -3,10 +3,7 @@ title: "{{% names/dedicated-gen-2 %}}"
 weight: 1
 sidebarTitle: "Overview"
 layout: single
-description: |
-  {{% names/dedicated-gen-2 %}} is a robust, redundant layer. It is well-suited for those who like the Platform.sh development experience but need more resources and redundancy for their production environment. It is available only with an Enterprise contract.
-aliases:
-  - /dedicated/overview.html
+description:  "{{% names/dedicated-gen-2 %}} is a robust, redundant layer. It's well-suited for those who like the Platform.sh development experience but need more resources and redundancy for their production environment. It's available only with an Enterprise contract."
 ---
 
 {{% description %}}

--- a/docs/src/dedicated-gen-2/overview/backups.md
+++ b/docs/src/dedicated-gen-2/overview/backups.md
@@ -3,8 +3,6 @@ title: "Backups"
 weight: 4
 toc: false
 description: See when backups of {{% names/dedicated-gen-2 %}} environments are taken.
-aliases:
-  - /dedicated/overview/backups.html
 ---
 
 Platform.sh takes a byte-for-byte snapshot of {{% names/dedicated-gen-2 %}} production environments every 6 hours.

--- a/docs/src/dedicated-gen-2/overview/grid.md
+++ b/docs/src/dedicated-gen-2/overview/grid.md
@@ -3,8 +3,6 @@ title: "Differences between Production and Development environments"
 weight: 5
 sidebarTitle: "Differences in development"
 description: See the differences between your Production/Staging environments (which are {{% names/dedicated-gen-2 %}}) and your Development environments (which are Grid environments).
-aliases:
-  - /dedicated/overview/grid.html
 ---
 
 With {{% names/dedicated-gen-2 %}} plans, your Production and Staging environments are dedicated virtual machines,

--- a/docs/src/dedicated-gen-2/overview/monitoring.md
+++ b/docs/src/dedicated-gen-2/overview/monitoring.md
@@ -4,8 +4,6 @@ weight: 2
 sidebarTitle: "Incident Monitoring"
 description: |
   All of our {{% names/dedicated-gen-2 %}} clusters are monitored 24/7 to ensure uptime and to measure server metrics such as available disk space, memory and disk usage, and several dozen other metrics that give us a complete picture of the health of your application’s infrastructure.
-aliases:
-  - /dedicated/overview/monitoring.html
 ---
 
 {{% description %}}

--- a/docs/src/dedicated-gen-2/overview/onboarding.md
+++ b/docs/src/dedicated-gen-2/overview/onboarding.md
@@ -3,10 +3,7 @@ title: "Onboarding process"
 weight: 3
 sidebarTitle: "Onboarding"
 toc: false
-description: |
-  On-Boarding a new {{% names/dedicated-gen-2 %}} client is a three phase process that begins the moment your contract is closed with your sales representative.
-aliases:
-  - /dedicated/overview/onboarding.html
+description: Onboarding a new {{% names/dedicated-gen-2 %}} client is a three phase process that begins the moment your contract is closed with your sales representative.
 ---
 
 {{% description %}}

--- a/docs/src/dedicated-gen-2/overview/security.md
+++ b/docs/src/dedicated-gen-2/overview/security.md
@@ -2,8 +2,6 @@
 title: "Security & data privacy"
 weight: 2
 sidebarTitle: "Security and privacy"
-aliases:
-  - /dedicated/overview/security.html
 ---
 
 ## Updates &amp; upgrades

--- a/docs/src/development/deploy-button.md
+++ b/docs/src/development/deploy-button.md
@@ -1,8 +1,5 @@
 ---
-title: "Deploy on Platform.sh"
-aliases:
-  - /frameworks/deploy-button.html
-  - /guides/general/deploy-button.html
+title: Deploy on Platform.sh
 ---
 
 Platform.sh offers a number of project templates as part of the Project Creation Wizard to help bootstrap a new project.

--- a/docs/src/development/regions.md
+++ b/docs/src/development/regions.md
@@ -5,8 +5,6 @@
 title: Regions
 weight: 14
 description: See information about Platform.sh regions, including their environmental impact and IP addresses.
-aliases:
-  - /development/public-ips.html
 ---
 
 Platform.sh offers several different regions for hosting project data.

--- a/docs/src/domains/cdn/cloudflare.md
+++ b/docs/src/domains/cdn/cloudflare.md
@@ -2,9 +2,6 @@
 title: "Cloudflare configuration"
 weight: 2
 sidebarTitle: "Cloudflare"
-toc: false
-aliases:
-  - "/golive/steps/cloudflare.html"
 ---
 
 Verify your registrar supports [`CNAME` records for apex domains](../steps/dns.md#handling-apex-domains).

--- a/docs/src/domains/cdn/fastly.md
+++ b/docs/src/domains/cdn/fastly.md
@@ -1,10 +1,7 @@
 ---
 title: "Fastly"
 weight: 1
-description: |
-  In some cases you may want to opt to use a CDN such as Fastly rather than the Platform.sh router's cache. Using a CDN can offer a better time-to-first-byte for cached content across a wider geographic region at the cost of the CDN service.
-aliases:
-  - "/golive/steps/fastly.html"
+description: In some cases you may want to opt to use a CDN such as Fastly rather than the Platform.sh router's cache. Using a CDN can offer a better time-to-first-byte for cached content across a wider geographic region at the cost of the CDN service.
 ---
 
 {{% description %}}

--- a/docs/src/domains/steps/_index.md
+++ b/docs/src/domains/steps/_index.md
@@ -3,8 +3,6 @@ title: Set up a custom domain
 weight: 2
 description: Add a custom domain to your project once it's ready to go live.
 layout: single
-aliases:
-   - /domains/quick-start.html
 ---
 
 Once your project is ready for production, replace the automatically generated domain with your own custom domain.

--- a/docs/src/environments/_index.md
+++ b/docs/src/environments/_index.md
@@ -3,8 +3,6 @@ title: "Manage Platform.sh environments"
 weight: -75
 sidebarTitle: Manage environments
 description: Learn what environments on Platform.sh are and how to take advantage of them.
-aliases: 
-  - /administration/web/environments.html
 ---
 
 On Platform.sh, an environment is a logically separate instance of an app or group of apps

--- a/docs/src/environments/default-environment.md
+++ b/docs/src/environments/default-environment.md
@@ -2,8 +2,6 @@
 title: Rename the default environment
 description: See how to change the name of your default/production environment after creating a project.
 multipleTabs: true
-aliases:
-  - /guides/general/default-branch.html
 ---
 
 You can set the name of your default/production environment when creating a project.

--- a/docs/src/increase-observability/logs/access-logs.md
+++ b/docs/src/increase-observability/logs/access-logs.md
@@ -3,8 +3,6 @@ title: "Access your logs"
 sidebarTitle: Access logs
 weight: 9
 description: Increase your knowledge of how your apps are performing by accessing their container and activity logs.
-aliases:
-  - /development/logs.html
 ---
 
 {{% legacy-regions featureIntro="Deploy hook and cron activity logs" featureShort="these logs" plural=true %}}

--- a/docs/src/increase-observability/metrics/_index.md
+++ b/docs/src/increase-observability/metrics/_index.md
@@ -2,8 +2,6 @@
 title: Monitor metrics
 weight: 5
 description: See all of the live infrastructure metrics available to give you an overview of resource usage.
-aliases:
-  - /dedicated/architecture/metrics.html
 ---
 
 Platform.sh projects are accompanied by live infrastructure metrics that provide an overview of resource usage for environments.

--- a/docs/src/languages/nodejs/node-version.md
+++ b/docs/src/languages/nodejs/node-version.md
@@ -1,10 +1,7 @@
 ---
 title: "Manage Node.js versions"
 weight: 1
-toc: false
-description: See how to manage different Node.js versions in your Platform.sh containers.
-aliases:
-    - "/languages/nodejs/nvm.html"
+description: See how to manage different Node.js versions in your Platform.sh containers."
 ---
 
 You may need to use a specific version of Node.js that isn't available in an app container for a different language.

--- a/docs/src/languages/php/composer-auth.md
+++ b/docs/src/languages/php/composer-auth.md
@@ -1,10 +1,7 @@
 ---
 title: "Authenticated Composer repositories"
 sidebarTitle: "Authenticated Composer"
-description: |
-  Some PHP projects may need to use a private, third-party Composer repository in addition to the public Packagist.org repository. Often, such third party repositories require authentication to download packages. These credentials shouldn't be located in the Git repository source code for security reasons.
-aliases:
-  - /guides/general/composer-auth.html
+description: Some PHP projects may need to use a private, third-party Composer repository in addition to the public Packagist.org repository. Often, such third party repositories require authentication to download packages. These credentials shouldn't be located in the Git repository source code for security reasons.
 ---
 
 {{% description %}}

--- a/docs/src/other/glossary.md
+++ b/docs/src/other/glossary.md
@@ -2,9 +2,6 @@
 title: "Glossary"
 weight: 1
 sidebarIgnore: true
-aliases:
-  - "/glossary.html"
-  - "/GLOSSARY.html"
 ---
 
 ## Active environment

--- a/docs/src/overview/yaml/_index.md
+++ b/docs/src/overview/yaml/_index.md
@@ -1,9 +1,7 @@
 ---
 title: YAML
 weight: 1
-description: An overview of YAML and its use at Platform.sh.
-aliases:
-  - "/configuration/yaml.html"  
+description: An overview of YAML and its use at Platform.sh.  
 ---
 
 [YAML](https://en.wikipedia.org/wiki/YAML) is a human-readable format for data serialization across languages.

--- a/docs/src/projects/delete-project.md
+++ b/docs/src/projects/delete-project.md
@@ -1,8 +1,6 @@
 ---
 title: Delete a project
 description: See how to delete projects you no longer need.
-aliases:
-  - /administration/web/delete.html
 ---
 
 To delete a project, you must be an organization owner or have the [manage plans permission](../administration/organizations.md#manage-your-organization-users)

--- a/docs/src/projects/region-migration.md
+++ b/docs/src/projects/region-migration.md
@@ -2,8 +2,6 @@
 title: Change a project's region
 sidebarTitle: Change regions
 description: See how to change the region your project is in and why you might want to do so.
-aliases:
-  - /guides/general/region-migration.html
 ---
 
 To host your project data, Platform.sh offers several [regions](../development/regions.md).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Hugo aliases use meta tags with `refresh` set to true.
For SEO, it's been suggested we should return 301 codes instead.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Changes aliases into redirects and added guidance on why.
