### PR TITLE
RabbitMQ deprecated fix

### DIFF
--- a/docs/src/add-services/rabbitmq.md
+++ b/docs/src/add-services/rabbitmq.md
@@ -30,7 +30,7 @@ and your messages a safe place to live until they're received.
 
 | Grid | {{% names/dedicated-gen-3 %}} | {{% names/dedicated-gen-2 %}} |
 |------|-------------------------------|------------------------------ |
-|  {{< image-versions image="rabbitmq" status="supported" environment="grid" >}} | {{< image-versions image="rabbitmq" status="supported" environment="dedicated-gen-3" >}} | {{< image-versions image="rabbitmq" status="supported" environment="dedicated-gen-2" >}} |
+|  {{< image-versions image="rabbitmq" status="deprecated" environment="grid" >}} | {{< image-versions image="rabbitmq" status="deprecated" environment="dedicated-gen-3" >}} | {{< image-versions image="rabbitmq" status="deprecated" environment="dedicated-gen-2" >}} |
 
 ## Usage example
 


### PR DESCRIPTION
## Why

The deprecated table for RabbitMQ service was pulling from the supported registry arrays.

## What's changed

Copypasta fix to pull from deprecated.
