### PR TITLE
Remove platformify recommendations

### DIFF
--- a/docs/src/guides/laravel/deploy/configure.md
+++ b/docs/src/guides/laravel/deploy/configure.md
@@ -6,7 +6,7 @@ description: |
   Review the basics of what makes up a Platform.sh project, including its three principle configuration files and how to define them for Laravel.
 ---
 
-{{% guides/config-desc name="Laravel" platformify="laravel" %}}
+{{% guides/config-desc name="Laravel" %}}
 
 {{% guides/config-app template="laravel" /%}}
 


### PR DESCRIPTION
## Why

We'll soon have a different tool, and the current suggestion is outdated. This change only affects Laravel.

**WIP**

~This PR is marked WIP since the shortcode is pulling `.Params`, not `.Get "platformify"`, so we need to verify.~

Verified
