### PR TITLE
💚 Remove false positives in broken link check

### DIFF
--- a/.github/workflows/scheduled-check-links.yaml
+++ b/.github/workflows/scheduled-check-links.yaml
@@ -19,7 +19,7 @@ jobs:
         run: wget --quiet -c "https://github.com/raviqqe/muffet/releases/download/v$MUFFET_VERSION/muffet_${MUFFET_VERSION}_Linux_x86_64.tar.gz" -O - | tar -xz
 
       - name: Check links
-        run: ./muffet --json --buffer-size=12192 --rate-limit=1 --max-connections-per-host=10 --color=always --header="Accept-Encoding:gzip, deflate" --header="User-Agent:Mozilla/5.0 (Windows NT 10.0) Gecko/20100101 Firefox/91.0" -e=console.platform.sh/projects/create-project -e=cloud.orange-business.com -e=developers.cloudflare.com -e=discord.com -e=pptr.dev -e=mvnrepository.com -e="https://github\.com.*#L\d*-L\d*" -e="https://dev.mysql.com/doc/refman/en/" https://docs.platform.sh > broken_links.json
+        run: ./muffet --json --buffer-size=12192 --rate-limit=1 --max-connections-per-host=10 --color=always --header="Accept-Encoding:gzip, deflate" --header="User-Agent:Mozilla/5.0 (Windows NT 10.0) Gecko/20100101 Firefox/91.0" -e=console.platform.sh/projects/create-project -e=cloud.orange-business.com -e=developers.cloudflare.com -e=discord.com -e=pptr.dev -e=mvnrepository.com -e="https://github\.com.*#L\d*-L\d*" -e="https://dev.mysql.com/doc/refman/en/" -e="https://www.microsoft.com/en-us/trust-center/privacy/data-management" https://docs.platform.sh > broken_links.json
       
       - name: Create Markdown file of broken links
         if: ${{ always() }}

--- a/contributing/markup-format.md
+++ b/contributing/markup-format.md
@@ -175,12 +175,10 @@ This is text with inline <code>code</code>.
 {{ partial "note" (dict "Inner" $inner "context" .) }}
 ```
 
-To include variables from a shortcode, use `printf` and `%s` as in the following example:
+To include variables from a shortcode, use `print` as in the following example:
 
 ```markdown
-{{ $inner := printf `
-This is text in the %s shortcode.
-` ( .Get "name" ) }}
+{{ $inner := print `This is text in the ` ( .Get "name" ) ` shortcode.`}}
 {{ partial "note" (dict "Inner" $inner "context" .) }}
 ```
 

--- a/docs/layouts/shortcodes/cli-installation.html
+++ b/docs/layouts/shortcodes/cli-installation.html
@@ -1,4 +1,4 @@
-<p>To install the CLI, use a <a href="https://github.com/platformsh/cli#bash-installer">Bash installation script</a>.
+<p>To install the CLI, use a <a href="https://github.com/platformsh/cli#user-content-bash-installer">Bash installation script</a>.
 You can also install with <a href="https://brew.sh/">Homebrew</a> (on Linux, macOS, or the Windows Subsystem for Linux)
 or <a href="https://scoop.sh/">Scoop</a> (on Windows).</p>
 

--- a/docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -1,8 +1,8 @@
 <!-- Handle the source name in a few varieties-->
 {{ $source := .Get "source" }}
 {{ $source_variable :=  replace $source " " "_" | lower }}
-{{ $token_variable := printf "%s_ACCESS_TOKEN" $source_variable | upper }}
-{{ $base_url_variable := printf "%s_URL" $source_variable | upper }}
+{{ $token_variable := print $source_variable "_ACCESS_TOKEN" | upper }}
+{{ $base_url_variable := print $source_variable "_URL" | upper }}
 <!-- Handle GitLab's MRs -->
 {{ $pull := "pull" }}
 {{ if eq $source "GitLab" }}{{ $pull = "merge" }}{{ end }}
@@ -12,11 +12,11 @@
   so we handle the list in the Console differently -->
 {{ $tokenConsoleInstructions := "" }}
 {{ if or ( eq $source "GitHub" ) ( eq $source "GitLab" ) }}
-  {{ $tokenConsoleInstructions = printf `
+  {{ $tokenConsoleInstructions = print `
 1. Add the [token you generated](#1-generate-a-token).
-1. Optional: If your %[1]s project isn't hosted at %[2]s.com, enter your %[1]s custom domain.
+1. Optional: If your ` $source ` project isn't hosted at ` ( $source | lower ) `.com, enter your ` $source ` custom domain.
 1. Click **Continue**.
-1. Choose the repository to use for the project.` $source ( $source | lower ) }}
+1. Choose the repository to use for the project.` }}
 
 {{ else if ( eq $source "Bitbucket" )}}
 {{ $tokenConsoleInstructions = `
@@ -38,7 +38,7 @@
 {{ $baseUrlServer := "GitLab" }}
 {{ $baseUrlSource := "https://gitlab.com" }}
 {{ $baseUrlExample := "" }}
-{{ $baseUrlVariable := printf "--base-url {{< variable %s >}} " $base_url_variable }}
+{{ $baseUrlVariable := print `--base-url {{< variable ` $base_url_variable ` >}} ` }}
 {{ $exampleUrl := "example.com" }}
 {{ if eq $source "GitHub" }}
   {{ $baseUrlServer = "GitHub Enterprise" }}
@@ -49,10 +49,10 @@
   {{ $baseUrlExample = "--base-url https://example.com " }}
 {{ end }}
 {{ if or ( eq $source "GitHub" ) ( eq $source "GitLab" ) }}
-{{ $baseUrlExpanation = printf `- <code>%[1]s</code> is the base URL for your %[2]s server if you self-host.
-  If you use <code>%[3]s</code>, don't include the <code>base-url</code> flag.` $base_url_variable $baseUrlServer $baseUrlSource }}
+{{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your ` $baseUrlServer ` server if you self-host.
+  If you use <code>` $baseUrlSource `</code>, don't include the <code>base-url</code> flag.` }}
 {{ else if ( eq $source "Bitbucket server" )}}
-  {{ $baseUrlExpanation = printf `- <code>%[1]s</code> is the base URL for your Bitbucket server.` $base_url_variable }}
+  {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your Bitbucket server.` }}
   {{ $baseUrlExample = "--base-url https://example.com " }}
 {{ else if ( eq $source "Bitbucket" ) }}
   {{ $baseUrlVariable = "" }}
@@ -61,12 +61,12 @@
 
 <!-- Bitbucket has a different access pattern for each version,
      The initial settings are used for GitLab and GitHub -->
-{{ $accessFlagsVariable := printf "--token {{< variable %s >}}" $token_variable }}
-{{ $accessFlagsExplanation := printf `- <code>%s</code> is the [token you generated](#1-generate-a-token).` $token_variable }}
+{{ $accessFlagsVariable := print `--token {{< variable ` $token_variable ` >}}`  }}
+{{ $accessFlagsExplanation := print `- <code>` $token_variable `</code> is the [token you generated](#1-generate-a-token).` }}
 {{ $accessFlagsExample := "--token abc123" }}
 {{ if ( eq $source "Bitbucket server" ) }}
-  {{ $accessFlagsVariable = printf "--username {{< variable USERNAME >}} %s" $accessFlagsVariable }}
-  {{ $accessFlagsExample = printf "--username user@example.com %s" $accessFlagsExample}}
+  {{ $accessFlagsVariable = print "--username {{< variable USERNAME >}} " $accessFlagsVariable }}
+  {{ $accessFlagsExample = print "--username user@example.com " $accessFlagsExample}}
 {{ end }}
 {{ if ( eq $source "Bitbucket" ) }}
   {{ $accessFlagsVariable = "--key {{< variable CONSUMER_KEY >}} --secret {{< variable CONSUMER_SECRET >}} " }}
@@ -77,29 +77,28 @@
 
 <!-- Generate the code tabs
      The strings above are added in by their index at the end of the literal string -->
-{{ $Inner := printf `
+{{ $Inner := print `
 +++
 title=Using the CLI
 +++
 
 Run the following command:
 
-<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type %[1]s \
-%[2]s --repository {{< variable "OWNER/REPOSITORY" >}} \
-%[3]s--project {{< variable "PLATFORM_SH_PROJECT_ID" >}}</code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \
+` $accessFlagsVariable ` --repository {{< variable "OWNER/REPOSITORY" >}} \
+` $baseUrlVariable ` --project {{< variable "PLATFORM_SH_PROJECT_ID" >}}</code></pre></div>
 
-
-%[4]s
-- <code>OWNER/REPOSITORY</code> is the name of the repository in %[5]s.
+` $accessFlagsExplanation `
+- <code>OWNER/REPOSITORY</code> is the name of the repository in ` $source `.
 - <code>PLATFORM_SH_PROJECT_ID</code> is the ID of your Platform.sh project.
-%[6]s
+` $baseUrlExpanation `
 
-For example, if your repository is located at <code>https://%[7]s/platformsh/platformsh-docs</code>,
+For example, if your repository is located at <code>https://` $exampleUrl `/platformsh/platformsh-docs</code>,
 the command is similar to the following:
 
-<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type %[1]s \
-%[8]s --repository platformsh/platformsh-docs \
-%[9]s--project abcdefgh1234567</code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \
+` $accessFlagsExample ` --repository platformsh/platformsh-docs \
+` $baseUrlExample `--project abcdefgh1234567</code></pre></div>
 
 <--->
 +++
@@ -110,12 +109,12 @@ title=In the Console
 1. Click {{< icon settings >}} **Settings**.
 1. Under **Project settings**, click **Integrations**.
 1. Click **+ Add integration**.
-1. Under **%[5]s**, click **+ Add**.
-%[10]s
+1. Under **` $source `**, click **+ Add**.
+` $tokenConsoleInstructions `
 1. Check that the other options match what you want.
 1. Click **Add integration**.
 
-` $source_variable $accessFlagsVariable $baseUrlVariable $accessFlagsExplanation $source $baseUrlExpanation $exampleUrl $accessFlagsExample $baseUrlExample $tokenConsoleInstructions }}
+` }}
 {{ partial "codetabs/tabs" ( dict "Inner" $Inner "Page" .Page ) }}
 
 <p>In both the CLI and Console, you can choose from the following options:</p>
@@ -123,8 +122,8 @@ title=In the Console
 <!-- Build table row for draft/WIP requests -->
 {{ $draftOption := "" }}
 {{ if or ( eq $source "GitHub" ) ( eq $source "GitLab") }}
-  {{ $draftOption = printf `
-  | <code>build-draft-%[1]s-requests</code> | <code>true</code> | Whether to also track and build draft %[1]s requests. Automatically disabled when %[1]s requests aren't built. |` $pull }}
+  {{ $draftOption = print `
+  | <code>build-draft-` $pull `-requests</code> | <code>true</code> | Whether to also track and build draft ` $pull ` requests. Automatically disabled when ` $pull ` requests aren't built. |` }}
 {{ end }}
 {{ if eq $source "GitLab" }}
   {{ $draftOption = replace $draftOption "-draft-" "-wip-" }}
@@ -133,7 +132,7 @@ title=In the Console
 <!-- Bitbucket Cloud is the only one without an option to clone parent data -->
 {{ $cloneOption := "" }}
 {{ if ne $source "Bitbucket" }}
-  {{ $cloneOption = printf `| <code>%[1]s-requests-clone-parent-data</code> | <code>true</code> | Whether to clone data from the parent environment when creating a %[1]s request environment. |` $pull }}
+  {{ $cloneOption = print `| <code>` $pull `-requests-clone-parent-data</code> | <code>true</code> | Whether to clone data from the parent environment when creating a ` $pull ` request environment. |` }}
 {{ end }}
 
 <!-- Add options only for certainly integrations -->
@@ -146,13 +145,11 @@ title=In the Console
 {{ end }}
 
 <!-- Create the table for the options -->
-{{ $OptionsTable := printf `
+{{ $OptionsTable := print `
 | CLI flag | Default | Description |
 | -------- | ------- | ----------- |
 | <code>fetch-branches</code> | <code>true</code> | Whether to track all branches and create inactive environments from them. |
-| <code>prune-branches</code> | <code>true</code> | Whether to delete branches from Platform.sh that don't exist in the %[1]s repository. Automatically disabled when fetching branches is disabled. |
-| <code>build-%[2]s-requests</code> | <code>true</code> | Whether to track all %[2]s requests and create active environments from them, which builds the %[2]s request. |%[3]s
-%[4]s%[5]s
-
-` $source $pull $draftOption $cloneOption $extraOption }}
+| <code>prune-branches</code> | <code>true</code> | Whether to delete branches from Platform.sh that don't exist in the ` $source ` repository. Automatically disabled when fetching branches is disabled. |
+| <code>build-` $pull `-requests</code> | <code>true</code> | Whether to track all ` $pull ` requests and create active environments from them, which builds the ` $pull ` request. |` $draftOption `
+` $cloneOption $extraOption }}
 {{ $OptionsTable | markdownify }}

--- a/docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -93,7 +93,7 @@ Run the following command:
 - <code>PLATFORM_SH_PROJECT_ID</code> is the ID of your Platform.sh project.
 ` $baseUrlExpanation `
 
-For example, if your repository is located at <code>https://` $exampleUrl `/platformsh/platformsh-docs</code>,
+For example, if your repository is located at <code>https&colon;//` $exampleUrl `/platformsh/platformsh-docs</code>,
 the command is similar to the following:
 
 <div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

In #2213, the scheduled broken link check was showing links that weren't problems but seemed to be.
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
- Made the example URLs in inline code not display as links by escaping the colon.
- Skipped https://www.microsoft.com/en-us/trust-center/privacy/data-management as it always times out.
- Fixed a link to GitHub headers (which work in browsers but need `user-content-` as a prefix for the check)

Along the way, I was confused by the content reuse in source integrations. So I changed it so that the variables are no longer at the end of the string but in the place in the text where they belong. At least for me, this was much, much clearer than having to check index numbers. I didn't go back and change other examples elsewhere, but I would stick to this as an approach going forwad if it makes sense to you.
