### PR TITLE
:memo: Add  Xdebug as available on PHP 8.2

### DIFF
--- a/docs/data/php_extensions.yaml
+++ b/docs/data/php_extensions.yaml
@@ -1149,6 +1149,7 @@ grid:
       - tideways
       - tidy
       - uuid
+      - xdebug
       - xsl
       - yaml
     default:


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Xdebug is now available on PHP 8.2.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Updated php-extensions.yaml file accordingly.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
