### PR TITLE
Fix banners and keywords

### DIFF
--- a/sites/platform/src/create-apps/source-operations.md
+++ b/sites/platform/src/create-apps/source-operations.md
@@ -3,11 +3,12 @@ title: Source operations
 description: Run automated code updates via source operations.
 weight: 5
 banner: 
-    title: Availability
-    body: All of the examples on this page can be run on Enterprise or Elite projects only.
-          To upgrade your plan or request a trial, [contact Sales](https://platform.sh/contact/).
+    type: tiered-feature
 keywords:
-  - "Automated code updates"
+  - "automated code updates"
+  - "automated code update"
+  - "source operations"
+  - "source operation"
 ---
 
 On {{< vendor/name >}}, you can run automated code updates through a feature called **source operations**.
@@ -264,6 +265,8 @@ The example above synchronizes the `development` environment with its parent
 and then runs the `update-file` source operation defined [previously](#define-a-source-operation).
 
 ## Source operation examples
+
+{{< premium-features/tiered "Enterprise and Elite" >}}
 
 ### Update your application dependencies
 

--- a/sites/platform/src/integrations/source/_index.md
+++ b/sites/platform/src/integrations/source/_index.md
@@ -2,6 +2,8 @@
 title: Source integrations
 weight: -4
 description: See how to maintain your code in a third-party repository that's linked to your {{< vendor/name >}} project.
+keywords:
+- "source integration"
 ---
 
 You might want to keep your code in a third-party repository that's linked to your {{< vendor/name >}} project.

--- a/sites/platform/src/integrations/source/bitbucket.md
+++ b/sites/platform/src/integrations/source/bitbucket.md
@@ -2,6 +2,9 @@
 title: Integrate with Bitbucket
 sidebarTitle: Bitbucket
 description: See how to manage your {{< vendor/name >}} environments directly from your Bitbucket repository.
+keywords:
+- "source integration"
+- "source integrations"
 ---
 
 {{% source-integration/intro source="Bitbucket" %}}

--- a/sites/platform/src/integrations/source/github.md
+++ b/sites/platform/src/integrations/source/github.md
@@ -2,6 +2,9 @@
 title: Integrate with GitHub
 sidebarTitle: GitHub
 description: See how to manage your {{< vendor/name >}} environments directly from your GitHub repository.
+keywords:
+- "source integration"
+- "source integrations"
 ---
 
 {{% source-integration/intro source="GitHub" %}}

--- a/sites/platform/src/integrations/source/gitlab.md
+++ b/sites/platform/src/integrations/source/gitlab.md
@@ -2,6 +2,9 @@
 title: Integrate with GitLab
 sidebarTitle: GitLab
 description: See how to manage your {{< vendor/name >}} environments directly from your GitLab repository.
+keywords:
+- "source integration"
+- "source integrations"
 ---
 
 {{% source-integration/intro source="GitLab" %}}

--- a/sites/platform/src/integrations/source/troubleshoot.md
+++ b/sites/platform/src/integrations/source/troubleshoot.md
@@ -3,6 +3,9 @@ title: Resolve access issues with source integrations
 sidebarTitle: Resolve access
 description: Learn how to troubleshoot access rights for integrated repositories.
 toc: false
+keywords:
+- "source integration"
+- "source integrations"
 ---
 
 If you [add a user](/administration/users.md#add-a-user-to-a-project) to a {{< vendor/name >}} project,

--- a/sites/platform/src/tutorials/dependency-updates.md
+++ b/sites/platform/src/tutorials/dependency-updates.md
@@ -1,13 +1,15 @@
 ---
 title: Automate your code updates
-keywords:
-  - "Automated code updates"
-  - "source operations"
 description: Learn how to automate your dependency updates through a source operation.
 weight: 1
 tier:
   - Elite
   - Enterprise
+keywords:
+  - "automated code updates"
+  - "automated code update"
+  - "source operations"
+  - "source operation"
 ---
 
 {{< vendor/name >}} allows you to update your dependencies through [source operations](../create-apps/source-operations.md).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Tier availability wasn't obvious if you jumped to examples section of the source operations page. Also, Meilisearch doesn't seem to have a feature to retrieve both the singular and plural forms of a keyword, so I added both forms to the keywords of the page and did the same for the source integration section.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
