### PR TITLE
Refix DoP link to use correct variable

### DIFF
--- a/docs/layouts/shortcodes/guides/starting-point.md
+++ b/docs/layouts/shortcodes/guides/starting-point.md
@@ -34,7 +34,7 @@ To get {{ $name }} running on Platform.sh, you have two potential starting place
         To use a template, click the button below to create a {{ .Get "name" }} template project.
 
         <p class="flex justify-center not-prose">
-          <a href='https://console.platform.sh/org/create-project?template={{ $templateUrl }}&_utm_campaign=cta_deploy_marketplace_template&utm_source=public_documentation&_utm_medium=organic'>
+          <a href='https://console.platform.sh/org/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/{{ $repo }}/.platform.template.yaml&_utm_campaign=cta_deploy_marketplace_template&utm_source=public_documentation&_utm_medium=organic'>
             <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
           </a>
         </p>


### PR DESCRIPTION
## Why

Stack guide DoP links broken again. Readds fix in https://github.com/platformsh/platformsh-docs/pull/2980
