### PR TITLE
Remove dot-prefix from applications.yaml

### DIFF
--- a/docs/src/create-apps/multi-app.md
+++ b/docs/src/create-apps/multi-app.md
@@ -159,7 +159,7 @@ you could organize the repository like this:
 ├── main-app
 |  └── ...                  <- PHP app code
 └── .platform
-    ├── .applications.yaml  <- Unified app configuration
+    ├── applications.yaml  <- Unified app configuration
     └── routes.yaml
 ```
 


### PR DESCRIPTION
## Why

The tree structure for unified applications shows `.applications.yaml` where as it's named `applications.yaml` (with no ".") afterwards

## What's changed

Removal of the "." prefix of the `applications.yaml` file shown in the tree structure for unified applications