### PR TITLE
Document Lando workaround

### DIFF
--- a/docs/src/development/local/lando.md
+++ b/docs/src/development/local/lando.md
@@ -57,7 +57,8 @@ Run <code>lando init --recipe platformsh --source cwd --platformsh-auth {{% vari
 
 {{< note >}}
 
-If you get an error stating that the `recipe` argument is invalid,
+If for some reason you get an error using the Platform.sh recipe,
+be sure to 
 [install the latest version of the Platform.sh plugin](https://docs.lando.dev/platformsh/getting-started.html#custom-installation)
 and run the command again.
 

--- a/docs/src/development/local/lando.md
+++ b/docs/src/development/local/lando.md
@@ -55,6 +55,14 @@ Otherwise, access the directory with your project.
 
 Run <code>lando init --recipe platformsh --source cwd --platformsh-auth {{% variable "API_TOKEN" %}}</code> and follow the instructions provided by the interactive prompt.
 
+{{< note >}}
+
+If you get an error stating that the `recipe` argument is invalid,
+[install the latest version of the Platform.sh plugin](https://docs.lando.dev/platformsh/getting-started.html#custom-installation)
+and run the command again.
+
+{{< /note >}}
+
 <--->
 
 +++


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #3054 

There was an issue with the `recipe` argument showing as invalid and preventing users from successfully initializing Lando using the documented command.
[Issue was fixed on Lando's side](https://github.com/lando/platformsh/pull/188) but users need to install the latest version of the Platform.sh plugin until this change is reflected on the next Lando general release.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added a temporary note below the command.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
