### PR TITLE
[Enhancement] Updates title of psh environment when pr is from fork

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -60,7 +60,11 @@ jobs:
           fi
 
           # If environment not active, activate it
-          if ! $(platform env --format plain --columns title,status | grep '${{ env.BRANCH_TITLE }}' | grep -q Active); then
-            echo "Activating environment"
+          if ! $(platform environment --format plain --columns title,status | grep '${{ env.BRANCH_TITLE }}' | grep -q Active); then
+            echo "::notice::Updating Platform.sh environment title for better tracking..."
+            # in this case we DO want to staticaly include `pr-##` since we're referring to a pull request number
+            newTitle="(pr-${{ github.event.number }}) ${{ github.event.pull_request.title }}"
+            platform environment:info title "${newTitle}" -e ${{ env.BRANCH_TITLE }}
+            echo "::notice::Activating environment ${{ env.BRANCH_TITLE }}"
             platform environment:activate -e ${{ env.BRANCH_TITLE }}
           fi

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -29,6 +29,14 @@ jobs:
       - name: Set up Platform.sh CLI
         uses: ./.github/actions/set-up-cli
 
+      - name: Set environment title
+        run: |
+          newTitle="(pr-${{ github.event.number }}) ${{ github.event.pull_request.title }}"
+          currentTitle=$(platform environment:info title)
+          if [[ "${currentTitle}" != "${newTitle}" ]]; then
+            echo "::notice::Setting environment's title"
+            platform environment:info title "${newTitle}"
+          fi
       - env:
           PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Set environment title
         run: |
+          # @todo - this is the same as the last step in build-from-fork:jobs:build. See if we can combine the two
           newTitle="(pr-${{ github.event.number }}) ${{ github.event.pull_request.title }}"
           currentTitle=$(platform environment:info title)
           if [[ "${currentTitle}" != "${newTitle}" ]]; then


### PR DESCRIPTION
## Why

Closes #3101 

## What's changed

- updates the shortcut `env` to `environment` in the platform command
- adds a section for updating the title of the platformsh environment before we activate it. 
- Closes #3101
