### PR TITLE
Postgres typo fix

### DIFF
--- a/sites/platform/src/add-services/postgresql.md
+++ b/sites/platform/src/add-services/postgresql.md
@@ -349,7 +349,7 @@ extensions not listed here.
 * `pgrouting` - pgRouting Extension (requires 9.6 or higher)
 * `pgrowlocks` - show row-level locking information
 * `pgstattuple` - show tuple-level statistics
-* `pgvector` - Open-source vector similarity search for Postgres 11+
+* `pgvector` - Open-source vector similarity search for PostgreSQL 11+
 * `plpgsql` - PL/pgSQL procedural language
 * `postgis` - PostGIS geometry, geography, and raster spatial types and functions
 * `postgis_sfcgal` - PostGIS SFCGAL functions


### PR DESCRIPTION
## Why

Closes https://github.com/platformsh/platformsh-docs/issues/3400

Vale error introduced in https://github.com/platformsh/platformsh-docs/pull/3391 for "Postgres/PostgreSQL". This is a fix for that to unblock current PR Vale tests.
