### PR TITLE
🐛 Have example output match example input

### DIFF
--- a/docs/src/define-routes/_index.md
+++ b/docs/src/define-routes/_index.md
@@ -103,7 +103,7 @@ you see the following resolved routes (assuming `example.com` is your default do
 
 ```json
 {
-  "http://example.com/": {
+  "https://example.com/": {
     "primary": true,
     "id": null,
     "attributes": {},
@@ -111,7 +111,7 @@ you see the following resolved routes (assuming `example.com` is your default do
     "upstream": "app",
     "original_url": "https://{default}"
   },
-  "http://subdomain.example.com/": {
+  "https://subdomain.example.com/": {
     "primary": false,
     "id": null,
     "attributes": {},


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The [example setting for trailing slashes](https://docs.platform.sh/define-routes.html#trailing-slashes) with routes uses HTTPS, but the example output didn't.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
Made it be also HTTPS