### PR TITLE
:memo: Replace pull request by merge request to fit GitLab terminology

### DIFF
--- a/docs/src/integrations/source/gitlab.md
+++ b/docs/src/integrations/source/gitlab.md
@@ -8,9 +8,9 @@ description: |
 
 **Features supported:**
 
-* Create a new environment when creating a branch or opening a pull request on GitLab.
+* Create a new environment when creating a branch or opening a merge request on GitLab.
 * Rebuild the environment when pushing new code to GitLab.
-* Delete the environment when merging a pull request.
+* Delete the environment when merging a request.
 
 {{% source-integration/requirements %}}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The term "pull request" doesn't exist in GitLab where "merge request" is used instead.

## What's changed

Changed "pull request" occurrences to "merge request" to fit GitLab terminology.
