### PR TITLE
Update vault.md to specify min disk space

### DIFF
--- a/docs/src/add-services/vault.md
+++ b/docs/src/add-services/vault.md
@@ -32,6 +32,8 @@ The Vault key management service (KMS) provides key management and access contro
 
 You can create multiple endpoints, such as to have key management separate from key use.
 
+512 MB is the minimum required disk space for the Vault KMS service.
+
 {{% /endpoint-description %}}
 
 ## Use Vault KMS


### PR DESCRIPTION
The docs suggest 512 MB of disk space, but they don't state that 512 is required.

The vault docs say that you can use as little as 100GB: https://developer.hashicorp.com/vault/tutorials/day-one-raft/raft-reference-architecture

But actually platformsh requires 512.  When I set 128 for my service, I got this error:

[detail] {"services.vault.disk":"minimum disk size of this service is 512MB"} [title] Bad Request

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
