### PR TITLE
Include type and name attributes for static sites

### DIFF
--- a/docs/src/create-apps/web/static.md
+++ b/docs/src/create-apps/web/static.md
@@ -97,6 +97,10 @@ such as a [script to handle 404 errors](https://community.platform.sh/t/custom-4
 ## Complete example
 
 ```yaml {location=".platform.app.yaml"}
+name: app
+
+type: 'python:3.11'
+
 web:
     locations:
         '/':


### PR DESCRIPTION
## Why

Closes https://github.com/platformsh/platformsh-docs/issues/2955

## What's changed

`type` and `name` attributes added to "complete example" for static sites, so it's usable.