### PR TITLE
Update static site index

### DIFF
--- a/docs/src/create-apps/web/static.md
+++ b/docs/src/create-apps/web/static.md
@@ -107,7 +107,8 @@ web:
             # The public directory of the application relative to its root
             root: 'public'
             # The files to look for when serving a directory
-            index: ['index.html']
+            index: 
+              - 'index.html'
             # Disable server-side scripts
             scripts: false
             allow: true


### PR DESCRIPTION
## Why

The current static site config for `index` results in a 404. Thanks @tylers-username !

## What's changed

The array format is changed slightly to the working version