### PR TITLE
changes token back to WORKFLOW__LABEL_TOKEN

### DIFF
--- a/.github/workflows/check-labels.yaml
+++ b/.github/workflows/check-labels.yaml
@@ -5,7 +5,7 @@ on:
     types: [labeled,opened,reopened,synchronize]
 
 env:
-  GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+  GH_TOKEN: ${{ secrets.WORKFLOW__LABEL_TOKEN }}
 
 jobs:
   check-for-upcoming:


### PR DESCRIPTION
no one seems to know what WORKFLOW_TOKEN contains or whose account it belongs to so switching back to the one I set up until we can figure it out.

