### PR TITLE
Encourage users to use python2 specifically

### DIFF
--- a/docs/src/create-apps/app-reference.md
+++ b/docs/src/create-apps/app-reference.md
@@ -551,9 +551,8 @@ dependencies:
     php: # Specify one Composer package per line.
         drush/drush: '8.0.0'
         composer/composer: '^2'
-    python: # Specify one Python 2 package per line.
-        behave: '*'
     python2: # Specify one Python 2 package per line.
+        behave: '*'
         requests: '*'
     python3: # Specify one Python 3 package per line.
         numpy: '*'


### PR DESCRIPTION


<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

```
      Generating runtime configuration.

      W: `python` and `python2` depedencies were both specified.
      W: Combine these dependencies in the `python2` block.
      Installing build dependencies...

```

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

remove `python` block and move deps to `python2` block