### PR TITLE
📝 Clarify need to be GitHub admin

### DIFF
--- a/docs/src/integrations/source/github.md
+++ b/docs/src/integrations/source/github.md
@@ -13,7 +13,8 @@ To integrate your Platform.sh project with an existing GitHub repository,
 [generate a new token](https://github.com/settings/tokens/new).
 Fine-grained access tokens aren't currently supported.
 For the integration to work,
-your GitHub user needs to have permission to push code to the repository.
+your GitHub user needs to have permission to push code to the repository and manage its webhooks.
+This means your user needs to be a repository admin.
 
 Give your token a description and then ensure the token has the scopes that correspond to what you want to do:
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
It wasn't clear that the user who added a token for a GitHub integration needed to be an admin. See Context.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Tried to clarify.