### PR TITLE
🐛 Avoid dupliction in DG3 service table

### DIFF
--- a/docs/layouts/shortcodes/gen-3-services.html
+++ b/docs/layouts/shortcodes/gen-3-services.html
@@ -4,7 +4,8 @@
     <th>Supported versions</th>
   </tr>
   {{- range $image, $info := .Site.Data.registry -}}
-    {{- if and (isset $info "versions-dedicated-gen-3") (ne $image "redis-persistent") -}}
+    <!-- Skip persistent Redis and MySQL to avoid duplication -->
+    {{- if and (isset $info "versions-dedicated-gen-3") (ne $image "redis-persistent") (ne $image "mysql") -}}
       {{- $label :=  index $info "name" -}}
       {{- $versions := index ( index $info "versions-dedicated-gen-3") "supported" -}}
       {{- $docs_link := index (index $info "docs") "url" -}}
@@ -14,26 +15,12 @@
           {{- $service_versions := "" -}}
           {{- range $versions -}}
             {{- if eq ( len $service_versions ) 0 -}}
-              {{- if eq $image "mysql" -}}
-                {{- $stripped := index ( split . " ") 0 -}}
-                {{- $service_versions = printf "%s%s" $service_versions $stripped -}}
-              {{- else -}}
-                {{- $service_versions = printf "%s%s" $service_versions . -}}
-              {{- end -}}
+              {{- $service_versions = printf "%s%s" $service_versions . -}}
             {{- else -}}
-              {{- if eq $image "mysql" -}}
-                {{- $stripped := index ( split . " ") 0 -}}
-                {{- $service_versions = printf "%s, %s" $service_versions $stripped -}}
-              {{- else -}}
-                {{- $service_versions = printf "%s, %s" $service_versions . -}}
-              {{- end -}}
+              {{- $service_versions = printf "%s, %s" $service_versions . -}}
             {{- end -}}
           {{- end -}}
-          {{- if eq $image "mysql" -}}
-            {{ printf "%s (all using Galera, for replication)" $service_versions }}
-          {{- else -}}
-            {{ $service_versions }}
-          {{- end -}}
+          {{ $service_versions }}
         </td>                                                                                                                                                                                                                                                                                                                                                                          </td>
       </tr>
     {{- end -}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

With both MariaDB and MySQL, the [services table for DG3](https://docs.platform.sh/dedicated-gen-3/overview.html#available-services) had duplication.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Removed MySQL from the list.
