### PR TITLE
:memo: Document cron syntax limitations

### DIFF
--- a/docs/src/add-services/network-storage.md
+++ b/docs/src/add-services/network-storage.md
@@ -207,7 +207,7 @@ mounts:
 # same mounts as the web container.
 crons:
     drupal:
-        spec: 'H * * * *'
+        spec: '*/20 * * * *'
         commands:
             start: 'cd web ; drush core-cron'
 

--- a/docs/src/create-apps/app-reference.md
+++ b/docs/src/create-apps/app-reference.md
@@ -630,7 +630,7 @@ The following table shows the properties for each job:
 
 | Name               | Type                                         | Required | Description |
 | ------------------ | -------------------------------------------- | -------- | ----------- |
-| `spec`             | `string`                                     | Yes      | The [cron specification](https://en.wikipedia.org/wiki/Cron#Cron_expression). To prevent competition for resources that might hurt performance, use `H` in definitions to indicate an unspecified but invariant time. For example, instead of using `0 * * * *` to indicate the cron job runs at the start of every hour, you can use `H * * * *` to indicate it runs every hour, but not necessarily at the start. This prevents multiple cron jobs from trying to start at the same time. |
+| `spec`             | `string`                                     | Yes      | The [cron specification](https://en.wikipedia.org/wiki/Cron#Cron_expression). To prevent competition for resources that might hurt performance, on **Grid or {{% names/dedicated-gen-3 %}}** projects use `H` in definitions to indicate an unspecified but invariant time. For example, instead of using `0 * * * *` to indicate the cron job runs at the start of every hour, you can use `H * * * *` to indicate it runs every hour, but not necessarily at the start. This prevents multiple cron jobs from trying to start at the same time. **The `H` syntax isn't available on {{% names/dedicated-gen-2 %}} projects.**|
 | `commands`         | A [cron commands dictionary](#cron-commands) | Yes      | A definition of what commands to run when starting and stopping the cron job. |
 | `shutdown_timeout` | `integer`                                    | No       | When a cron is canceled, this represents the number of seconds after which a `SIGKILL` signal is sent to the process to force terminate it. The default is `10` seconds. |
 | `timeout`          | `integer`                                    | No       | The maximum amount of time a cron can run before it's terminated. Defaults to the maximum allowed value of `86400` seconds (24 hours).
@@ -651,6 +651,10 @@ crons:
             stop: killall sleep
         shutdown_timeout: 18
 ```
+
+In this example configuration, the [cron specification](#crons) uses the `H` syntax.
+Note that this syntax is only supported on Grid and {{% names/dedicated-gen-3 %}} projects.
+On {{% names/dedicated-gen-2 %}} projects, use the [standard cron syntax](https://en.wikipedia.org/wiki/Cron#Cron_expression).
 
 ### Example cron jobs
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #3017 
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Updated sections dedicated to crons : [here](https://docs.platform.sh/create-apps/app-reference.html#crons) and [there](https://docs.platform.sh/create-apps/app-reference.html#cron-commands) to make it clear that `H` syntax isn't supported on DG2. 

A few months ago, the docs were updated to include a few examples featuring the `H` syntax as it was understood to be the new norm at that time. Since then, we were alerted that the `H` syntax doesn't work on DG2 projects. Also, all but two of the examples using the `H` syntax have been updated again over the past weeks/months, with new examples that happen to be using the standard syntax supported on all architectures instead.

Given these new developments, I've reverted one of the remaining 2 examples to the standard cron syntax for consistency's sake and not to confuse customers who can't use the `H` syntax. The only place where I've kept a description of the `H` syntax and its availability limitations + an example in a later section on that same page (complete with a note to redirect DG2 users to the standard syntax) is the [App reference](https://docs.platform.sh/create-apps/app-reference.html#crons) page.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
