### PR TITLE
Update PSH Blackfire doc page

### DIFF
--- a/sites/platform/src/increase-observability/integrate-observability/blackfire.md
+++ b/sites/platform/src/increase-observability/integrate-observability/blackfire.md
@@ -2,11 +2,11 @@
 title: "Blackfire"
 sidebarTitle: Blackfire
 weight: 1
-sectionBefore: In-house observability tool 
+sectionBefore: In-house observability tool
 description: Blackfire is the official {{% vendor/name %}} observability service for monitoring and profiling your PHP and Python apps.
 ---
 
-As the **official {{% vendor/name %}} observability service**, 
+As the **official {{% vendor/name %}} observability service**,
 [Blackfire](https://www.blackfire.io/) helps you improve the performance of your apps at each stage of their lifecycle.
 With Blackfire's unique Application Performance Monitoring (APM) and Profiling features,
 you can achieve the following goals:
@@ -20,7 +20,6 @@ you can achieve the following goals:
 Blackfire is installed natively on {{% vendor/name %}} and [works integrally with the {{% vendor/name %}} workflow](https://www.youtube.com/watch?v=Bq-LFjgD6L0).
 This results in an effortless setup process and smooth user experience.
 
-{{% version/specific %}}
 {{< note >}}
 
 Blackfire.io can be bundled with Enterprise and Elite subscriptions as part of the Observability Suite.
@@ -31,7 +30,7 @@ All customers can also subscribe to Blackfire separately.
 
 ## Set up Blackfire
 
-### On a Grid or {{% names/dedicated-gen-3 %}} infrastructure 
+### On a Grid or {{% names/dedicated-gen-3 %}} infrastructure
 
 If you're using a plan with the [Observability Suite](https://platform.sh/features/observability-suite/),
 the [Blackfire automated integration](#automated-integration) is enabled on your environments by default.
@@ -54,8 +53,8 @@ To do so, follow these steps:
 6. Follow [the instructions from the Blackfire documentation](https://blackfire.io/docs/integrations/paas/platformsh).
 
 If you're using the [Managed Fastly CDN](../../domains/cdn/managed-fastly.md),
-it's already configured to operate with Blackfire. 
-If you're using a different [Content Delivery Network (CDN)](../../domains/cdn/_index.md), 
+it's already configured to operate with Blackfire.
+If you're using a different [Content Delivery Network (CDN)](../../domains/cdn/_index.md),
 make sure you [configure it](https://blackfire.io/docs/integrations/proxies/index)
 to let Blackfire profile the code running on your servers.
 
@@ -74,120 +73,61 @@ To install Blackfire on your {{% names/dedicated-gen-2 %}} environments:
 6. Send those credentials to [Support](https://console.platform.sh/-/users/~/tickets/open) so they complete the installation.
 
 If you're using the [Managed Fastly CDN](../../domains/cdn/managed-fastly.md),
-it's already configured to operate with Blackfire. 
-If you're using a different [Content Delivery Network (CDN)](../../domains/cdn/_index.md), 
+it's already configured to operate with Blackfire.
+If you're using a different [Content Delivery Network (CDN)](../../domains/cdn/_index.md),
 make sure you [configure it](https://blackfire.io/docs/integrations/proxies/index)
 to let Blackfire profile the code running on your servers.
-
-<--->
-## Get started with Blackfire
-You can only access your Blackfire environments after you've been granted access to the related {{% vendor/name %}} project.
-Therefore, to access your Blackfire environments, make sure you log in using your {{% vendor/name %}} account.
-
-To access a Blackfire environment, each project user needs a Blackfire account.
-When a project user doesn't already have a Blackfire account, 
-a new one is automatically created using the user's {{% vendor/name %}} credentials.
-
-{{< note >}}
-If you're using a [Content Delivery Network (CDN)](../../domains/cdn/_index.md), 
-make sure you [configure it](https://blackfire.io/docs/integrations/proxies/index)
-to let Blackfire profile the code running on your servers.
-{{< /note >}}
-{{% /version/specific %}}
 
 ### Automated integration
 
-{{% version/specific %}}
 {{< partial "observability-suite/body.md" >}}
 
 The Blackfire automated integration is available for Grid and {{% names/dedicated-gen-3 %}} environments.
-
-<--->
-The Blackfire automated integration is enabled on your environments by default.
-
-{{% /version/specific %}}
 
 When you create a new environment,
 it automatically triggers the creation of a Blackfire environment with the same settings.
 On this Blackfire environment, you have access to [all the features provided by Blackfire](https://www.blackfire.io/features/).
 This includes monitoring, profiling, alerting, and build-related features.
 
-{{% version/specific %}}
 When a Blackfire environment is created based on a Grid environment,
 user access settings are replicated from the {{% vendor/name %}} Console to Blackfire.
 
-<--->
-Note that Blackfire monitoring is enabled by default on your production environment.
-On other environment types, you need to [enable it](#blackfire-monitoring).
-User access settings are replicated from the {{% vendor/name %}} Console to Blackfire.
-
-{{% /version/specific %}}
-
 This includes all [access levels](https://blackfire.io/docs/up-and-running/access-management).
 
-{{% version/specific %}} 
 To access the Blackfire environment, each project user needs a Blackfire account.
-When a project user doesn't already have a Blackfire account, 
+When a project user doesn't already have a Blackfire account,
 a new one is automatically created using the user's {{% vendor/name %}} credentials.
-<--->
-{{% /version/specific %}}
- 
+
 You might have Blackfire variables already set on your project.
 In this case, the existing variables override the settings of the automated integration.
 
-{{% version/specific %}}
 Note that to trigger the synchronization of changes to users and their access levels,
 you need to redeploy the environment.
 
 ## Get started with Blackfire Monitoring
 
-Once Blackfire is [set up on your infrastructure](#set-up-blackfire), 
+Once Blackfire is [set up on your infrastructure](#set-up-blackfire),
 to start monitoring your environment follow these steps:
 
-1. For Python apps, you need to [activate Blackfire Monitoring](#1-activate-blackfire-monitoring) first.
-2. For both Python and PHP apps, you need to [enable Blackfire Monitoring on the required environments](#2-enable-blackfire-monitoring-on-your-environments).
-
-<--->
-
-{{% /version/specific %}}
-
-
-{{% version/specific %}}
 ### 1. Activate Blackfire Monitoring
 
-If you want to monitor a PHP app, Blackfire Monitoring is available by default on your environments.
+If you want to monitor a PHP or Python app, Blackfire Monitoring is available by default on your environments.
 You only need to [specify which environments](#2-enable-blackfire-monitoring-on-your-environments) you want to monitor.
 
-If you want to monitor a Python app, you need to activate Blackfire Monitoring yourself.
-To do so, create the following [environment variable](../../development/variables/set-variables.md#create-environment-specific-variables):
+You can override the default behavior and deactivate Blackfire Monitoring by setting a `env:BLACKFIRE_APM_ENABLED`
+[environment variable](../../development/variables/set-variables.md#create-environment-specific-variables) with a value of `0`.
+
+To do so, create the following :
 
 ```bash
-{{% vendor/cli %}} variable:create --level environment --prefix env: --name BLACKFIRE_APM_ENABLED --value 1
+{{% vendor/cli %}} variable:create --level environment --prefix env: --name BLACKFIRE_APM_ENABLED --value 0
 ```
 
-If you later need to deactivate Blackfire Monitoring, change the value of the variable to `0`.
-
-<--->
-
-{{< note >}}
-To trigger the synchronization of changes to users and their access levels,
-you need to redeploy the environment.
-{{< /note >}}
-
-{{% /version/specific %}}
-
-{{% version/specific %}}
 ### 2. Enable Blackfire Monitoring on your environments
 
 To enable Blackfire Monitoring on your environments, follow these steps:
 
-<--->
-### Blackfire monitoring
-Blackfire monitoring is enabled by default on your production environment. 
-To enable Blackfire monitoring on your development or staging environments, follow these steps:
-{{% /version/specific %}}
-
-1.  Go to your [organizations list](https://blackfire.io/my/organizations) 
+1.  Go to your [organizations list](https://blackfire.io/my/organizations)
     and select the organization where you want to enable Blackfire monitoring.
 
 2.  Click **Organization Monitoring Usage**.
@@ -210,7 +150,7 @@ This helps you find the root cause of performance bottlenecks.
 
 Blackfire lets you profile your application anywhere it's deployed,
 including on your local development machines.
-Using a browser extension or CLI command, 
+Using a browser extension or CLI command,
 you can profile HTTP requests, CLI scripts, Consumers, and Daemons.
 
 For more information on Blackfire profiling features,
@@ -264,7 +204,7 @@ follow these steps:
 To retrieve startup errors, run the following command:
 
 ```bash
-{{% vendor/cli %}} ssh -- php -d display_startup_errors=on --ri blackfire 
+{{% vendor/cli %}} ssh -- php -d display_startup_errors=on --ri blackfire
 ```
 
 ### 2. Retrieve your Blackfire logs


### PR DESCRIPTION
- remove vendorization for a page now existing only on Platform's side
- Blackfire monitoring is now enable by default for PHP and Python