### PR TITLE
Missing `y`

### DIFF
--- a/docs/src/add-services/mysql/troubleshoot.md
+++ b/docs/src/add-services/mysql/troubleshoot.md
@@ -66,7 +66,7 @@ to learn about low disk space before it becomes an issue.
 
 ### Packet size limitations
 
-`MySQL server has gone awa` errors may be caused by the size of the database packets.
+`MySQL server has gone away` errors may be caused by the size of the database packets.
 If so, the logs may show warnings like `Error while sending QUERY packet` before the error.
 
 One way to resolve the issue is to use the [`max_allowed_packet` parameter](./_index.md#configure-the-database).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## What's changed

Added missing `y`. Possible typo

