### PR TITLE
More recent version as example

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -68,7 +68,7 @@ The following basic app configuration is sufficient to run most Elixir applicati
 ```yaml {location=".platform.app.yaml"}
 name: app
 
-type: elixir:1.9
+type: elixir:1.13
 
 variables:
     env:


### PR DESCRIPTION
1.9 is pretty old, and deprecated.
might want to update to 1.13 since that's the latest we support at the moment