### PR TITLE
💄 Make table content more accessible

### DIFF
--- a/docs/config/_default/params.yaml
+++ b/docs/config/_default/params.yaml
@@ -1,6 +1,6 @@
 
 # Basics
-version: "1.0.16"
+version: "1.0.17"
 description: Platform.sh User Documentation
 author: Platform.sh
 title: User documentation

--- a/docs/themes/psh-docs/layouts/partials/page-content.html
+++ b/docs/themes/psh-docs/layouts/partials/page-content.html
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class="prose xl:prose-lg max-w-none prose-code:!mb-0 prose-h2:text-xl prose-h3:text-xl prose-h4:text-lg">
+  <div class="prose xl:prose-lg max-w-[96vw] md:max-w-none prose-code:!mb-0 prose-h2:text-xl prose-h3:text-xl prose-h4:text-lg">
     <!-- Add the stack picker for Get started section -->
     {{ if and ( eq .context.Section "get-started" ) ( ne .context.Title "Introduction" ) }}
       {{ partial "get-started/stack-picker" }}

--- a/docs/themes/psh-docs/layouts/partials/page-content.html
+++ b/docs/themes/psh-docs/layouts/partials/page-content.html
@@ -11,10 +11,10 @@
 
 <div class="grid md:grid-cols-80-20 md:gap-4">
 
-  <div class="md:order-2 md:top-24 md:sticky max-h-fullv overflow-y-scroll">
+  <div class="max-w-[92vw] md:max-w-none md:order-2 md:top-24 md:sticky md:max-h-fullv md:overflow-y-scroll border-t border-stone">
     <!-- Table of contents -->
     {{ if and (ne .context.Params.toc false) (ne .context.TableOfContents "<nav id=\"TableOfContents\"></nav>") }}
-      <div class="border border-stone px-6 pt-1 pb-4 text-sm [&_a]:text-skye-dark hover:[&_a]:underline focus:[&_a]:underline [&_ul_ul]:pl-4">
+      <div class="border border-stone border-t-0 px-6 pt-1 pb-4 mb-8 md:mb-0 text-sm [&_a]:text-skye-dark hover:[&_a]:underline focus:[&_a]:underline [&_ul_ul]:pl-4">
         <h3 class="pt-4 pb-2 font-light text-base text-slate">On this page</h3>
         {{ .context.TableOfContents }}
       </div>

--- a/docs/themes/psh-docs/layouts/partials/scripts/tailwind.html
+++ b/docs/themes/psh-docs/layouts/partials/scripts/tailwind.html
@@ -22,6 +22,9 @@
           sans: ["Overpass", "Helvetica Neue", "Helvetica", "Arial", "sans-serif"],
           mono: ["SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"]
         },
+        spacing: {
+          "fullv": "calc(100vh - 6rem)",
+        },
         typography: ({ theme }) => ({
           DEFAULT: {
             css: {
@@ -94,7 +97,9 @@
                 marginTop: '0',
               },
               table: {
-                tableLayout: 'fixed',
+                position: 'relative',
+                zIndex: '10',
+                backgroundColor: theme('colors.snow'),
               },
               tbody: {
                 'td:first-child': {
@@ -115,12 +120,13 @@
                 },
               },
               thead: {
+                position: 'sticky',
+                top: '6rem',
                 'th:first-child': {
                   paddingLeft: '0.5rem',
                 },
-                tr: {
-                  position: 'sticky',
-                  top: '6rem',
+                'th:last-child': {
+                  paddingRight: '0.5rem',
                 },
               },
               var: {

--- a/docs/themes/psh-docs/tailwind.config.js
+++ b/docs/themes/psh-docs/tailwind.config.js
@@ -37,7 +37,7 @@ module.exports = {
         "80-20": "minmax(20rem,80%) minmax(10rem,20%)",
       },
       spacing: {
-        "fullv": "100vh",
+        "fullv": "calc(100vh - 6rem)",
       },
       typography: ({ theme }) => ({
         DEFAULT: {
@@ -111,7 +111,9 @@ module.exports = {
               marginTop: '0',
             },
             table: {
-              tableLayout: 'fixed',
+              position: 'relative',
+              zIndex: '10',
+              backgroundColor: theme('colors.snow'),
             },
             tbody: {
               'td:first-child': {
@@ -132,12 +134,13 @@ module.exports = {
               },
             },
             thead: {
+              position: 'sticky',
+              top: '6rem',
               'th:first-child': {
                 paddingLeft: '0.5rem',
               },
-              tr: {
-                position: 'sticky',
-                top: '6rem',
+              'th:last-child': {
+                paddingRight: '0.5rem',
               },
             },
             var: {


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Tables on some pages ([example](https://docs.platform.sh/create-apps/hooks/hooks-comparison.html)) don't display well making it hard to access their contents.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Will wait for a more clear design decision for a final form, but form now, allowed tables to expand to the right outside the main content container. Placed above the table of contents. Might prefer a horizontal scroll, but then we lose the header staying at the top on long tables ([example](https://docs.platform.sh/create-apps/app-reference.html#top-level-properties)). Think this might work for now. :shrug:
