### PR TITLE
[Bug fix] Don't prefix pull requests from forks with `pr-`

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -11,6 +11,7 @@ env:
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
   SLEEP_TIME: 5
   NUM_TRIES: 30
+  BFF_PREFX: ${{ vars.BFF_PREFIX }}-
 
 jobs:
   build:
@@ -30,7 +31,7 @@ jobs:
       - env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         run: |
-          BRANCH_TITLE=pr-${{ github.event.number }}
+          BRANCH_TITLE="${{ env.BFF_PREFIX }}${{ github.event.number }}"
 
           # Get most recent changes
           git checkout ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -8,7 +8,7 @@ env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
   PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
-
+  BFF_PREFX: ${{ vars.BFF_PREFIX }}-
 jobs:
   get_pr_info:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
 
           # For PRs from forks
           else
-            branch_name="pr-${{ github.event.number }}"
+            branch_name="${{ env.BFF_PREFIX }}${{ github.event.number }}"
           fi
           echo "::notice::Setting branch name to ${branch_name}."
           echo "branch_name=${branch_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -58,7 +58,7 @@ jobs:
   deactivate_forked_environment:
     runs-on: ubuntu-latest
     env:
-      BRANCH_TITLE: pr-${{ github.event.number }}
+      BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
     # For forked PRs labelled as build-fork
     # Delete branch when a PR is closed
     if: >-
@@ -90,7 +90,7 @@ jobs:
         env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         run: |
-          git push origin -d pr-${{ github.event.number }}
+          git push origin -d ${{ env.BFF_PREFIX }}${{ github.event.number }}
 
         # Set up workflow environment to use the Platform.sh CLI
       - name: Set up Platform.sh CLI


### PR DESCRIPTION
## Why

Closes #3070 

## What's changed

Removes the hardcoded `pr-` prefix that is prepended to branches created when the PR comes from a fork, and instead references `${{ var.BFF_PREFIX }}`. 
