### PR TITLE
[Fix] Update path on get-pr-info

### DIFF
--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -141,13 +141,13 @@ jobs:
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
 
             # Rewrite all Markdown files in the source to be links in the final environment
-            if [[ $file = "sites/platform/"*".md" ]]; then
+            if [[ $file = "sites/platform/src/"*".md" ]]; then
 
               # Remove file extension
               page=${file/.md/.html}
 
               # Remove initial directory
-              page=${page/"sites/platform/"/}
+              page=${page/"sites/platform/src/"/}
 
               # Shift index pages up a level
               page=${page/"/_index.html"/".html"}


### PR DESCRIPTION
## Why

Closes https://github.com/platformsh/platformsh-docs/issues/3344

Following #3328, the path on "Get info from PR" was updated, but didn't include the `/src/` subdirectory. So this stays in the "changed files" links included in the PR comment. 

## What's changed

Path is updated.

As seen in https://github.com/platformsh/platformsh-docs/pull/3338

![CleanShot 2023-08-11 at 14 13 29](https://github.com/platformsh/platformsh-docs/assets/5473659/d7b99e8a-9459-4f7a-a99d-fa5b5967a126)
