### PR TITLE
💚 Don't fail on non-existant branches

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -30,11 +30,10 @@ jobs:
         run: |
           BRANCH_TITLE=pr-${{ github.event.number }}
           # Check if environment exists
-          BRANCH=$(platform env --pipe --columns title | grep $BRANCH_TITLE)
-          # If the environment doesn't exist, create it it
-          if [[ -z $BRANCH ]]; then
-            platform branch $BRANCH_TITLE main
-          # If it does exist, update it
-          else
+          if $(platform env --pipe --columns title | grep -q $BRANCH_TITLE); then
+            # If the environment exists, update it
             platform push --force -e $BRANCH_TITLE --activate
+          else
+            # If it doesn't exist, create it
+            platform branch $BRANCH_TITLE main
           fi


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

I forgot `grep` exists with an error if it finds nothing, meaning the workflow always exists as a failure if the branch doesn't exist.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Shiften the grep check to the if statement to allow it to not find something and not return an error
