### PR TITLE
[Enhancement] sets up BRANCH_TITLE as an env var for the entire workflow

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -11,7 +11,7 @@ env:
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
   SLEEP_TIME: 5
   NUM_TRIES: 30
-  BFF_PREFIX: ${{ vars.BFF_PREFIX }}-
+  BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
 
 jobs:
   build:
@@ -31,17 +31,15 @@ jobs:
       - env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         run: |
-          BRANCH_TITLE="${{ env.BFF_PREFIX }}${{ github.event.number }}"
-
           # Get most recent changes
           git checkout ${{ github.event.pull_request.head.sha }}
 
           # Put most recent changes on the branch
-          echo "Switching to branch"
-          git switch -C $BRANCH_TITLE
+          echo "Switching to branch ${{ env.BRANCH_TITLE }}"
+          git switch -C ${{ env.BRANCH_TITLE }}
 
           echo "Pushing most recent changes"
-          git push --force origin $BRANCH_TITLE
+          git push --force origin ${{ env.BRANCH_TITLE }}
 
           # has platform.sh received our new branch?
           counter=0
@@ -50,19 +48,19 @@ jobs:
           while (( counter < ${{ env.NUM_TRIES }} )) && [[ -z "${branchReceived}" ]]; do
             sleep ${{ env.SLEEP_TIME }}
             echo "::notice Attempt ${counter} of ${{ env.NUM_TRIES }}"
-            branchReceived=$(platform project:curl /environments | jq --arg branch "${BRANCH_TITLE}" -r '.[] | select(.name | contains($branch))');
+            branchReceived=$(platform project:curl /environments | jq --arg branch "${{ env.BRANCH_TITLE }}" -r '.[] | select(.name | contains($branch))');
             counter=$((++counter))
           done
 
           if [[ -z "${branchReceived}" ]]; then
-            echo "::warniing::It appears that Platform.sh did not receive our branch ${BRANCH_TITLE}. Please look at the logs and try again."
+            echo "::warniing::It appears that Platform.sh did not receive our branch ${{ env.BRANCH_TITLE }}. Please look at the logs and try again."
             exit 24;
           else
-            echo "::notice::Branch ${BRANCH_TITLE} was successfully pushed to Platform.sh. Continuing..."
+            echo "::notice::Branch ${{ env.BRANCH_TITLE }} was successfully pushed to Platform.sh. Continuing..."
           fi
 
           # If environment not active, activate it
-          if ! $(platform env --format plain --columns title,status | grep $BRANCH_TITLE | grep -q Active); then
+          if ! $(platform env --format plain --columns title,status | grep '${{ env.BRANCH_TITLE }}' | grep -q Active); then
             echo "Activating environment"
-            platform environment:activate -e $BRANCH_TITLE
+            platform environment:activate -e ${{ env.BRANCH_TITLE }}
           fi

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -8,7 +8,7 @@ env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
   PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
-  BFF_PREFIX: ${{ vars.BFF_PREFIX }}-
+  BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
 jobs:
   get_pr_info:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
 
           # For PRs from forks
           else
-            branch_name="${{ env.BFF_PREFIX }}${{ github.event.number }}"
+            branch_name="${{ env.BRANCH_TITLE }}"
           fi
           echo "::notice::Setting branch name to ${branch_name}."
           echo "branch_name=${branch_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -11,6 +11,7 @@ env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
   PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
+  BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
 
 jobs:
   activate_environment:
@@ -57,8 +58,6 @@ jobs:
 
   deactivate_forked_environment:
     runs-on: ubuntu-latest
-    env:
-      BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
     # For forked PRs labelled as build-fork
     # Delete branch when a PR is closed
     if: >-
@@ -75,7 +74,7 @@ jobs:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         # Check if the Git branch exists
         run: |
-          BRANCH=$(git ls-remote --heads origin $BRANCH_TITLE)
+          BRANCH=$(git ls-remote --heads origin ${{ env.BRANCH_TITLE }})
           echo $BRANCH
 
           if [[ -n $BRANCH ]]; then
@@ -105,7 +104,7 @@ jobs:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         # Check if the built environment exists
         run: |
-          BRANCH=$(platform environments --pipe --columns title | grep $BRANCH_TITLE)
+          BRANCH=$(platform environments --pipe --columns title | grep ${{ env.BRANCH_TITLE }})
 
           if [[ -n $BRANCH ]]; then
             echo "environment_exists=true" >> $GITHUB_OUTPUT
@@ -117,4 +116,4 @@ jobs:
         env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         run: |
-          platform environment:delete --delete-branch --no-wait $BRANCH_TITLE
+          platform environment:delete --delete-branch --no-wait ${{ env.BRANCH_TITLE }}


### PR DESCRIPTION
sets up `BRANCH_TITLE` as an env var for the entire workflow at the beginning for all workflow files where it is used instead of setting it up in various jobs and steps throughout the workflow

## Why

Closes #3096 

