### PR TITLE
Lint workflow trigger: s/pull_request_target/pull_request

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,6 +1,6 @@
 name: Linting
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [labeled,opened,reopened,synchronize]
 


### PR DESCRIPTION
## Why

Vale is finding errors that have not been fixed on `main`, even though they have been fixed in a pull request.

## What's changed

`s/pull_request_target/pull_request`