### PR TITLE
🔥 Redirect index pages in get started section

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -152,6 +152,11 @@ https://{default}/:
       "/configuration/yaml.html":  { "to": "/overview/yaml.html", "code": 301 }
       "/administration/web/delete.html":  { "to": "/projects/delete-project.html", "code": 301 }
       "/guides/general/region-migration.html":  { "to": "/projects/region-migration.html", "code": 301 }
+      
+      # Remove get started index pages
+      "/get-started/deploy.html(.*)" : { "to": "/get-started/deploy/init.html$1", "code": 301, "regexp": true }
+      "/get-started/add-data.html(.*)" : { "to": "/get-started/add-data/branch.html$1", "code": 301, "regexp": true }
+      "/get-started/monitor-and-troubleshoot.html(.*)" : { "to": "/get-started/monitor-and-troubleshoot/log.html$1", "code": 301, "regexp": true }
 
 "https://search.{default}/":
     type: upstream


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

People were getting confused about the index pages in the Get started section. See Context for an example.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Redirected those pages to their first children, including regex for stacks in the URL.