### PR TITLE
Highlight Blackfire as recommended observability service

### DIFF
--- a/docs/src/increase-observability/integrate-observability/_index.md
+++ b/docs/src/increase-observability/integrate-observability/_index.md
@@ -8,4 +8,4 @@ The recommended observability service to optimize your code as a Platform.sh use
 
 Platform.sh also supports third-party services such as New Relic and Tideways.
 Note that these third-party services have their own associated cost,
-are language-specific and may not be available for all languages.
+are language-specific, and may not be available for all languages.

--- a/docs/src/increase-observability/integrate-observability/_index.md
+++ b/docs/src/increase-observability/integrate-observability/_index.md
@@ -1,9 +1,11 @@
 ---
 title: "Integrate observability"
 weight: 10
-description: Find a third-party observability service for optimizing your code.
+description: Find an observability service to optimize your code.
 ---
 
-Platform.sh supports a number of observability services for optimizing your code.
-These are third-party services and may have their own associated cost.
-They're language-specific and may not be available for all languages.
+The recommended observability service to optimize your code as a Platform.sh user is Blackfire.
+
+Platform.sh also supports third-party services such as New Relic and Tideways.
+Note that these third-party services have their own associated cost,
+are language-specific and may not be available for all languages.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

On the [Integrate observability](https://docs.platform.sh/increase-observability/integrate-observability.html) page, there was no distinction between Blackfire and other third-party observability services supported by Platform.sh.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

The short introduction was reworked to make it clear that Blackfire is the recommended observability service and highlight the downsides of using a third-party service instead.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
