### PR TITLE
Fix command on logs page

### DIFF
--- a/sites/platform/src/increase-observability/logs/access-logs.md
+++ b/sites/platform/src/increase-observability/logs/access-logs.md
@@ -110,7 +110,7 @@ title=Using SSH directly
    If you're on a {{% names/dedicated-gen-2 %}} cluster, run
 
    ``` bash
-   /var/log/platform/{{% variable "APP_NAME" %}}/
+   cd /var/log/platform/{{% variable "APP_NAME" %}}/
    ```
 
 3. Read the desired log, such as by running `tail access.log`.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

`cd` was missing from a command.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Fixed the command.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
