### PR TITLE
docs: fix backquote in mysql / go sample code

### DIFF
--- a/docs/static/files/fetch/examples/golang/mysql
+++ b/docs/static/files/fetch/examples/golang/mysql
@@ -3,6 +3,7 @@ package examples
 import (
 	"database/sql"
 	"fmt"
+
 	_ "github.com/go-sql-driver/mysql"
 	psh "github.com/platformsh/config-reader-go/v2"
 	sqldsn "github.com/platformsh/config-reader-go/v2/sqldsn"
@@ -31,35 +32,35 @@ func UsageExampleMySQL() string {
 
 	// Force MySQL into modern mode.
 	db.Exec("SET NAMES=utf8")
-	db.Exec(\x60SET sql_mode = 'ANSI,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,
+	db.Exec(`SET sql_mode = 'ANSI,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,
     NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,
-    NO_AUTO_CREATE_USER,ONLY_FULL_GROUP_BY'\x60)
+    NO_AUTO_CREATE_USER,ONLY_FULL_GROUP_BY'`)
 
 	// Creating a table.
-	sqlCreate := \x60
+	sqlCreate := `
 CREATE TABLE IF NOT EXISTS People (
 id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
 name VARCHAR(30) NOT NULL,
-city VARCHAR(30) NOT NULL)\x60
+city VARCHAR(30) NOT NULL)`
 
 	_, err = db.Exec(sqlCreate)
 	checkErr(err)
 
 	// Insert data.
-	sqlInsert := \x60
+	sqlInsert := `
 INSERT INTO People (name, city) VALUES
 ('Neil Armstrong', 'Moon'),
 ('Buzz Aldrin', 'Glen Ridge'),
-('Sally Ride', 'La Jolla');\x60
+('Sally Ride', 'La Jolla');`
 
 	_, err = db.Exec(sqlInsert)
 	checkErr(err)
 
-	table := \x60<table>
+	table := `<table>
 <thead>
 <tr><th>Name</th><th>City</th></tr>
 </thead>
-<tbody>\x60
+<tbody>`
 
 	var id int
 	var name string


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The backtick in MySQL / go sample code got hex encoded somehow, this restores them so the code can be copy pasted.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

`\x60` occurrences got replaced by ``` ` ```