### PR TITLE
:art: Unify references to the config reader

### DIFF
--- a/docs/layouts/shortcodes/databases-passwords.md
+++ b/docs/layouts/shortcodes/databases-passwords.md
@@ -3,7 +3,7 @@
 When you connect your app to a database,
 an empty password is generated for the database by default.
 This can cause issues with your app.
- 
+
 To generate real passwords for your database,
 define custom endpoints in your [service configuration](#1-configure-the-service).
 For each custom endpoint you create,
@@ -14,9 +14,10 @@ Note that you can't customize these automatically generated passwords.
 After your custom endpoints are exposed as relationships in your [app configuration](../../create-apps/_index.md),
 you can retrieve the password for each endpoint
 through the `PLATFORM_RELATIONSHIPS` [environment variable](../../development/variables/use-variables.md#use-platformsh-provided-variables).
-You can access the `PLATFORM_RELATIONSHIPS` environment variable directly [in your app](../../development/variables/use-variables.md#access-variables-in-your-app),
-for example using a Platform.sh configuration reader.
- 
+You can access the `PLATFORM_RELATIONSHIPS` environment variable directly [in your app or through the configuration reader](../../development/variables/use-variables.md#access-variables-in-your-app).
+The password value changes automatically over time, to avoid downtime its value has to be read dynamically by your app.
+Globally speaking, having passwords hard-coded into your codebase can cause security issues and should be avoided.
+
 When you switch from the default configuration with an empty password to custom endpoints,
 make sure your service name remains unchanged.
 Failure to do so results in the creation of a new service,

--- a/docs/layouts/shortcodes/guides/config-reader-info.md
+++ b/docs/layouts/shortcodes/guides/config-reader-info.md
@@ -1,8 +1,7 @@
 {{ $lang := .Get "lang" }}
 You can get all information about a deployed environment,
 including how to connect to services, through [environment variables]({{ relref . "/development/variables/_index.md" }}).
-Your app can access these variables directly or use the [Config Reader library](https://github.com/platformsh/config-reader-{{ $lang }}).
-It's a set of utilities to wrap the environment variables and make them easier to work with.
+Your app can [access these variables]({{ relref . "development/variables/use-variables.md#access-variables-in-your-app" }}).
 
 {{ if eq $lang "nodejs" }}
 Install the package with your preferred package manager:

--- a/docs/src/add-services/headless-chrome.md
+++ b/docs/src/add-services/headless-chrome.md
@@ -29,7 +29,7 @@ Puppeteer can be used to generate PDFs and screenshots of web pages, automate fo
 
 Puppeteer requires at least Node.js version 6.4.0, while using the async and await examples below requires Node 7.6.0 or greater.
 
-Using the Platform.sh [Config Reader](https://github.com/platformsh/config-reader-nodejs) library requires Node.js 10 or later.
+Using the [Config Reader](../development/variables/use-variables.md#access-variables-in-your-app) library requires Node.js 10 or later.
 
 ### Other languages
 
@@ -50,7 +50,7 @@ After configuration, include Puppeteer as a dependency:
 }
 ```
 
-Using the [Node.js Config Reader](https://github.com/platformsh/config-reader-nodejs) library, you can retrieve formatted credentials for connecting to headless Chrome with Puppeteer:
+Using the [Node.js Config Reader library](../development/variables/use-variables.md#access-variables-in-your-app), you can retrieve formatted credentials for connecting to headless Chrome with Puppeteer:
 
 ```js
 const platformsh = require('platformsh-config');

--- a/docs/src/development/variables/set-variables.md
+++ b/docs/src/development/variables/set-variables.md
@@ -186,7 +186,7 @@ To solve the issue, remove the printed output from your `.environment` file.
 
 If your app needs different names for environment variable than those set by Platform.sh, which is common for database connections,
 map the Platform.sh's variable names to those required by the application.
-Do this in the app with the help of a [Config Reader library](https://github.com/platformsh?q=config-reader) or via a shell script.
+Do this in the app with the help of the [Config Reader library](./use-variables.md#access-variables-in-your-app) or via a shell script.
 
 For example, the following [`.environment` script](#set-variables-via-script) exports variables that are visible to the application.
 It uses the `jq` library, which is included in all app containers for this purpose.

--- a/docs/src/guides/drupal9/elasticsearch.md
+++ b/docs/src/guides/drupal9/elasticsearch.md
@@ -31,7 +31,7 @@ Then, paste the following code snippet into your `settings.platformsh.php` file.
 
 {{< note >}}
 
-If you do not already have the Platform.sh Config Reader library installed and referenced at the top of the file, you need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
+If you do not already have the [Config Reader library](../../development/variables/use-variables.md#access-variables-in-your-app) installed and referenced at the top of the file, you need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
 
 ```php
 <?php

--- a/docs/src/guides/drupal9/memcached.md
+++ b/docs/src/guides/drupal9/memcached.md
@@ -48,7 +48,7 @@ The example below is intended as a "most common case" and has been tested with v
 
 {{< note >}}
 
-If you don't already have the Platform.sh Config Reader library installed and referenced at the top of the file,
+If you don't already have the [Config Reader library](../../development/variables/use-variables.md#access-variables-in-your-app) installed and referenced at the top of the file,
 you need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
 
 ```php

--- a/docs/src/guides/drupal9/redis.md
+++ b/docs/src/guides/drupal9/redis.md
@@ -22,9 +22,9 @@ You need:
 - A [Drupal 9 version deployed on Platform.sh](../drupal9/deploy/_index.md)
 - The [Platform.sh CLI](../../administration/cli/)
 - [Composer](https://getcomposer.org/)
-- The [Platform.sh Config Reader library](../../guides/drupal9/deploy/customize.md#install-the-config-reader)
+- The [Config Reader library](../../guides/drupal9/deploy/customize.md#install-the-config-reader)
 
-You also need a `settings.platformsh.php` file from which you can [manage the configuration of the Redis service](../drupal9/deploy/customize.md#settingsphp). 
+You also need a `settings.platformsh.php` file from which you can [manage the configuration of the Redis service](../drupal9/deploy/customize.md#settingsphp).
 If you installed Drupal 9 with a template, this file is already present in your project.
 
 Note that, by default, Redis is an ephemeral service.

--- a/docs/src/guides/drupal9/solr.md
+++ b/docs/src/guides/drupal9/solr.md
@@ -80,7 +80,7 @@ The configuration can be managed from `settings.platformsh.php` by adding the fo
 It will override the environment-specific parts of the configuration object with the correct values to connect to the Platform.sh Solr instance.
 
 {{< note >}}
-If you don't already have the Platform.sh Config Reader library installed and referenced at the top of the file, you need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
+If you don't already have the [Config Reader library](../../development/variables/use-variables.md#access-variables-in-your-app) installed and referenced at the top of the file, you need to install it with `composer require platformsh/config-reader` and then add the following code before the block below:
 
 ```php
 <?php

--- a/docs/src/guides/strapi/database-configuration/sqlite.md
+++ b/docs/src/guides/strapi/database-configuration/sqlite.md
@@ -10,7 +10,7 @@ Strapi uses SQLite database by default when it's run on a local machine.
 When you create a new Strapi project, you can use SQLite or a custom database installation (PostgreSQL, MongoDB, or MySQL).
 Since Strapi uses SQLite by default, you don't need much configuration, just follow these steps:
 
-1. In your Strapi project, install the Platfom.sh config reader.
+1. In your Strapi project, install the [config reader](../../../development/variables/use-variables.md#access-variables-in-your-app).
 
    ```bash
    npm install platformsh-config

--- a/docs/src/guides/strapi/local-development/local-development-v3.md
+++ b/docs/src/guides/strapi/local-development/local-development-v3.md
@@ -6,7 +6,7 @@ description: How to develop a Strapi v3 app locally.
 
 You can run your Strapi v3 app locally with all of its services.
 
-First install the Platform.sh config reader by running the following command:
+First install the [config reader](../../../development/variables/use-variables.md#access-variables-in-your-app) by running the following command:
 
 ```bash
 npm install platformsh-config OR yarn add platformsh-config

--- a/docs/src/guides/wordpress/redis.md
+++ b/docs/src/guides/wordpress/redis.md
@@ -133,7 +133,7 @@ somewhere before the final `require_once(ABSPATH . 'wp-settings.php');` line.
 
 {{< note >}}
 
-The following examples assume you are using the [Platform.sh Config Reader](./deploy/customize.md#install-the-config-reader).
+The following examples assume you are using the [Config Reader library](../../development/variables/use-variables.md#access-variables-in-your-app).
 
 {{</ note >}}
 

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -106,9 +106,7 @@ You can commit a `mix.exs` file in your repository and the system downloads the 
 
 ## Accessing Services
 
-{{% config-reader %}}
-[Platform.sh Config Reader library](https://hex.pm/packages/platformshconfig) 
-{{% /config-reader%}}
+{{% guides/config-reader-info lang="elixir" %}}
 
 If you are building a Phoenix app for example, it would suffice to add a database to `.platform/services.yaml` and a relationship in `.platform.app.yaml`. Put the lib in your `deps` and, assuming you renamed the `prod.secret.exs` to `releases.exs` per the [Phoenix guide](https://hexdocs.pm/phoenix/releases.html), change:
 
@@ -122,7 +120,7 @@ to
 Platformsh.Config.ecto_dsn_formatter("database")
 ```
 
-See [Platform.sh Config Reader Documentation](https://hexdocs.pm/platformshconfig/Platformsh.Config.html) for the full API.
+See [Config Reader Documentation](../development/variables/use-variables.md#access-variables-in-your-app) for the full API.
 
 ### Accessing Services Manually
 

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -121,10 +121,7 @@ markdownify=false
 
 {{< /codetabs >}}
 
-
-{{% config-reader %}}
-[Config Reader library](https://github.com/platformsh/config-reader-go)
-{{% /config-reader%}}
+{{% guides/config-reader-info lang="go" %}}
 
 You can also use the library to read other environment variables.
 

--- a/docs/src/languages/java/migration.md
+++ b/docs/src/languages/java/migration.md
@@ -172,7 +172,8 @@ web:
 
 ### Using Java Config Reader
 
-If your framework doesn't support configuration via environment variables, there is the [Platform.sh Config Reader](https://github.com/platformsh/config-reader-java).This library provides a streamlined way to interact with a Platform.sh environment. It offers utility methods to access routes and relationships more cleanly than reading the raw environment variables yourself. [See the maven dependency](https://mvnrepository.com/artifact/sh.platform/config).
+If your framework doesn't support configuration via environment variables, use the [Config Reader](../../development/variables/use-variables.md#access-variables-in-your-app).
+This library provides a streamlined way to interact with a Platform.sh environment. It offers utility methods to access routes and relationships more cleanly than reading the raw environment variables yourself. [See the maven dependency](https://mvnrepository.com/artifact/sh.platform/config).
 
 ```java
 import Config;


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

References to the Config Reader were inconsistent.
Tried to make the logic simpler and link to the generic page where possible.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Short codes for handling the Config Reader links.
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
