### PR TITLE
Recommend persistent Redis in Drupal guide

### DIFF
--- a/docs/src/guides/drupal9/redis.md
+++ b/docs/src/guides/drupal9/redis.md
@@ -27,19 +27,21 @@ You need:
 You also need a `settings.platformsh.php` file from which you can [manage the configuration of the Redis service](../drupal9/deploy/customize.md#settingsphp).
 If you installed Drupal 9 with a template, this file is already present in your project.
 
-Note that, by default, Redis is an ephemeral service.
+{{< note >}}
+
+By default, Redis is an ephemeral service.
 This means that the Redis storage isn't persistent 
 and that data can be lost when a container is moved, shut down 
 or when the service hits its memory limit.
 
-To solve this, you can change the [service type](../../add-services/redis.md#service-types) 
+To solve this, Platform.sh recommends that you change the [service type](../../add-services/redis.md#service-types) 
 to persistent Redis (`redis-persistent`).
-Alternatively, you can clean the cache each time your app starts 
-via the `start` key in [your web configuration](../../create-apps/app-reference.md#web-commands).
+
+{{< /note >}}
 
 ## Add a Redis service
 
-{{% endpoint-description type="redis" noApp=true onlyLanguage="php" php=true /%}}
+{{% endpoint-description type="redis-persistent" noApp=true onlyLanguage="php" php=true /%}}
 
 ### 3. Add the Drupal module
 

--- a/docs/src/guides/drupal9/redis.md
+++ b/docs/src/guides/drupal9/redis.md
@@ -35,7 +35,7 @@ and that data can be lost when a container is moved, shut down
 or when the service hits its memory limit.
 
 To solve this, Platform.sh recommends that you change the [service type](../../add-services/redis.md#service-types) 
-to persistent Redis (`redis-persistent`).
+to [persistent Redis](../../add-services/redis.md#persistent-redis) (`redis-persistent`).
 
 {{< /note >}}
 

--- a/docs/themes/psh-docs/layouts/partials/examples/config_links.html
+++ b/docs/themes/psh-docs/layouts/partials/examples/config_links.html
@@ -7,6 +7,9 @@
   {{ if eq .type "mongodb-enterprise" }}
     {{ $extension_name = "mongodb" }}
   {{ end }}
+  {{ if eq (.type) "redis-persistent" }}
+   {{ $extension_name = "redis" }}
+  {{ end }}
   {{ if eq (.type) "postgresql" }}
    {{ $extension_name = "pdo_pgsql" }}
   {{ end }}

--- a/docs/themes/psh-docs/layouts/shortcodes/endpoint-description.md
+++ b/docs/themes/psh-docs/layouts/shortcodes/endpoint-description.md
@@ -77,6 +77,9 @@ You can define `<SERVICE_NAME>` and `<RELATIONSHIP_NAME>` as you like, but it's 
   {{ if eq $type "postgresql" }}
    {{ $extension_name = "pdo_pgsql" }}
   {{ end }}
+  {{ if eq $type "redis-persistent" }}
+   {{ $extension_name = "redis" }}
+  {{ end }}
 For PHP, enable the [extension](/languages/php/extensions.html) for the service:
 
 ```yaml {location=".platform.app.yaml"}

--- a/docs/themes/psh-docs/layouts/shortcodes/endpoint-description.md
+++ b/docs/themes/psh-docs/layouts/shortcodes/endpoint-description.md
@@ -27,7 +27,7 @@ To define the service, use {{ if eq ($type) "mariadb" }}
 {{ partial "examples/servicedefn" $data }}
 
 {{ if eq $type "redis-persistent" }}
-Note that persistent Redis requires a disk to store data.
+Note that persistent Redis requires `disk` to store data.
 For more information, refer to the [dedicated Redis page](/add-services/redis.md).
 
 If want to use ephemeral Redis instead, use the `redis` type:

--- a/docs/themes/psh-docs/layouts/shortcodes/endpoint-description.md
+++ b/docs/themes/psh-docs/layouts/shortcodes/endpoint-description.md
@@ -19,20 +19,22 @@
 To define the service, use {{ if eq ($type) "mariadb" }}
   the `{{ $type }}` or `mysql` type for MariaDB or the `oracle-mysql` type for Oracle MySQL
   {{ else if eq $type "redis" }}
-  the `{{ $type }}` type for ephemeral Redis
+  the `{{ $type }}` type for persistent Redis
   {{ else }}
   the `{{ $type }}` type{{ end }}:
 
 <!-- Create an example services.yaml file from data in the registry. -->
 {{ partial "examples/servicedefn" $data }}
 
-{{ if eq $type "redis" }}
-Alternatively, use the `redis-persistent` type for persistent Redis:
+{{ if eq $type "redis-persistent" }}
+Note that persistent Redis requires a disk to store data.
+For more information, refer to the [dedicated Redis page](/add-services/redis.md).
 
-  {{ $redis_data := index .Site.Data.registry "redis-persistent" }}
+If want to use ephemeral Redis instead, use the `redis` type:
+
+  {{ $redis_data := index .Site.Data.registry "redis" }}
   {{ partial "examples/servicedefn" $redis_data }}
 
-Persistent Redis requires a disk to store data.
 {{ else if eq $type "network-storage" }}
 You can define `<SERVICE_NAME>` as you like, but it shouldn't include underscores (`_`).
 {{ else if eq $type "elasticsearch" }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Redis ephemeral config came first on https://docs.platform.sh/guides/drupal9/redis.html#1-configure-the-service which could be taken as we recommend ephemeral vs persistent, when in fact it's the opposite.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added formatted note to Before you begin section to recommend Redis persistent + swapped the order of the configs to highlight Redis persistent first.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
