### PR TITLE
[Bug fix] Corrects issue with PR titles

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -30,6 +30,8 @@ jobs:
       # Create an environment and activate it
       - env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+          # @see activate_environment:Set environment title:env in manage-environment.yaml
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Get most recent changes
           git checkout ${{ github.event.pull_request.head.sha }}
@@ -63,8 +65,7 @@ jobs:
           if ! $(platform environments --format plain --columns title,status | grep '${{ env.BRANCH_TITLE }}' | grep -q Active); then
             echo "::notice::Updating Platform.sh environment title for better tracking..."
             # in this case we DO want to statically include `pr-##` since we're referring to a pull request number
-            prTitle=${{ github.event.pull_request.title }}
-            newTitle="(pr-${{ github.event.number }}) $(echo prTitle | gawk '{ gsub(/"/,"\\\"") } 1')"
+            newTitle="(pr-${{ github.event.number }}) ${PR_TITLE}"
             platform environment:info title "${newTitle}" -e ${{ env.BRANCH_TITLE }}
             echo "::notice::Activating environment ${{ env.BRANCH_TITLE }}"
             platform environment:activate -e ${{ env.BRANCH_TITLE }}

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -31,10 +31,16 @@ jobs:
         uses: ./.github/actions/set-up-cli
 
       - name: Set environment title
+        env:
+          # Github does not escape PR titles before swapping the token with the value. This means that in a shell context
+          # if a PR title includes a single or double quote, it will break the shell command. If you try to enclose
+          # the value with quotes before assigning it to a variable, it will also break. The only way around it is to
+          # assign it as an environmental variable for the step which will force GitHub to escape it properly for the
+          # shell, and *then* you can use it
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # @todo - this is the same as the last step in build-from-fork:jobs:build. See if we can combine the two
-          prTitle=${{ github.event.pull_request.title }}
-          newTitle="(pr-${{ github.event.number }}) $(echo prTitle | gawk '{ gsub(/"/,"\\\"") } 1')"
+          newTitle="(pr-${{ github.event.number }}) ${PR_TITLE}"
           currentTitle=$(platform environment:info -e ${{ github.event.pull_request.head.ref }} title)
           if [[ "${currentTitle}" != "${newTitle}" ]]; then
             echo "::notice::Setting environment's title"


### PR DESCRIPTION
## Why

Closes #3413 

## What's changed
adds `env:PR_TITLE` to the "Set environment title" and "Create an environment and activate it" steps in the manage-environments and build-from-fork workflows. Then references the environmental variable instead of the `${{ github.event.number }}` context.

Github does not escape PR titles before swapping the token/context with the value. This means that in a shell if a PR title includes a single or double quote, it will break the shell command. If you try to enclose the context with quotes before assigning it to a variable, it will also break. The only way around it is to assign it as an environmental variable for the step which will cause GitHub to escape it properly in order for it to be assigned as an environmental variable, and *then* you can use it in shell commands. 