### PR TITLE
🔍️ Improve title tags

### DIFF
--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -1,6 +1,6 @@
 # Basics
 baseURL: /
-title: Platform.sh Documentation
+title: Platform.sh Docs
 author: Platform.sh
 description: Platform.sh User Documentation
 

--- a/docs/themes/psh-docs/layouts/partials/head/head.html
+++ b/docs/themes/psh-docs/layouts/partials/head/head.html
@@ -1,7 +1,15 @@
 <head>
 
   <!-- Title -->
-  <title>{{ .Page.Title | .RenderString }} · {{ .Site.Title }}</title>
+  {{ $title := .Page.Title | .RenderString }}
+  <!-- If space, add the site name -->
+  {{ if lt ( len $title ) 42 }}
+    {{ $title = printf "%s | %s" ( .Page.Title | .RenderString ) .Site.Title }}
+  <!-- Set a max size of 60 characters -->
+  {{ else if gt ( len $title ) 60 }}
+    {{ $title = truncate 60 "" $title }}
+  {{ end }}
+  <title>{{ $title }}</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   {{ if isset .Site.Params "favicon" }}

--- a/docs/themes/psh-docs/layouts/partials/head/twittercard.html
+++ b/docs/themes/psh-docs/layouts/partials/head/twittercard.html
@@ -10,7 +10,7 @@
 {{ if .Page.IsHome }}
     <meta name="twitter:title" content="{{ .Site.Params.meta.twittercard.title }}">
 {{ else }}
-    <meta name="twitter:title" content="{{ .Title }}">
+    <meta name="twitter:title" content="{{ .Title | .RenderString }}">
 {{ end }}
 
 {{ if isset .Site.Params "meta" }}


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Titles for Twitter cards (which show up elsewhere, such as when linking to a page in Slack) didn't render shortcodes.

The titles for some pages were too long: over 60 characters. See Context.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
- Rendered titles properly
- Set a limit of 60 characters with the site title only in cases of shorter page titles
