### PR TITLE
 [Bug fix] pr from fork workflow fails when it shouldnt run 

### DIFF
--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -26,11 +26,14 @@ jobs:
         run: |
           # For PRs from non-forked repos
           if [ ${{ github.event.pull_request.head.repo.id }} == 21975579 ]; then
-            echo "branch_name=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+            branch_name="${{ github.event.pull_request.head.ref }}"
+
           # For PRs from forks
           else
-            echo "branch_name=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+            branch_name="pr-${{ github.event.number }}"
           fi
+          echo "::notice::Setting branch name to ${branch_name}."
+          echo "branch_name=${branch_name}" >> $GITHUB_OUTPUT
 
       # Set up workflow environment to use the Platform.sh CLI
       - name: Set up Platform.sh CLI
@@ -46,15 +49,25 @@ jobs:
 
           # Get the state of the most recent deployment activity
           STATE=$(platform activities --format plain --type "environment.push environment.activate environment.redeploy environment.branch" --no-header --columns "state" --limit 1 --environment ${{ steps.branch_name.outputs.branch_name }})
-
+          echo "::notice::Attempting to retrieve deployed environment URL. Current state is: ${STATE}"
           # Set tries to 0 to start countdown to timeout
-          STATUS_TRY=0
+          STATUS_TRY=1
+          # We'll try up to 20 minutes, so (SLEEP_TIME*NUM_ATTEMPTS)/60
+          SLEEP_TIME=10
+          =120
 
           # Wait until state is complete or 20 minutes has passed
-          until [ "$STATE" == "complete" ] || [ $STATUS_TRY == 40 ]; do
-            sleep 30
+          until [ "${STATE}" = "complete" ] || [ ${STATUS_TRY} = ${NUM_ATTEMPTS} ]; do
+            sleep ${SLEEP_TIME}
+            echo "::notice::Environment is not deployed. Attempting to retrieve deployed status. Attempt ${STATUS_TRY} of ${NUM_ATTEMPTS}."
             STATE=$(platform activities --format plain --type "environment.push environment.activate environment.redeploy environment.branch" --no-header --columns "state" --limit 1 --environment ${{ steps.branch_name.outputs.branch_name }})
-            ((STATUS_TRY+=1))
+            echo "::notice::Status retrieved: ${STATE}"
+
+            if [ "${STATE}" = "complete" ]; then
+              echo "::notice::Activity is complete."
+            fi
+
+            STATUS_TRY=$((++STATUS_TRY))
           done
 
           # Get the URL of the environment
@@ -66,7 +79,7 @@ jobs:
           # Report findings
           echo "The Platform.sh environment is:"
           echo "$COMMIT_STATUS"
-          if [ "$COMMIT_STATUS" == "success" ]; then
+          if [ "$COMMIT_STATUS" = "success" ]; then
             echo "Environment deployed to:"
             echo "$ENV_URL"
           fi

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -13,20 +13,13 @@ jobs:
   get_pr_info:
     runs-on: ubuntu-latest
     name: Get info on build from PR
-    steps: 
+    # Run only for PRs from default repo and approved PRs from forks
+    if: github.event.pull_request.head.repo.id == 21975579 || contains(github.event.pull_request.labels.*.name, 'build-fork')
+    steps:
       - uses: actions/checkout@v3
-        # Run only for PRs from default repo and approved PRs from forks
-        if: github.event.pull_request.head.repo.id == 21975579 || contains(github.event.pull_request.labels.*.name, 'build-fork')
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fail forked PRs without authorization
-        # If a PR is from a fork and doesn't have the `build-fork` label, fail the workflow
-        if: github.event.pull_request.head.repo.id != 21975579 && !contains(github.event.pull_request.labels.*.name, 'build-fork')
-        run: |
-          echo "This PR doesn't have sufficient permission to be built"
-          exit 1
 
       - name: Set branch name
         id: branch_name

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -93,7 +93,7 @@ jobs:
         if: steps.get_env_url.outputs.env_status == 'failure'
         run: |
           echo -e "The environment on Platform.sh failed to deploy. :slightly_frowning_face:\n\nCheck the logs: https://console.platform.sh/projects/652soceglkw4u/${{ steps.branch_name.outputs.branch_name }}" > pr_comment.txt
-        
+
       # Create a list of relevant changed pages
       - name: Report environment URL
         if: steps.get_env_url.outputs.env_status == 'success'
@@ -129,7 +129,7 @@ jobs:
 
               # Shift index pages up a level
               page=${page/"/_index.html"/".html"}
-              
+
               files+=("$ENV_URL$page")
             fi
           done
@@ -169,8 +169,16 @@ jobs:
             pr_number.txt
             pr_sha.txt
           retention-days: 1
-      
+
       # If environment failed to create, fail the workflow
       - name: Fail workflow
         if: steps.get_env_url.outputs.env_status != 'success'
         run: exit 1
+  dont_run_nonlabeled_forks:
+    name: Warn about non-labeled PRs from forks
+    if: github.event.pull_request.head.repo.id != 21975579 && !contains(github.event.pull_request.labels.*.name, 'build-fork')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Warn the environment will not be built
+        run: |
+          echo "::warning::Pull Requests from forks will not have an environment built until they are given the appropriate label."

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -52,9 +52,9 @@ jobs:
           echo "::notice::Attempting to retrieve deployed environment URL. Current state is: ${STATE}"
           # Set tries to 0 to start countdown to timeout
           STATUS_TRY=1
-          # We'll try up to 20 minutes, so (SLEEP_TIME*NUM_ATTEMPTS)/60
+          # We'll try up to 20 minutes, so (SLEEP_TIME*NUM_ATTEMPTS)/60 = 10*
           SLEEP_TIME=10
-          =120
+          NUM_ATTEMPTS=120
 
           # Wait until state is complete or 20 minutes has passed
           until [ "${STATE}" = "complete" ] || [ ${STATUS_TRY} = ${NUM_ATTEMPTS} ]; do


### PR DESCRIPTION
## Why

Closes #3069 

## What's changed

In [get-pr-info.yaml](https://github.com/platformsh/platformsh-docs/blob/8bd60af2326704beea9897cefbe1efc9c027ae47/.github/workflows/get-pr-info.yaml) : 

- Makes the entire get_pr_info job conditional on the repo.id being our repo, or that the appropriate label has been added
- Removes conditional from the git checkout step
- Removes the step that fails the workflow if it is a forked PR w/o a label
- Adds a second job that is conditional on the PR being from a fork that is non-labeled
- Adds a step to the second job that generates a warning notice
