### PR TITLE
:memo: Add command to restart PHP processes in app container

### DIFF
--- a/docs/src/development/troubleshoot.md
+++ b/docs/src/development/troubleshoot.md
@@ -123,9 +123,9 @@ Typical causes and potential solutions include:
   - Check your code is running smoothly.
   - Consider adding an [observability solution](../increase-observability/integrate-observability/_index.md) to get a better view of your application.
 - A PHP process is crashing because of a segmentation fault.
-  - See [how to deal with crashed processes](../languages/php/troubleshoot.md#php-process-crashed).
+  - See [how to deal with crashed processes](../languages/php/troubleshoot.md#troubleshoot-a-crashed-php-process).
 - A PHP process is killed by the kernel out-of-memory killer.
-  - See [how to deal with killed processes](../languages/php/troubleshoot.md#php-process-is-killed).
+  - See [how to deal with killed processes](../languages/php/troubleshoot.md#troubleshoot-a-killed-php-process).
 
 ## Site outage
 
@@ -235,6 +235,10 @@ When a deployment is blocked, you should try the following:
   Replace `{{< variable "PID" >}}` with the process ID shown by `ps afx`.
 
 If a `sync` of `activate` process is stuck, try the above on the parent environment.
+
+Note that, for PHP apps, 
+you can [restart processes that get stuck during a build or deployment](../languages/php/troubleshoot.md#restart-php-processes-stuck-during-a-build-or-deployment)
+from your app container.
 
 ## Slow or failing build or deployment
 

--- a/docs/src/languages/php/troubleshoot.md
+++ b/docs/src/languages/php/troubleshoot.md
@@ -58,7 +58,7 @@ Otherwise, you may check if the following options are applicable:
   Refer to [how caching works](../../define-routes/cache.md).
 - Upgrade your Platform.sh plan to get more computing resources.
 
-## PHP process crashed
+## Troubleshoot a crashed PHP process
 
 If your PHP process crashed with a segmentation fault,
 you encounter a message like the following:
@@ -68,10 +68,10 @@ WARNING: [pool web] child 112 exited on signal 11 (SIGSEGV) after 7.405936 secon
 ```
 
 Either a PHP extension is hitting a segmentation fault or your PHP app code is crashing.
-You should review recent changes in your app and try to find the cause of it, 
-probably with the help of [Xdebug](./xdebug.md).
+Review recent changes in your app and try to find the root cause.
+You might want to use a tool such as [Xdebug](./xdebug.md) for quicker troubleshooting.
 
-## PHP process is killed
+## Troubleshoot a killed PHP process
 
 If your PHP process is killed by the kernel,
 you encounter a message like the following:
@@ -81,11 +81,22 @@ WARNING: [pool web] child 429 exited on signal 9 (SIGKILL) after 50.938617 secon
 ```
 
 That means the memory usage of your container exceeds the limit allowed on your plan, so the kernel kills the offending process.
-You should try the following:
+To solve this issue, try the following approaches:
 
-- Check if the memory usage of your app is expected and try to optimize it.
+- Check if the memory usage of your app is as expected and try to optimize it.
 - Use [sizing hints](./fpm.md) to reduce the amount of PHP workers, which reduces the memory footprint.
 - Upgrade your Platform.sh plan to get more computing resources.
+
+## Restart PHP processes stuck during a build or deployment
+
+If your [build or deployment is running longer than expected](../../development/troubleshoot.md#stuck-build-or-deployment),
+it might be because of a PHP process getting stuck.
+
+To restart your PHP processes, run the following command in your app container:
+
+```bash
+pkill -f php-fpm
+```
 
 ## Resource temporarily unavailable
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

It is possible to restart PHP processes that get stuck during a build or deployment by simply running a command in the app container.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

- Added  a dediacted section to the [PHP > Troubleshooting](https://docs.platform.sh/languages/php/troubleshoot.html) page.
- Linked to and from general [Development > Troubleshooting](https://docs.platform.sh/development/troubleshoot.html#stuck-build-or-deployment) page to ease access to the information.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
