### PR TITLE
Update guide-buttons for vendor/name substitution

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/guide-buttons.html
+++ b/themes/psh-docs/layouts/shortcodes/guide-buttons.html
@@ -1,3 +1,4 @@
+{{ $pageContext := .Page }}
 {{ $navType := "*" }}
 {{ with .Get "type" }}
   {{ $navType = . }}
@@ -15,7 +16,7 @@
 
   <!-- Next button -->
   <a href="{{ .Page.PrevInSection.Permalink }}" type="button" class="{{ partial "pink-button-styles" }}">
-    {{ with .Get "next" }}{{ . }}{{ end }}
+    {{ with .Get "next" }}{{ . | $pageContext.RenderString }}{{ end }}
     <img class="inline" aria-hidden="true" alt="" src="/images/icons/chevrons.svg" />
   </a>
 
@@ -40,7 +41,7 @@
         {{ end }}
       {{ end }}
       <a href="{{ $firstPageInSection.Permalink }}" type="button" class="{{ partial "pink-button-styles" }}">
-        {{ with .Get "next" }}{{ . }}{{ end }}
+        {{ with .Get "next" }}{{ . | $pageContext.RenderString }}{{ end }}
         <img class="inline" aria-hidden="true" alt="" src="/images/icons/chevrons.svg" />
       </a>
   {{ end }}


### PR DESCRIPTION
## Why

Fixes vendor/name rendering in `guide-buttons`, seen in https://docs.platform.sh/guides/laravel/deploy/configure.html
