### PR TITLE
Update check-labels.yaml

### DIFF
--- a/.github/workflows/check-labels.yaml
+++ b/.github/workflows/check-labels.yaml
@@ -5,7 +5,7 @@ on:
     types: [labeled,opened,reopened,synchronize]
 
 env:
-  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+  GH_TOKEN: ${{ secrets.WORKFLOW__LABEL_TOKEN }}
 
 jobs:
   check-for-upcoming:


### PR DESCRIPTION
updates GH_TOKEN to new secret

The current token doesn't have the necessary permissions. Updates the workflow to point to the new secret with the correct permissions