### PR TITLE
Make info about env prefix more prominent

### DIFF
--- a/docs/src/development/variables/set-variables.md
+++ b/docs/src/development/variables/set-variables.md
@@ -61,6 +61,8 @@ To add a project variable, follow these steps:
 {{< /codetabs >}}
 
 When naming variables, be sure to take [variable prefixes](./_index.md#variable-prefixes) into account.
+In particular, to expose a variable as its own environment variable,
+[use the prefix `env:`](../../development/variables/_index.md#top-level-environment-variables).
 
 ### Variable options
 
@@ -130,6 +132,8 @@ To add a project variable, follow these steps:
 {{< /codetabs >}}
 
 When naming variables, be sure to take [variable prefixes](./_index.md#variable-prefixes) into account.
+In particular, to expose a variable as its own environment variable,
+[use the prefix `env:`](../../development/variables/_index.md#top-level-environment-variables).
 
 ### Environment variable options
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #3271 

We received feedback that the need to include the `env:` prefix to expose a variable as its own environment variable wasn't explicit enough on https://docs.platform.sh/development/variables/set-variables.html. 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added a sentence to make this prerequisite more visible right after both parts mentioning the use of prefixes.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
