### PR TITLE
Update build-from-fork.yaml

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -3,7 +3,7 @@ name: Build from fork
 on:
   pull_request_target:
     branches: [main]
-    types: [labeled,unlabeled]
+    types: [labeled,unlabeled,synchronize]
 
 env:
   PLATFORMSH_CLI_NO_INTERACTION: 1


### PR DESCRIPTION
## Why

Closes #3087 

## What's changed

adds a type of `synchronize` to the on:pull_request_target:types array. This should allow us to push changes to a branch-from-fork over to our copy of the branch.
