### PR TITLE
[hotfix] adds ENV for GH_TOKEN

### DIFF
--- a/.github/workflows/check-labels.yaml
+++ b/.github/workflows/check-labels.yaml
@@ -4,6 +4,9 @@ on:
     branches: [main]
     types: [labeled,opened,reopened,synchronize]
 
+env:
+  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+
 jobs:
   check-for-upcoming:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
adds env for GH_TOKEN using secrets.WORKFLOW_TOKEN, since default token in worfklow cant be used to create labels

