### PR TITLE
Custom domains on non-prod env - Update --replace to --attach

### DIFF
--- a/docs/src/domains/steps/custom-non-production-domains.md
+++ b/docs/src/domains/steps/custom-non-production-domains.md
@@ -64,7 +64,7 @@ You need:
   For more information, contact [Support](https://console.platform.sh/-/users/~/tickets/open).   
 - A production environment with at least one custom domain already set up
 - At least one non-production (staging or development) environment
-- The [Platform.sh CLI](../../administration/cli/_index.md) (v4.3.0+) <BR>
+- The [Platform.sh CLI](../../administration/cli/_index.md) (v4.8.0+) <BR>
   In the current Beta version, you can only add and manage non-production custom domains
   through the [Platform.sh CLI](../../administration/cli/_index.md).
   In future versions, you'll be able to do so in the [Platform.sh Console](../../administration/web/_index.md) too.
@@ -129,7 +129,7 @@ title=In the Console
 3. Run a command similar to the following:
 
    ```bash
-   platform domain:add staging.example.com --environment {{< variable "STAGING_ENVIRONMENT_ID" >}} --replace {{< variable "PRODUCTION_CUSTOM_DOMAIN_TO_REPLACE" >}}
+   platform domain:add staging.example.com --environment {{< variable "STAGING_ENVIRONMENT_ID" >}} --attach {{< variable "PRODUCTION_CUSTOM_DOMAIN_TO_ATTACH" >}}
    ```
 
    {{< note title="Example" >}}
@@ -140,7 +140,7 @@ title=In the Console
    To do so, run the following command:
 
    ```bash
-   platform domain:add mydev.com --environment Dev --replace mysite.com
+   platform domain:add mydev.com --environment Dev --attach mysite.com
    ```
 
    {{< /note >}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Update of the custom domains on non-production environments doc page.
We released a new version of the CLI (4.8.0) today, where the --replace option is changed to --attach.
So I'm updating this page accordingly.

## What's changed

Update `--replace` option to `--attach`.
