### PR TITLE
Amend registry to fix display of Opensearch version

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -700,7 +700,9 @@
     },
     "versions-dedicated-gen-3": {
       "deprecated": [],
-      "supported": [2]
+      "supported": [
+        "2"
+      ]
     }
   },
   "oracle-mysql": {


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The supported OpenSearch version wasn't displayed correctly on the DG3 index page because it was improperly entered in the registry file. 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Fixed the registry.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
