### PR TITLE
🐛 Fix redirect to right page

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -144,7 +144,7 @@ https://{default}/:
       "/domains/quick-start.html":  { "to": "/domains/steps.html", "code": 301 }
       "/administration/web/environments.html":  { "to": "/environments.html", "code": 301 }
       "/guides/general/default-branch.html":  { "to": "/environments/default-environment.html", "code": 301 }
-      "/development/logs.html":  { "to": "/increase-observability/access-logs.html", "code": 301 }
+      "/development/logs.html":  { "to": "/increase-observability/logs/access-logs.html", "code": 301 }
       "/languages/nodejs/nvm.html":  { "to": "/languages/nodejs/node-version.html", "code": 301 }
       "/guides/general/composer-auth.htmll":  { "to": "/languages/php/composer-auth.html", "code": 301 }
       "/GLOSSARY.html":  { "to": "/other/glossary.html", "code": 301 }

--- a/contributing/markup-format.md
+++ b/contributing/markup-format.md
@@ -51,7 +51,6 @@ The following table presents the available options:
 | `weight`             | integer            | Defines the order in which the page should appear in the sidebar. Higher numbers are lower. |
 | `toc`                | Boolean            | Optionally allows you to hide the table of contents on a page (by setting to `false`). |
 | `layout`             | `single` or `list` | Set to `single` on `_index.md` files to give them the same layout as other pages. |
-| `aliases`            | list of strings    | Optionally creates redirects to the page from the given locations. Start with `/` for root-relative locations. Start with `../` for locations relative to the current page. |
 | `description`        | string             | Appears on `list` pages as a description of the page's content. Also overrides generic content for the `<meta name="description">` tag for SEO. Can be used in the page with the `description` shortcode. |
 | `multipleTabs`       | Boolean            | If set to true, codetabs are changed across the page. So changing the tabs in one place changes them for the entire page. Useful when codetabs are repeated often with the same title (such as comparing actions in the CLI and Console). |
 | `tier`               | list of strings    | Include to put at banner at the top indicating the feature is only available to certain plan tiers, such as only Enterprise and Elite customers. |


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

One redirect from #2763 was to the wrong place. And there was still guidance on how to use Hugo aliases.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Fixed the redirect and removed the guidance.
