### PR TITLE
typo: java language page

### DIFF
--- a/sites/platform/src/languages/java/_index.md
+++ b/sites/platform/src/languages/java/_index.md
@@ -223,7 +223,7 @@ highlight=java
 
 {{% version/only "1" %}}
 
-{{% config-reader %}} [Java configuration reader library](https://github.com/platformsh/config-reader-java){{% /config-reader%}}
+{{% config-reader %}}[ Java configuration reader library](https://github.com/platformsh/config-reader-java){{% /config-reader%}}
 
 If your Java framework allows, you can instead overwrite configuration following the [twelve-factor app](https://12factor.net/config).
 That removes the need for an additional dependency.

--- a/sites/platform/src/languages/java/_index.md
+++ b/sites/platform/src/languages/java/_index.md
@@ -223,7 +223,7 @@ highlight=java
 
 {{% version/only "1" %}}
 
-{{% config-reader %}}[Java configuration reader library](https://github.com/platformsh/config-reader-java){{% /config-reader%}}
+{{% config-reader %}} [Java configuration reader library](https://github.com/platformsh/config-reader-java){{% /config-reader%}}
 
 If your Java framework allows, you can instead overwrite configuration following the [twelve-factor app](https://12factor.net/config).
 That removes the need for an additional dependency.


### PR DESCRIPTION
Not sure about this. There's a missing ' ' but I don't know if this is the right fix.