### PR TITLE
🐛 Fix index of replacement string

### DIFF
--- a/docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -133,7 +133,7 @@ title=In the Console
 <!-- Bitbucket Cloud is the only one without an option to clone parent data -->
 {{ $cloneOption := "" }}
 {{ if ne $source "Bitbucket" }}
-  {{ $cloneOption = printf `| <code>%[1]s-requests-clone-parent-data</code> | <code>true</code> | Whether to clone data from the parent environment when creating a %[2]s request environment. |` $pull }}
+  {{ $cloneOption = printf `| <code>%[1]s-requests-clone-parent-data</code> | <code>true</code> | Whether to clone data from the parent environment when creating a %[1]s request environment. |` $pull }}
 {{ end }}
 
 <!-- Add options only for certainly integrations -->


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Had an index for a non-existing replacement string. Led to `%!s(BADINDEX)` in source integrations ([example in second to last table row](https://docs.platform.sh/integrations/source/github.html#2-enable-the-integration))

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Fixed it to use the same string both times.