### PR TITLE
Note partial fix

### DIFF
--- a/contributing/markup-format.md
+++ b/contributing/markup-format.md
@@ -175,6 +175,15 @@ This is text with inline <code>code</code>.
 {{ partial "note" (dict "Inner" $inner "context" .) }}
 ```
 
+To include variables from a shortcode, use `printf` and `%s` as in the following example:
+
+```markdown
+{{ $inner := printf `
+This is text in the %s shortcode.
+` ( .Get "name" ) }}
+{{ partial "note" (dict "Inner" $inner "context" .) }}
+```
+
 ### Footnotes
 
 To add a footnote, add two parts:

--- a/docs/layouts/shortcodes/guides/signup.md
+++ b/docs/layouts/shortcodes/guides/signup.md
@@ -90,8 +90,7 @@ That's expected because you haven't provided configuration files yet.
 You add them in the next step.
 Remember to have a local clone of your project.
 
-{{ $inner := `
-
+{{ $inner := printf `
 If you're integrating a repository to Platform.sh that contains a number of open pull requests,
 don't use the default integration options.
 Projects are limited to three\* development environments (active and deployed branches or pull requests)
@@ -104,10 +103,9 @@ Instead, each service integration should be made with the following flag:
 You can then go through this guide and activate the environment when you're ready to deploy
 
 \* You can purchase additional development environments at any time in the Console.
-Open your {{ .Get "name" }} project and select **Edit plan**.
+Open your %s project and select **Edit plan**.
 Add additional **Environments**, view a cost estimate, and confirm your changes.
-
-`}}
+` ( .Get "name" ) }}
 {{ partial "note" (dict "Inner" $inner "context" .) }}
 
 Now that you have a local Git repository, a Platform.sh project, and a way to push code to that project, you're all set to continue.

--- a/docs/themes/psh-docs/layouts/partials/note.html
+++ b/docs/themes/psh-docs/layouts/partials/note.html
@@ -13,7 +13,7 @@
 {{ end }}
 <div class="bg-{{ $bg }} p-4 mb-4 [&>p:last-child]:mb-0 [&>h3]:mt-0" role="alert">
   {{ if ne $title "none" }}
-    <h3 class="font-bold text-base">{{ $title }}</h3>
+  <h3 class="font-bold text-base">{{ $title }}</h3>
   {{ end }}
   <p>{{ .Inner | .context.Page.RenderString }}</p>
 </div>


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes https://github.com/platformsh/platformsh-docs/issues/2805

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

Pulling in the note partial from the psh-docs theme was resulting in formatting issues (HTML visible for the note "title"). 

Within the `signup` shortcode, the `.Get "name"` was also not rendering, so I replaced with `printf`.
