### PR TITLE
:memo: Update supported and deprecated versions for PostgreSQL on DG3

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -831,13 +831,15 @@
       ]
     },
     "versions-dedicated-gen-3": {
-      "deprecated": [],
+      "deprecated": [
+        "10"
+      ],
       "supported": [
+        "15",
         "14",
         "13",
         "12",
-        "11",
-        "10"
+        "11"
       ]
     }
   },


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

[Last update](https://github.com/platformsh/platformsh-docs/pull/2777) wasn't complete as DG3 was overlooked.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

PostgreSQL supported/deprecated versions for DG3 have been updated.
DG2 section was already up-to-date.
