### PR TITLE
Varnish: fix wrong display of variables in .Inner subrequest

### DIFF
--- a/docs/src/add-services/varnish.md
+++ b/docs/src/add-services/varnish.md
@@ -34,8 +34,8 @@ graph LR
 {{% endpoint-description type="varnish" noApp=true %}}
 
 The `relationships` block defines the connection between Varnish and your app.
-You can define `{{< variable "RELATIONSHIP_NAME" >}}` as you like.
-`{{< variable "APP_NAME" >}}` should match your app's `name` in the [app configuration](../create-apps/app-reference.md).
+You can define <code>{{< variable "RELATIONSHIP_NAME" >}}</code> as you like.
+<code>{{< variable "APP_NAME" >}}</code> should match your app's `name` in the [app configuration](../create-apps/app-reference.md).
 
 The `configuration` block must reference a VCL file inside the `.platform` directory.
 The `path` defines the file relative to the `.platform` directory.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
When looking at [this page](https://docs.platform.sh/add-services/varnish.html#1-configure-the-service), the variable RELATIONSHIP_NAME is called using `{{ .Inner }}` inside  `docs/layouts/shortcodes/endpoint-description.md` and so, is replace by its raw value (instead of the HTML one), because of the \` character that encapsulate the variable.
So i replace by the html code and display is better.


<img width="842" alt="Capture d’écran 2023-03-22 à 08 53 01" src="https://user-images.githubusercontent.com/1842696/226838378-cd045cfa-aa44-4a0f-b32c-d9fa65c41021.png">


Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed
replace \` by its html equivalent `<code></code>`
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
