### PR TITLE
fix: pgvector use vector extension name

### DIFF
--- a/sites/platform/src/add-services/postgresql.md
+++ b/sites/platform/src/add-services/postgresql.md
@@ -349,7 +349,6 @@ extensions not listed here.
 * `pgrouting` - pgRouting Extension (requires 9.6 or higher)
 * `pgrowlocks` - show row-level locking information
 * `pgstattuple` - show tuple-level statistics
-* `pgvector` - Open-source vector similarity search for PostgreSQL 11+
 * `plpgsql` - PL/pgSQL procedural language
 * `postgis` - PostGIS geometry, geography, and raster spatial types and functions
 * `postgis_sfcgal` - PostGIS SFCGAL functions
@@ -367,6 +366,7 @@ extensions not listed here.
 * `tsm_system_time` - TABLESAMPLE method which accepts time in milliseconds as a limit (requires 9.6 or higher)
 * `unaccent` - text search dictionary that removes accents
 * `uuid-ossp` - generate universally unique identifiers (UUIDs)
+* `vector` - Open-source [vector](https://github.com/pgvector/pgvector) similarity search for PostgreSQL 11+
 * `xml2` - XPath querying and XSLT
 
 {{< note >}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

pgvector use vector extension name https://github.com/pgvector/pgvector

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Fix the name