### PR TITLE
:memo: Update certificate renewal section

### DIFF
--- a/docs/src/define-routes/https.md
+++ b/docs/src/define-routes/https.md
@@ -43,11 +43,8 @@ Alternatively, consider splitting your project up into multiple Platform.sh proj
 When you use the [TLS certificates](#tls-certificates) provided by Platform.sh,
 certificate renewals are automatic.
 They trigger a redeployment of your environment.
-During this redeployment, required security and system upgrades are applied to your containers
-and only the [`post-deploy` hook is run](../create-apps/hooks/hooks-comparison.md).
-
-Renewals take seconds unless upgrades are available for your containers.
-If upgrades are available, your containers are rebuilt, which lengthens the process.
+During this redeployment, required security and system upgrades are applied to your containers.
+So the duration of the redeployment depends on what needs to be upgraded.
 
 ## Enable HTTPS
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

There was an error in the section as it stated that only the post-deploy hook was run during a redeploy post certificate renewal.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Removed the error and changed the wording not to provide unnecessary detail => offer more flexibility as requested by reporter. See context.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
