### PR TITLE
:memo: Add introduction and link to Trust Center

### DIFF
--- a/docs/src/security/_index.md
+++ b/docs/src/security/_index.md
@@ -2,5 +2,20 @@
 title: "Security and compliance"
 weight: -50
 description: |
-  Platform.sh takes your privacy seriously. We’re compliant with the European GDPR (DPA available), German BDSG (DPA available), and Canadian PIPEDA.
+  Learn how Platform.sh ensures your data is handled with appropriate care and according to industry standards.
 ---
+
+Platform.sh is compliant with many regulations in favor of the protection of user data,
+including the European General Data Protection Regulation (GDPR),
+the German Privacy Act (BDSG),
+and the California Consumer Privacy Act (CCPA).
+
+In this section of the Platform.sh docs,
+you can find information on how Platform.sh handles [data retention](./data-retention.md)
+and [backups and recoveries](./backups.md).
+You can also learn how the Platform.sh [web application firewall (WAF)](./waf.md)
+can help you protect your data.
+
+For more information about the security, privacy,
+and compliance of the Platform.sh products and services,
+check out the Platform.sh [Trust Center](https://platform.sh/trust-center/).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2940 
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added a short introduction to the **Security & Compliance** page with a link to the Trust Center.
The introduction highlights the content that's going to stay in the docs so we don't have to necessarily change it when we remove the pages that will live in the Trust Center in the future.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
