### PR TITLE
Erratum source integrations

### DIFF
--- a/docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -2,6 +2,7 @@
 {{ $source := .Get "source" }}
 {{ $source_variable :=  replace $source " " "_" | lower }}
 {{ $token_variable := print $source_variable "_ACCESS_TOKEN" | upper }}
+{{ $base_url_variable := print $source_variable "_URL" | upper }}
 
 <!-- Handle GitLab's MRs -->
 {{ $pull := "pull" }}
@@ -33,6 +34,40 @@
    - The repository in the form <code>owner/repository</code>` }}
 {{ end }}
 
+<!-- Add explanations for the base-url flag for various sources -->
+{{ $baseUrlExpanation := "" }}
+{{ $baseUrlServer := "GitLab" }}
+{{ $baseUrlSource := "https://gitlab.com" }}
+{{ $baseUrlExample := "" }}
+{{ $baseUrlVariable := print `--base-url {{< variable ` $base_url_variable ` >}} ` }}
+{{ $exampleUrl := "example.com" }}
+{{ if eq $source "GitHub" }}
+  {{ $baseUrlServer = "GitHub Enterprise" }}
+  {{ $baseUrlSource = "https://github.com" }}
+  {{ $exampleUrl = "github.com" }}
+{{ end }}
+{{ if eq $source "GitLab" }}
+  {{ $baseUrlExample = "--base-url https://example.com " }}
+{{ end }}
+{{ if or ( eq $source "GitHub" ) ( eq $source "GitLab" ) }}
+{{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your ` $baseUrlServer ` server if you self-host.
+  If you use <code>` $baseUrlSource `</code>, don't include the <code>base-url</code> flag.` }}
+{{ else if ( eq $source "Bitbucket server" )}}
+  {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your Bitbucket server.` }}
+  {{ $baseUrlExample = "--base-url https://example.com " }}
+{{ else if ( eq $source "Bitbucket" ) }}
+  {{ $baseUrlVariable = "" }}
+  {{ $exampleUrl = "bitbucket.org" }}
+{{ end }}
+
+<!-- GitLab uses the --server-project flag instead of the --repository flag that GitHub and Bitbucket use -->
+{{ $repoVariable := "" }}
+{{ if eq $source "GitLab" }}
+  {{ $repoVariable := print "--server-project {{< variable OWNER/REPOSITORY >}} " }}
+{{ else }}
+  {{ $repoVariable := print "--repository {{< variable OWNER/REPOSITORY >}} " }}
+{{ end }}
+
 <!-- Bitbucket has a different access pattern for each version,
      The initial settings are used for GitLab and GitHub -->
 {{ $accessFlagsVariable := print `--token {{< variable ` $token_variable ` >}}`  }}
@@ -59,19 +94,21 @@ title=Using the CLI
 Run the following command:
 
 <div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \
-` $accessFlagsVariable ` --repository {{< variable "OWNER/REPOSITORY" >}} \
---project {{< variable "PLATFORM_SH_PROJECT_ID" >}}</code></pre></div>
+` $accessFlagsVariable ` \
+` $repoVariable ` \
+` $baseUrlVariable ` --project {{< variable "PLATFORM_SH_PROJECT_ID" >}}</code></pre></div>
 
 ` $accessFlagsExplanation `
 - <code>OWNER/REPOSITORY</code> is the name of the repository in ` $source `.
 - <code>PLATFORM_SH_PROJECT_ID</code> is the ID of your Platform.sh project.
+` $baseUrlExpanation `
 
-For example, if your repository is located at <code>https&colon;//platformsh/platformsh-docs</code>,
+For example, if your repository is located at <code>https&colon;//` $exampleUrl `/platformsh/platformsh-docs</code>,
 the command is similar to the following:
 
 <div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \
 ` $accessFlagsExample ` --repository platformsh/platformsh-docs \
---project abcdefgh1234567</code></pre></div>
+` $baseUrlExample `--project abcdefgh1234567</code></pre></div>
 
 <--->
 +++

--- a/docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -7,6 +7,7 @@
 <!-- Handle GitLab's MRs -->
 {{ $pull := "pull" }}
 {{ if eq $source "GitLab" }}{{ $pull = "merge" }}{{ end }}
+
 <p>To enable the integration, use either the <a href="/administration/cli.html">CLI</a> or the <a href="/administration/web.html">Console</a>.</p>
 
 <!-- Different services have different first steps and access variables,
@@ -28,7 +29,7 @@
   {{ $tokenConsoleInstructions = `
 1. Complete the form with:
    - Your server URL
-   - Your username
+   - Your Bitbucket username
    - The [token you generated](#1-generate-a-token)
    - The Bitbucket server project name
    - The repository in the form <code>owner/repository</code>` }}
@@ -51,7 +52,7 @@
 {{ end }}
 {{ if or ( eq $source "GitHub" ) ( eq $source "GitLab" ) }}
 {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your ` $baseUrlServer ` server if you self-host.
-  If you use <code>` $baseUrlSource `</code>, don't include the <code>base-url</code> flag.` }}
+  If you use the public <code>` $baseUrlSource `</code>, omit the <code>--base-url</code> flag when running the command.` }}
 {{ else if ( eq $source "Bitbucket server" )}}
   {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your Bitbucket server.` }}
   {{ $baseUrlExample = "--base-url https://example.com " }}
@@ -61,11 +62,9 @@
 {{ end }}
 
 <!-- GitLab uses the --server-project flag instead of the --repository flag that GitHub and Bitbucket use -->
-{{ $repoVariable := "" }}
+{{ $repoVariable := print `--repository {{< variable "OWNER/REPOSITORY" >}} ` }}
 {{ if eq $source "GitLab" }}
-  {{ $repoVariable := print "--server-project {{< variable OWNER/REPOSITORY >}} " }}
-{{ else }}
-  {{ $repoVariable := print "--repository {{< variable OWNER/REPOSITORY >}} " }}
+  {{ $repoVariable := print `--server-project {{< variable "OWNER/REPOSITORY" >}} ` }}
 {{ end }}
 
 <!-- Bitbucket has a different access pattern for each version,
@@ -74,43 +73,67 @@
 {{ $accessFlagsExplanation := print `- <code>` $token_variable `</code> is the [token you generated](#1-generate-a-token).` }}
 {{ $accessFlagsExample := "--token abc123" }}
 {{ if ( eq $source "Bitbucket server" ) }}
-  {{ $accessFlagsVariable = print "--username {{< variable USERNAME >}} " $accessFlagsVariable }}
-  {{ $accessFlagsExample = print "--username user@example.com " $accessFlagsExample}}
+  {{ $accessFlagsVariable = print `--username {{< variable BITBUCKET_USERNAME >}} \` "\n  " $accessFlagsVariable }}
+  {{ $accessFlagsExample = print `--username user@example.com \` "\n  " $accessFlagsExample}}
 {{ end }}
 {{ if ( eq $source "Bitbucket" ) }}
-  {{ $accessFlagsVariable = "--key {{< variable CONSUMER_KEY >}} --secret {{< variable CONSUMER_SECRET >}} " }}
+  {{ $accessFlagsVariable = print `--key {{< variable CONSUMER_KEY >}} \` "\n  " "--secret {{< variable CONSUMER_SECRET >}}" }}
   {{ $accessFlagsExplanation = `- <code>CONSUMER_KEY</code> is the key of the [OAuth consumer you created](#1-create-an-oauth-consumer).
 - <code>CONSUMER_SECRET</code> is the secret of the [OAuth consumer you created](#1-create-an-oauth-consumer).` }}
-  {{ $accessFlagsExample = "--key abcd1234 --secret abcd1234" }}
+  {{ $accessFlagsExample = print `--key abcd1234 \` "\n  " "--secret abcd1234" }}
 {{ end }}
 
 <!-- Generate the code tabs
      The strings above are added in by their index at the end of the literal string -->
-{{ $Inner := print `
+{{ $CLIa := print `
 +++
 title=Using the CLI
 +++
 
 Run the following command:
 
-<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \
-` $accessFlagsVariable ` \
-` $repoVariable ` \
-` $baseUrlVariable ` --project {{< variable "PLATFORM_SH_PROJECT_ID" >}}</code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add \
+  --project {{< variable "PLATFORM_SH_PROJECT_ID" >}} \
+  --type ` $source_variable ` \
+  ` $repoVariable `\
+  ` $accessFlagsVariable ` `}}
 
-` $accessFlagsExplanation `
-- <code>OWNER/REPOSITORY</code> is the name of the repository in ` $source `.
+{{ $CLIb := print `
+</code></pre></div>
+`}}
+
+{{ if gt ( len $baseUrlVariable ) 0 }}
+    {{ $CLIb = print `\
+  ` $baseUrlVariable `</code></pre></div>
+    `}}
+{{ end }}
+
+{{ $CLIc := print `
 - <code>PLATFORM_SH_PROJECT_ID</code> is the ID of your Platform.sh project.
+- <code>OWNER/REPOSITORY</code> is the name of the repository in ` $source `.
+` $accessFlagsExplanation `
 ` $baseUrlExpanation `
 
 For example, if your repository is located at <code>https&colon;//` $exampleUrl `/platformsh/platformsh-docs</code>,
 the command is similar to the following:
 
-<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add --type ` $source_variable ` \
-` $accessFlagsExample ` --repository platformsh/platformsh-docs \
-` $baseUrlExample `--project abcdefgh1234567</code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-bash" data-lang="bash">platform integration:add \
+  --project abcdefgh1234567 \
+  --type ` $source_variable ` \
+  --repository platformsh/platformsh-docs \
+  ` $accessFlagsExample ` ` }}
 
-<--->
+{{ $CLId := print `
+</code></pre></div>
+`}}
+
+{{ if gt ( len $baseUrlExample ) 0 }}
+    {{ $CLId := print `\
+  ` $baseUrlExample `</code></pre></div>
+    `}}
+{{ end }}
+
+{{ $ConsoleInner:= print `<--->
 +++
 title=In the Console
 +++
@@ -125,6 +148,9 @@ title=In the Console
 1. Click **Add integration**.
 
 ` }}
+
+{{ $Inner := printf `%s%s%s%s%s` $CLIa $CLIb $CLIc $CLId $ConsoleInner }}
+
 {{ partial "codetabs/tabs" ( dict "Inner" $Inner "Page" .Page ) }}
 
 <p>In both the CLI and Console, you can choose from the following options:</p>

--- a/docs/layouts/shortcodes/source-integration/validate.md
+++ b/docs/layouts/shortcodes/source-integration/validate.md
@@ -22,7 +22,7 @@ If you see a message that the webhook wasn't added, add one manually.
 {{ else if eq $source "GitLab" }}
   {{ $reqdPerms := "Maintainer or Owner" }}
   {{ $permsLink = "https://docs.gitlab.com/ee/user/permissions.html" }}
-{{ end }} 
+{{ end }}
 
 To configure a webhook on a {{ $source }} repository,
 you need to have {{ $reqdPerms }} [user permissions]({{ $permsLink }}). 
@@ -32,5 +32,6 @@ you need to have {{ $reqdPerms }} [user permissions]({{ $permsLink }}).
 {{ .Inner }}
 
 You can now start pushing code, creating new branches,
-and opening {{ if eq $source "GitLab" }}merge{{ else }}pull{{ end }} requests directly in your {{ $source }} repository.
+and opening {{ if eq $source "GitLab" }}merge{{ else }}pull{{ end }} requests
+directly in your {{ $source }} repository.
 Your Platform.sh environments are automatically created and updated.

--- a/docs/layouts/shortcodes/source-integration/validate.md
+++ b/docs/layouts/shortcodes/source-integration/validate.md
@@ -20,7 +20,7 @@ If you see a message that the webhook wasn't added, add one manually.
 {{ else if eq $source "GitHub" }}
   {{ $permsLink = "https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role" }}
 {{ else if eq $source "GitLab" }}
-  {{ $reqdPerms := "Maintainer or Owner" }}
+  {{ $reqdPerms = "Maintainer or Owner" }}
   {{ $permsLink = "https://docs.gitlab.com/ee/user/permissions.html" }}
 {{ end }}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Following #3172 I realized that:

- The shortcode for displaying different user permissions & links depending on the CI/CD tool didn't work as expected (links work well but it always displays Admin rights when it should be Owner or Maintainer on the GitLab page).
- GitLab integration uses `--server-project` instead of `--repository` which I failed to address in #3172.
- The `--base_url` flag, while not a strictly mandatory flag (i.e. it's technically possible to set up an integration without it) _is_ needed if people self host,so I put it back in the doc.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

- Fix the user permissions shortcode.
- Create a shortcode for `--server-project` vs. `--repository` flags.
- Put the info on `--base_url` back in.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
