### PR TITLE
🐛 Fix vendor/name substitution in premium/add-on banner

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/premium-features/add-on.html
+++ b/themes/psh-docs/layouts/shortcodes/premium-features/add-on.html
@@ -1,5 +1,5 @@
 {{ $feature := .Get "feature" }}
-{{ $content := print $feature ` isn't included in any {{ .Site.Params.vendor.name }} plan.
+{{ $content := print $feature ` isn't included in any ` .Site.Params.vendor.name ` plan.
 You need to add it separately at an additional cost.
 To add ` $feature `, [contact Sales](https://platform.sh/contact/).`}}
     


### PR DESCRIPTION
## What's changed

Vendor/name replacement in banner was using incorrect format.
