### PR TITLE
🐛 Restore background to warning notes

### DIFF
--- a/docs/themes/psh-docs/tailwind.config.js
+++ b/docs/themes/psh-docs/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
     "./themes/**/content/**/*.{html,md}",
     "./static/scripts/xss/**/*.js"
   ],
-  safelist: ['-rotate-90'],
+  safelist: ['-rotate-90','bg-pink-light'],
   theme: {
     extend: {
       backgroundPosition: {


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Because the background for warning notes wasn't used anywhere directly (only as a variable), Tailwind removed it for production. So they got no background. [Example](https://docs.platform.sh/administration/organizations.html#manage-your-organization-users)
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Added it to the list of classes always included.
[Example fixed](https://warning-note-fix-tfkrw3a-652soceglkw4u.eu-3.platformsh.site/administration/organizations.html#manage-your-organization-users)