### PR TITLE
Add last step in procedure on third-party TLS certificates

### DIFF
--- a/docs/src/domains/cdn/managed-fastly.md
+++ b/docs/src/domains/cdn/managed-fastly.md
@@ -33,16 +33,15 @@ This allows for encryption of all traffic between your users and your app.
  
 If you use a Fastly CDN provided by Platform.sh, 
 you can provide your own third-party TLS certificates for an additional fee.
-If you don't have one, set up a [mount](../../create-apps/app-reference.md#mounts)
-that isn't accessible to the web.
+
+To do so, if you don't have one, 
+set up a [mount](../../create-apps/app-reference.md#mounts) that isn't accessible to the web.
 Use an environment with access limited to Platform.sh support and trusted users.
 [Transfer](../../development/file-transfer.md) each certificate, its unencrypted private key, 
 and the intermediate certificate to the mount.
+To notify Platform.sh that a certificate is to be added to your CDN configuration,
+[create a support ticket](../../overview/get-support.md#create-a-support-ticket).
  
 Note that when you add your own third-party TLS certificates,
 you are responsible for renewing them in due time.
 Failure to do so may result in outages and compromised security for your site.
- 
-If you need an Extended Validation TLS certificate, 
-you can get it from any TLS provider.
-To add it to your CDN configuration, [create a support ticket](../../overview/get-support.md#create-a-support-ticket).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

In the section on third-party certificates, the last step was missing. See context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Reworked the TLS certificates section to add the missing step. 
