### PR TITLE
Add mariadb 10.11 to Grid and DG3

### DIFF
--- a/docs/data/registry.json
+++ b/docs/data/registry.json
@@ -421,6 +421,7 @@
         "5.5"
       ],
       "supported": [
+        "10.11",
         "10.6",
         "10.5",
         "10.4",
@@ -444,6 +445,7 @@
     },
     "versions-dedicated-gen-3": {
       "supported": [
+        "10.11 Galera",
         "10.6 Galera",
         "10.5 Galera",
         "10.4 Galera",


### PR DESCRIPTION
## Why

Mariadb 10.11 is missing on Grid and DG3

## What's changed

10.11 version has been added to the two lists.