### PR TITLE
:memo: Add links to cancelable activities page

### DIFF
--- a/docs/src/create-apps/app-reference.md
+++ b/docs/src/create-apps/app-reference.md
@@ -635,6 +635,8 @@ The following table shows the properties for each job:
 | `shutdown_timeout` | `integer`                                    | No       | When a cron is canceled, this represents the number of seconds after which a `SIGKILL` signal is sent to the process to force terminate it. The default is `10` seconds. |
 | `timeout`          | `integer`                                    | No       | The maximum amount of time a cron can run before it's terminated. Defaults to the maximum allowed value of `86400` seconds (24 hours).
 
+Note that you can [cancel pending or running crons](../environments/cancel-activity.md).
+
 ### Cron commands
 
 | Name               | Type      | Required | Description |

--- a/docs/src/create-apps/source-operations.md
+++ b/docs/src/create-apps/source-operations.md
@@ -109,6 +109,8 @@ Replace {{< variable "OPERATION_NAME" >}} with the name of your operation, such 
 After running a source operation, 
 to apply the changes to your local development environment run the `git pull` command.
 
+Note that you can [cancel pending or running source operations](../environments/cancel-activity.md).
+
 ## Use variables in your source operations
 
 You can add [variables](../development/variables/_index.md) to the environment of the source operation.

--- a/docs/src/overview/build-deploy.md
+++ b/docs/src/overview/build-deploy.md
@@ -52,6 +52,7 @@ Once the app has gone through all of the build steps, it can connect to services
    It could be compiling Sass files, running a bundler, rearranging files on disk, or compiling.
    The committed build hook runs in the build container.
    During this time, commands have write access to the file system, but there aren't connections to other containers (services and other apps).
+   Note that you can [cancel deployments stuck on the build hook](../environments/cancel-activity.md).
 1. **Freeze app container**:
    The file system is frozen and produces a read-only container image, which is the final build artifact.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #2952 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added links from the [source operations](https://docs.platform.sh/create-apps/source-operations.html#run-a-source-operation), [crons](https://docs.platform.sh/create-apps/app-reference.html#crons), and [build](https://docs.platform.sh/overview/build-deploy.html) pages/sections to the [cancel activity](https://docs.platform.sh/environments/cancel-activity.html) page.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
