### PR TITLE
Add versioning shortcodes

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/version/only.html
+++ b/themes/psh-docs/layouts/shortcodes/version/only.html
@@ -1,0 +1,10 @@
+<!-- Markdown passed between shortcode `vendor/inner` will render only if the current version = first passed variable -->
+<!-- For example, -->
+<!-- {{< vendor/only "1" >}} -->
+<!-- platform variable:get  -->
+<!-- {{< /vendor/only >}} -->
+<!-- When the site is built, the `platform` command will appear iff vendor.config.version = 1 in params.yaml -->
+{{- $version := .Site.Params.vendor.config.version -}}
+{{- if eq $version ( int (.Get 0)) -}}
+    {{- .Inner | .Page.RenderString -}}
+{{- end -}}

--- a/themes/psh-docs/layouts/shortcodes/version/only.html
+++ b/themes/psh-docs/layouts/shortcodes/version/only.html
@@ -1,8 +1,8 @@
 <!-- Markdown passed between shortcode `vendor/inner` will render only if the current version = first passed variable -->
 <!-- For example, -->
-<!-- {{< vendor/only "1" >}} -->
+<!-- vendor/only "1" -->
 <!-- platform variable:get  -->
-<!-- {{< /vendor/only >}} -->
+<!-- /vendor/only -->
 <!-- When the site is built, the `platform` command will appear iff vendor.config.version = 1 in params.yaml -->
 {{- $version := .Site.Params.vendor.config.version -}}
 {{- if eq $version ( int (.Get 0)) -}}

--- a/themes/psh-docs/layouts/shortcodes/version/specific.html
+++ b/themes/psh-docs/layouts/shortcodes/version/specific.html
@@ -1,0 +1,18 @@
+<!-- Markdown processes 2 versions, rendering only if key matches current version -->
+<!-- Key 1: Version 1; the first Inner prior to the dividing character -->
+<!-- Key 2: Version 2; the second Inner after the dividing character -->
+<!-- For example, -->
+<!-- {{< vendor/specific >}} -->
+<!-- platform variable:get  -->
+<!-- \<---\>  -->
+<!-- friday variable:get -->
+<!-- {{< /vendor/specific}} -->
+{{- $page := .Page -}}
+{{- $version := .Site.Params.vendor.config.version -}}
+{{- $splitVersionChar := "<--->" -}}
+{{- range $k, $v := split .Inner $splitVersionChar -}}
+    {{- $current := add $k 1 -}}
+    {{- if eq $current $version -}}
+{{- $v | $page.RenderString -}}
+    {{- end -}}
+{{- end -}}

--- a/themes/psh-docs/layouts/shortcodes/version/specific.html
+++ b/themes/psh-docs/layouts/shortcodes/version/specific.html
@@ -2,11 +2,11 @@
 <!-- Key 1: Version 1; the first Inner prior to the dividing character -->
 <!-- Key 2: Version 2; the second Inner after the dividing character -->
 <!-- For example, -->
-<!-- {{< vendor/specific >}} -->
+<!-- vendor/specific -->
 <!-- platform variable:get  -->
-<!-- \<---\>  -->
+<!-- (divider: see $splitVersionChar below)  -->
 <!-- friday variable:get -->
-<!-- {{< /vendor/specific}} -->
+<!-- /vendor/specific -->
 {{- $page := .Page -}}
 {{- $version := .Site.Params.vendor.config.version -}}
 {{- $splitVersionChar := "<--->" -}}


### PR DESCRIPTION
## Why

A versioning shortcode was to be introduced in https://github.com/platformsh/platformsh-docs/pull/3387, but it can be used now in a few open PRs, so this adds them by themselves. 

## What's changed

- `version/only` allows `.Inner` content only to render when belonging to a specific API version (1 or 2)
- `version/specific` provides a space for both API versions, using a `<--->` divider character to alternate what is rendered on which version of the docs. 