### PR TITLE
[Bug 3066] Check to make sure branch received before activation

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -9,7 +9,7 @@ env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
   PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
-  SLEEP_TIME: 10
+  SLEEP_TIME: 5
   NUM_TRIES: 30
 
 jobs:
@@ -41,6 +41,24 @@ jobs:
 
           echo "Pushing most recent changes"
           git push --force origin $BRANCH_TITLE
+
+          # has platform.sh received our new branch?
+          counter=0
+          branchReceived=""
+          echo "::notice::Checking if Platform.sh has received our new branch..."
+          while (( counter < ${{ env.NUM_TRIES }} )) && [[ -z "${branchReceived}" ]]; do
+            sleep ${{ env.SLEEP_TIME }}
+            echo "::notice Attempt ${counter} of ${{ env.NUM_TRIES }}"
+            branchReceived=$(platform project:curl /environments | jq --arg branch "${BRANCH_TITLE}" -r '.[] | select(.name | contains($branch))');
+            counter=$((++counter))
+          done
+
+          if [[ -z "${branchReceived}" ]]; then
+            echo "::warniing::It appears that Platform.sh did not receive our branch ${BRANCH_TITLE}. Please look at the logs and try again."
+            exit 24;
+          else
+            echo "::notice::Branch ${BRANCH_TITLE} was successfully pushed to Platform.sh. Continuing..."
+          fi
 
           # If environment not active, activate it
           if ! $(platform env --format plain --columns title,status | grep $BRANCH_TITLE | grep -q Active); then

--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -9,6 +9,8 @@ env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
   PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
+  SLEEP_TIME: 10
+  NUM_TRIES: 30
 
 jobs:
   build:


### PR DESCRIPTION
## Why

Closes #3066 
Per #3066 the current workflow attempts to activate the recently pushed branch. Occassionally, the attempted activation occurs before the branch is successfully received by Platform.sh. Refactors workflow to query the environments endpoint and checks if our branch is listed. Will attempt this query a determined number of times, pausing between each execution.

## What's changed

- Adds environmental variables for how long to sleep between each check, and how many times we should check
- Queries the /environments API endpoint for a list of environments where the branch name is the branch we just pushed.
- Loops through `NUM_TRIES` until we get a match, sleeping `SLEEP_TIME` before each execution of the query

