### PR TITLE
Define Route for multi-app: add web.locations definition example

### DIFF
--- a/docs/src/create-apps/multi-app.md
+++ b/docs/src/create-apps/multi-app.md
@@ -235,10 +235,18 @@ Assume you have an app for a CMS and another app for the frontend defined as fol
     ...
 ```
 
-You could then define routes for your apps as follows:
+You don't need to define a route for each app in the repository.
+If an app isn't specified, then it isn't accessible to the web.
+You can achieve the same thing by defining the app as  [`worker`](./app-reference.md#workers).
+
+Below are two approaches to configuring the Router container: using subdomains, and using subdirectories.
+
+#### Using subdomains per application
+
+You can define routes for your apps as follows:
 
 ```yaml {location=".platform/routes.yaml"}
-"https://backend.{default}/":
+"https://api.{default}/":
     type: upstream
     upstream: "cms:http"
 "https://{default}/":
@@ -248,12 +256,61 @@ You could then define routes for your apps as follows:
 
 So if your default domain is `example.com`, that means:
 
-* `https://backend.example.com/` is served by your CMS app.
+* `https://api.example.com/` is served by your CMS app.
 * `https://example.com/` is served by your frontend app.
 
-You don't need to define a route for each app.
-If an app isn't specified, then it isn't accessible to the web.
-You can achieve the same thing by defining the app as  [`worker`](./app-reference.md#workers).
+{{< note >}}
+Be aware that using a subdomain might [double your network traffic](https://nickolinger.com/blog/2021-08-04-you-dont-need-that-cors-request/),
+so consider using a path like `https://{default}/api` instead.
+{{< /note >}}
+
+#### Using subdirectories per application
+
+Using the same example, you could also define your routes as follows:
+
+```yaml {location=".platform/routes.yaml"}
+"https://{default}/":
+    type: upstream
+    upstream: "frontend:http"
+"https://{default}/api":
+    type: upstream
+    upstream: "cms:http"
+```
+
+Then you need to configure each app `web.locations` to match these paths:
+
+```yaml {location=".platform/applications.yaml"}
+-   name: cms
+    type: php:8.1
+    source:
+        root: drupal
+    ...
+    web:
+        locations:
+            "/api":
+                passthru: "/api/index.php"
+                root: "public"
+                index:
+                    - index.php
+
+-   name: frontend
+    type: nodejs:16
+    source:
+        root: react
+    ...
+    web:
+        locations:
+            "/":
+                passthru: "/index.js"
+                root: "build"
+                index:
+                    - index.js
+```
+
+So if your default domain is `example.com`, that means:
+
+* `https://example.com/` is served by your frontend app.
+* `https://example.com/api` is served by your CMS app.
 
 ## Relationships
 

--- a/docs/src/define-routes/_index.md
+++ b/docs/src/define-routes/_index.md
@@ -65,51 +65,7 @@ Redirects from `http` to `https` are generally included by default and don't nee
 
 ### Multi-app route definition
 
-You can define routes for multiple apps per environment.
-For example, if you have a front-end app with the name `app` and another app with the name `api`,
-you could define your routes like this:
-
-```yaml {location=".platform/routes.yaml"}
-"https://{default}/":
-    type: upstream
-    upstream: "app:http"
-"https://{default}/api":
-    type: upstream
-    upstream: "api:http"
-```
-
-The route for the `api` app could be anything in the domain, even a subdomain like `https://api.{default}/`.
-Be aware that using a subdomain might [double your network traffic](https://nickolinger.com/blog/2021-08-04-you-dont-need-that-cors-request/),
-so consider using a path like `https://{default}/api` instead.
-
-Then you need to configure each app `web.locations` with the following:
-* `web.locations` definition for the `app` app:
-
-```yaml {location="app/.platform.app.yaml"}
-web:
-  locations:
-    "/":
-      passthru: "/index.php"
-      root: "public"
-      index:
-        - index.php
-```
-
-* `web.locations` definition for `api` app:
-
-```yaml {location="api/.platform.app.yaml"}
-web:
-  locations:
-    "/api":
-      passthru: "/api/index.php"
-      root: "public"
-      index:
-        - index.php
-```
-
-{{< note >}}
-If using a path like `https://{default}/<something>` for your app, you will need to repeat `<something>` in your `web.locations` definition, as shown in the `api` app example above.
-{{< /note >}}
+The specifics of configuring the Router container for multiple applications is explored in detail in the [Multiple apps](/create-apps/multi-app.md#routes) documentation.
 
 ## Trailing slashes
 

--- a/docs/src/define-routes/_index.md
+++ b/docs/src/define-routes/_index.md
@@ -82,6 +82,35 @@ The route for the `api` app could be anything in the domain, even a subdomain li
 Be aware that using a subdomain might [double your network traffic](https://nickolinger.com/blog/2021-08-04-you-dont-need-that-cors-request/),
 so consider using a path like `https://{default}/api` instead.
 
+Then you need to configure each app `web.locations` with the following:
+* `web.locations` definition for the `app` app:
+
+```yaml {location="app/.platform.app.yaml"}
+web:
+  locations:
+    "/":
+      passthru: "/index.php"
+      root: "public"
+      index:
+        - index.php
+```
+
+* `web.locations` definition for `api` app:
+
+```yaml {location="api/.platform.app.yaml"}
+web:
+  locations:
+    "/api":
+      passthru: "/api/index.php"
+      root: "public"
+      index:
+        - index.php
+```
+
+{{< note >}}
+If using a path like `https://{default}/<something>` for your app, you will need to repeat `<something>` in your `web.locations` definition, as shown in the `api` app example above.
+{{< /note >}}
+
 ## Trailing slashes
 
 All defined routes have at least a slash in the path.

--- a/docs/src/define-routes/_index.md
+++ b/docs/src/define-routes/_index.md
@@ -116,7 +116,7 @@ If using a path like `https://{default}/<something>` for your app, you will need
 All defined routes have at least a slash in the path.
 So you might define routes for 2 apps named `app` and `api` as follows:
 
-```yaml {location==".platform/routes.yaml"}
+```yaml {location=".platform/routes.yaml"}
 
 "https://{default}":
     type: upstream
@@ -454,7 +454,7 @@ plus the default redirect from HTTP to HTTPS.
 They aren't the final generated routes.
 
 ```bash
-$ platform environment:routes 
+$ platform environment:routes
 Routes on the project Example (abcdef123456), environment main (type: production):
 +---------------------------+----------+---------------------------+
 | Route                     | Type     | To                        |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
When i first try to create a multi-app project, i can't make it till @chadwcarlson helps me debugging my `web.locations` definition into my `.platform.app.yaml` file, adding this `passthru: /api/index.php` settings.
So i guess it worths to be mention here. 

Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
