### PR TITLE
Remove wrong default values on flexible resources page

### DIFF
--- a/docs/src/create-apps/flexible-resources.md
+++ b/docs/src/create-apps/flexible-resources.md
@@ -17,10 +17,10 @@ The Support team can look into the details of your project.
 
 The `resources` key has the following possible options:
 
-| Name           | Type      | Default | Minimum | Description                                                               |
-| -------------- | --------- | ------- | ------- | ------------------------------------------------------------------------- |
-| `base_memory`  | `integer` | 45      | 64      | The base amount of memory in MB to be given to the container. Up to 1024. |
-| `memory_ratio` | `integer` | 70      | 128     | The amount of memory in MB that increases with CPU size. Up to 1024.      |
+| Name           | Type      | Minimum | Description                                                               |
+| -------------- | --------- | ------- | ------------------------------------------------------------------------- |
+| `base_memory`  | `integer` | 64      | The base amount of memory in MB to be given to the container. Up to 1024. |
+| `memory_ratio` | `integer` | 128     | The amount of memory in MB that increases with CPU size. Up to 1024.      |
 
 The memory allocated to the container is calculated as the base memory plus the memory ratio multiplied by the CPU:
 `memory = base_memory + (memory_ratio * CPU)`.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The docs showed default values for the `base_memory` and `memory_ratio` options (`resources` key) that conflicted with the minimum values advertised within the same table, which generated confusion.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Support confirmed that there are no default values so I removed the `Default` column from the table. 

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
