### PR TITLE
Add a generic GH example snippet.

### DIFF
--- a/docs/layouts/shortcodes/ghExample.html
+++ b/docs/layouts/shortcodes/ghExample.html
@@ -1,0 +1,15 @@
+{{ $repo := .Get "repo" }}
+{{ $path := .Get "path" }}
+{{ $lang := .Get "lang" }}
+
+{{ $url := printf "https://api.github.com/repos/%s/contents/%s" $repo $path }}
+
+<!-- Requires a HUGO_GH_TOKEN environment variable -->
+
+{{ $token := site.Params.GH_TOKEN }}
+{{ $resp := getJSON $url (dict "Accept" "application/vnd.github+json" "Authorization" $token ) }}
+
+{{ $contents:= index $resp "content" | base64Decode }}
+
+<div class="bg-stone px-4 pt-2 rounded-t-lg inline-block text-base pb-1">{{ $path }}</div>
+{{ transform.Highlight $contents $lang }}

--- a/docs/src/guides/wordpress/deploy/configure.md
+++ b/docs/src/guides/wordpress/deploy/configure.md
@@ -26,7 +26,7 @@ We recommend the latest [MariaDB](../../../add-services/mysql/_index.md) version
 
 {{% /guides/config-service %}}
 
-{{< readFile file="static/files/fetch/servicesyaml/wordpress-composer" highlight="yaml" >}}
+{{< ghExample repo="platformsh-templates/wordpress-composer" path=".platform/services.yaml" lang="yaml" >}}
 
 {{% guides/config-routes template="wordpress-composer" name="WordPress" %}}
 


### PR DESCRIPTION
## Why

We'd like to cache as much as possible of the docs build to reduce deployment time and speed up reviews. This PR addresses how example snippets from _templates_ contribute to build times. 

Today, if we want to show an example file that exists on GitHub, the path is as follows:

- Place that file in one of the provide `data` files. For example, showing the `.platform.app.yaml` file from the Next.js template (`github.com/platformsh-templates/nextjs`), we would need to add that line to [this file](https://github.com/platformsh/platformsh-docs/blob/8510555c9589e5c2be67bc5ade9468397b39c1fe/docs/data/remote-examples/templates/app.yaml#L5).
- Once there, [`npm run dev`](https://github.com/platformsh/platformsh-docs/blob/8510555c9589e5c2be67bc5ade9468397b39c1fe/docs/package.json#L16) (local development) and [`npm run build`](https://github.com/platformsh/platformsh-docs/blob/8510555c9589e5c2be67bc5ade9468397b39c1fe/docs/package.json#L13) (Platform.sh) will run `fetch-files`, and [`utils/fetchTemplates.js`](https://github.com/platformsh/platformsh-docs/blob/main/docs/utils/fetchTemplates.mjs). This script 1) cycles through files listed in `data/remote-examples/templates` using `https://raw.githubusercontent.com` to download the files specified, and 2) uses the GitHub Rest API to ping template-builder for the list of _all_ templates to be used in [Project templates](https://docs.platform.sh/development/templates.html), and the bottom of individual runtime pages. All requests are unauthenticated, so files can be `Not found` when rate limits are reached. 
- Unlike [examples](https://github.com/platformsh/platformsh-docs/blob/main/docs/utils/fetch-examples.mjs) taken from examples.docs.platform.sh, these examples are never committed. [The retrieved files are placed in the same destination as those examples, however](https://github.com/platformsh/platformsh-docs/tree/main/docs/static/files/fetch). 
- To place that retrieved file into docs, we use a rewrite of Hugo's `readFile` shortcode 

https://github.com/platformsh/platformsh-docs/blob/8510555c9589e5c2be67bc5ade9468397b39c1fe/docs/src/guides/drupal9/deploy/configure.md?plain=1#L24

- All of this logic exists because, when the shortcode was set up, Hugo did not support [Authentication headers](https://gohugo.io/templates/data-templates/#add-http-headers) in it's `getJSON` function (to hit the GitHub API) - which is no longer the case.

### Downsides

- Files are downloaded on every push.
- Requests are _not_ authenticated, causing occasional failures locally and on environments. 
- Caching logic would need to be built-in with the current system

## What's changed

- A `HUGO_GH_TOKEN` variable has been added to the project.
- This PR does not yet replace/remove the existing way template examples are retrieved. It only adds the shortcode to do so. 
- Call for any file on GitHub using the following shortcode

```html
{{< ghExample repo="platformsh-templates/nextjs" path=".platform.app.yaml" lang="yaml" >}}
```

### Still to consider

- [ ] Local development: the shortcode doesn't contain a fallback for when a GitHub token is not provided via `HUGO_GH_TOKEN`. 
- [ ] Caching itself is not implemented, but `HUGO_CACHE_DIR=$PLATFORM_CACHE_DIR` would allow us to do so, as every `getJSON` result is cached automatically. 
- [ ] If `fetchTemplates.mjs` were to be replaced entirely, another shortcode would need to be defined that built the template lists from template-builder/.platform.template.yaml files
- [ ] Need to review Hugo's security measures to make sure someone can't open a PR with `{{ $token }}` and expose the variable. 

Consideration: what does this do for local - requires a token. Do we still need a committed/user content fallback?