### PR TITLE
Generalized banners

### DIFF
--- a/docs/data/banners.yaml
+++ b/docs/data/banners.yaml
@@ -1,0 +1,34 @@
+# PAGE BANNERS
+#
+# To enable on a page:
+# 
+# banner:
+#   type: beta 
+#   # title: Override the default values below by setting a banner.title
+#   # body: Override the default values below by setting a banner.body
+#
+# You can also set a completely custom banner (without a 'type'), as long as body and title are defined
+#
+# banner:
+#   title: Custom banner title
+#   body: Explanation of the custom banner title
+beta:
+    title: Beta
+    body: This feature is only available to Enterprise and Elite customers and is currently in Beta.
+        If you’re an Enterprise or Elite customer, to become a Beta tester [contact Support](/overview/get-support.html).
+        If you’re a Professional customer, you need to [contact Sales](https://platform.sh/contact/) first to upgrade your plan.
+
+# For now, the only tier-gated feature is applicable BOTH to Enterprise and Elite. 
+# If this changes, it may make sense to use instead
+#
+# tiered-elite-enterprise
+# tiered-elite
+# tiered-enterprise
+# ...
+tiered-feature: 
+    title: Loaded
+    body: Loaded
+
+observabilitySuite: same as above
+
+premium: same as above

--- a/docs/data/banners.yaml
+++ b/docs/data/banners.yaml
@@ -36,5 +36,3 @@ observability-suite:
     body: This feature is available as part of the [Observability Suite](https://platform.sh/features/observability-suite/).
         To add the Observability Suite to your project and take advantage of this feature,
         [contact Sales](https://platform.sh/contact/).
-
-premium: same as above

--- a/docs/data/banners.yaml
+++ b/docs/data/banners.yaml
@@ -26,8 +26,10 @@ beta:
 # tiered-enterprise
 # ...
 tiered-feature: 
-    title: Loaded
-    body: Loaded
+    title: Tier availability
+    body: This feature is available for **Elite** and **Enterprise** customers. 
+        [Compare the Platform.sh tiers](https://platform.sh/pricing/) on our pricing page, 
+        or [contact our sales team](https://platform.sh/contact/) for more information.
 
 observabilitySuite: same as above
 

--- a/docs/data/banners.yaml
+++ b/docs/data/banners.yaml
@@ -31,6 +31,10 @@ tiered-feature:
         [Compare the Platform.sh tiers](https://platform.sh/pricing/) on our pricing page, 
         or [contact our sales team](https://platform.sh/contact/) for more information.
 
-observabilitySuite: same as above
+observability-suite:
+    title: Observability Suite
+    body: This feature is available as part of the [Observability Suite](https://platform.sh/features/observability-suite/).
+        To add the Observability Suite to your project and take advantage of this feature,
+        [contact Sales](https://platform.sh/contact/).
 
 premium: same as above

--- a/docs/layouts/shortcodes/premium-features/add-on.html
+++ b/docs/layouts/shortcodes/premium-features/add-on.html
@@ -3,4 +3,4 @@
 You need to add it separately at an additional cost.
 To add ` $feature `, [contact Sales](https://platform.sh/contact/).`}}
     
-{{ partial "premium-features/banner" ( dict "context" . "content" $content "title" "Beta" )}}
+{{ partial "note" ( dict "context" . "Inner" $content "title" "Beta" "theme" "info" )}}

--- a/docs/src/administration/sso.md
+++ b/docs/src/administration/sso.md
@@ -3,9 +3,8 @@ title: "Single sign-on (SSO)"
 weight: 4
 description: |
   Platform.sh allows you to set up mandatory SSO with a third-party identity provider (IdP) for all your users.
-tier:
-  - Elite
-  - Enterprise
+banner: 
+    type: tiered-feature
 ---
 
 {{% description %}}

--- a/docs/src/create-apps/source-operations.md
+++ b/docs/src/create-apps/source-operations.md
@@ -2,9 +2,8 @@
 title: Automated code updates
 description: |
   Run automated code updates via source operations.
-tier:
-  - Elite
-  - Enterprise
+banner: 
+    type: tiered-feature
 ---
 
 You can run automated code updates via a Platform.sh mechanism called: source operation.

--- a/docs/src/domains/cdn/managed-fastly.md
+++ b/docs/src/domains/cdn/managed-fastly.md
@@ -3,9 +3,8 @@ title: "Managed Fastly CDN"
 sidebarTitle: "Managed Fastly CDN"
 weight: 2
 description: Bring your content closer to users with a Fastly CDN fully managed by Platform.sh.
-tier:
-  - Elite
-  - Enterprise
+banner: 
+    type: tiered-feature
 ---
 
 Instead of starting your own Fastly subscription and [managing your CDN yourself](./fastly.md),

--- a/docs/src/domains/steps/custom-non-production-domains.md
+++ b/docs/src/domains/steps/custom-non-production-domains.md
@@ -3,7 +3,8 @@ title: Set up a custom domain on your non-production environments
 sidebarTitle: (Beta) Non-production environments
 weight: 3
 description: Learn how to set up custom domains on your staging and development environments
-betaFlag: true
+banner: 
+    type: beta
 ---
 
 You can add a custom domain to a non-production environment (`staging` or `development` environment types)

--- a/docs/src/guides/django/deploy/_index.md
+++ b/docs/src/guides/django/deploy/_index.md
@@ -4,7 +4,6 @@ sidebarTitle: Get started
 weight: -130
 layout: single
 description: See how to get started deploying Django on Platform.sh.
-betaFlag: true
 ---
 
 Django is a web application framework written in Python with a built-in ORM (Object-Relational Mapper).

--- a/docs/src/increase-observability/logs/forward-logs.md
+++ b/docs/src/increase-observability/logs/forward-logs.md
@@ -1,7 +1,8 @@
 ---
 title: Forward logs
 description: Send your logs to a third-party service for further analysis.
-observabilitySuite: true
+banner: 
+    type: observability-suite
 ---
 
 You might use a service to analyze logs from various parts of your fleet.

--- a/docs/src/security/waf.md
+++ b/docs/src/security/waf.md
@@ -1,9 +1,8 @@
 ---
 title: Web application firewall (WAF)
 description: Learn how the WAF included in Enterprise and Elite plans can help protect your site from distributed denial of service (DDoS) attacks.
-tier:
-  - Enterprise
-  - Elite
+banner: 
+    type: tiered-feature
 ---
 
 Enterprise and Elite projects on Platform.sh come with a web application firewall (WAF) at no additional cost.

--- a/docs/themes/psh-docs/layouts/partials/banners/banner.html
+++ b/docs/themes/psh-docs/layouts/partials/banners/banner.html
@@ -1,0 +1,56 @@
+<!-- Creates single page banner note for page warning -->
+
+<!-- Get default banner data -->
+{{ $banners := .Site.Data.banners }}
+{{ $bannerTypes := slice }}
+{{ range $bannerType, $y := $banners }}
+   {{ $bannerTypes = $bannerTypes | append $bannerType}}
+{{ end }}
+
+<!-- Build the banner if 'banner' param exists on the page -->
+{{- if .Params.banner -}}
+
+<!-- NOTE: a future version could allow for banner types to have a default, and overridable color... -->
+<div class="prose xl:prose-lg bg-skye-light p-4 mb-4 max-w-none">
+
+  <!-- Check if 'banner.type' exists, to load default strings in data/banners.yaml -->
+  {{- if .Params.banner.type -}}
+    <!-- Check that the provided banner type exists -->
+    {{- if in $bannerTypes .Params.banner.type -}}
+
+      <!-- Use provided or banner type default title -->
+      {{- if .Params.banner.title -}}
+        <p><strong>{{ .Params.banner.title }}</strong></p>
+      {{- else -}}
+        <p><strong>{{ index .Site.Data.banners .Params.banner.type "title" }}</strong></p>
+      {{- end -}}
+      <!-- Use provided or or banner type default body -->
+      {{- if .Params.banner.body -}}
+        <p>{{ .Params.banner.body | .Page.RenderString }}</p>
+      {{- else -}}
+        <p>{{ index .Site.Data.banners .Params.banner.type "body"  | .Page.RenderString }}</p>
+      {{- end -}}
+
+    {{- end -}}
+
+  <!-- If no .Params.banner.type provided... -->
+  {{- else -}}
+
+    <!-- Use provided or some default title -->
+    {{- if .Params.banner.title -}}
+      <p><strong>{{ .Params.banner.title }}</strong></p>
+    {{- else -}}
+      <p><strong>Note</strong></p>
+    {{- end -}}
+    <!-- Use provided or some default body -->
+    {{- if .Params.banner.body -}}
+      <p>{{ .Params.banner.body | .Page.RenderString }}</p>
+    {{- else -}}
+      <p>Lorem ipsum is the thing to say.</p>
+    {{- end -}}
+
+  {{- end -}}
+
+  </div>
+
+{{- end -}}

--- a/docs/themes/psh-docs/layouts/partials/page-content.html
+++ b/docs/themes/psh-docs/layouts/partials/page-content.html
@@ -1,3 +1,6 @@
+<!-- Platform.sh page banners -->
+{{ partial "banners/banner.html" .context }}
+
 <!-- Platform.sh tier-gated features -->
 {{ partial "tiered-features/banner.html" .context }}
 


### PR DESCRIPTION
## Why

Closes https://github.com/platformsh/platformsh-docs/issues/3013

## What's changed

- All banners go through the same partial: `docs/themes/psh-docs/layouts/banners/banner.html`
- A banner is created on a page with the `banner` front matter parameter, which should include the banner `type`
- All banners have default values for `title` and `body` defined in `docs/data/banners.yaml`, which is displayed if only `banner.type` is defined.
- `title` and `body` can be overwritten for a given page when `type` is defined
- Banners without a defined `type` can be displayed, so long as `title` and `body` are defined
- The Premium feature (currently only used for MongoDB enterprise) is updated, since it depended on the old banner partials
- The `betaFlag` parameter was removed from the Django deploy guide - copypasta

See https://github.com/platformsh/platformsh-docs/issues/3013 for more details