### PR TITLE
Update build-from-fork.yaml

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    if: ${{ github.event.label.name == 'build-fork' }}
+    if: github.event.label.name == 'build-fork' || contains(github.event.pull_request.labels.*.name, 'build-fork')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
a synchronize type doesn't include `event.label.name` so the workflow doesn't fire on a synch type event. 
For that event we'll add a conditional to run the job if the PR has our  build-fork label

