### PR TITLE
:memo: Update Opensearch latest version available

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -682,7 +682,7 @@
     "versions": {
       "deprecated": [],
       "supported": [
-        "2.5",
+        "2",
         "1.2",
         "1.1"
       ],
@@ -693,12 +693,13 @@
     "versions-dedicated-gen-2": {
       "deprecated": [],
       "supported": [
+        "2.5",
         "1.2"
       ]
     },
     "versions-dedicated-gen-3": {
       "deprecated": [],
-      "supported": []
+      "supported": [2]
     }
   },
   "oracle-mysql": {

--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -682,7 +682,7 @@
     "versions": {
       "deprecated": [],
       "supported": [
-        "2",
+        "2.5",
         "1.2",
         "1.1"
       ],

--- a/docs/src/add-services/opensearch.md
+++ b/docs/src/add-services/opensearch.md
@@ -21,6 +21,9 @@ To update the versions in this table, use docs/data/registry.json
 |------|-------------------------------|------------------------------ |
 |  {{< image-versions image="opensearch" status="supported" environment="grid" >}} | {{< image-versions image="opensearch" status="supported" environment="dedicated-gen-3" >}} | {{< image-versions image="opensearch" status="supported" environment="dedicated-gen-2" >}} |
 
+On Grid and {{% names/dedicated-gen-3 %}}, from version 2, you only specify the major version.
+The latest compatible minor version and patches are applied automatically.
+
 {{% image-versions-legacy "opensearch" %}}
 
 {{% relationship-ref-intro %}}

--- a/docs/src/add-services/opensearch.md
+++ b/docs/src/add-services/opensearch.md
@@ -21,9 +21,6 @@ To update the versions in this table, use docs/data/registry.json
 |------|-------------------------------|------------------------------ |
 |  {{< image-versions image="opensearch" status="supported" environment="grid" >}} | {{< image-versions image="opensearch" status="supported" environment="dedicated-gen-3" >}} | {{< image-versions image="opensearch" status="supported" environment="dedicated-gen-2" >}} |
 
-From version 2, you only specify the major version.
-The latest compatible minor version and patches are applied automatically.
-
 {{% image-versions-legacy "opensearch" %}}
 
 {{% relationship-ref-intro %}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The only 2.x version supported atm is 2.5, so made that clear in the doc + removed the note about minor versions as it could bring confusion/doesn't apply yet.

ERRATUM: After further exchange with support, it seems 2.5 is the only 2.x version supported on DG2. So I updated the DG2 versions and put the note back but amended it.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
