### PR TITLE
[chore-3555] Removes section on cron jobs for laravel

### DIFF
--- a/sites/platform/src/guides/laravel/deploy/scheduling.md
+++ b/sites/platform/src/guides/laravel/deploy/scheduling.md
@@ -5,31 +5,47 @@ weight: -100
 description: Schedule tasks for your Laravel app.
 ---
 
+{{< note theme="warning" >}}
+The use of workers requires a [Medium plan](/administration/pricing/_index.md#multiple-apps-in-a-single-project)
+or greater.
+{{< /note >}}
+
 Laravel offers a very convenient and flexible way of scheduling tasks. A large set of [helper functions](https://laravel.com/docs/scheduling#schedule-frequency-options) help you schedule commands and jobs.
 
 Once the scheduled tasks are defined, they need to be effectively executed at the right time and pace.
-The recommended way is a cron configuration entry running the `artisan schedule:run` command.
+The recommended way is a cron configuration entry running the `artisan schedule:run` command schedule for every minute.
+However, on Platform.sh the [minimum time between cron jobs](../../../create-apps/app-reference.md#cron-job-timing)
+depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency. Schedules outside the
+specified cron frequency are ignored and the related tasks aren't triggered.
 
-```yaml {configFile="app"}
-crons:
-    # Run Laravel's scheduler every 5 minutes, which is as often as crons can run on Professional plans.
-    scheduler:
-        spec: '*/5 * * * *'
-        cmd: 'php artisan schedule:run'
-```
+Due to this conflict, we suggest utilizing [workers](/create-apps/workers.md) to run both the scheduler and the queue
+systems (the [Laravel template](https://github.com/platformsh-templates/laravel) utilizes this method). In order to have
+enough resources to support these workers as well as services (e.g. MariaDB, Redis, etc), a
+**[Medium plan](/administration/pricing/_index.md#multiple-apps-in-a-single-project) _or greater_ is required**.
 
-The [minimum time between cron jobs](../../../create-apps/app-reference.md#cron-job-timing) being triggered depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency. Schedules outside the specified cron frequency are ignored and the related tasks aren't triggered.
-
-This [blog post](https://platform.sh/blog/of-cicadas-and-cron-jobs/) may help you understand the stakes and harmonize the frequencies so all your scheduled tasks can be effectively triggered.
-
-You could also [configure a worker](../../../create-apps/workers.md) that relies on `artisan schedule:work`.
-To invoke the scheduler every minute, run [the following command](https://laravel.com/docs/scheduling#running-the-scheduler-locally):
+To use workers to handle scheduling and queues add the following to your {{< vendor/configfile "app" >}} file:
 
 ```yaml {configFile="app"}
 workers:
-   queue:
-       size: S
-       commands:
-           start: php artisan schedule:work
+  queue:
+    size: S
+    commands:
+      # To minimize leakage, the queue worker will stop every hour
+      # and get restarted automatically.
+      start: |
+        php artisan queue:work --max-time=3600
+    disk: 256
+  scheduler:
+    size: S
+    commands:
+      start: php artisan schedule:work
+    disk: 256
 ```
+
+{{< note theme="warning" >}}
+By default, [workers inherit all top level properties](/create-apps/workers.md#inheritance) from the parent application.
+You may need to override certain properties in the worker configuration above depending on your application.
+{{< /note >}}
+
+
 

--- a/sites/platform/src/guides/laravel/deploy/scheduling.md
+++ b/sites/platform/src/guides/laravel/deploy/scheduling.md
@@ -14,7 +14,7 @@ Laravel offers a very convenient and flexible way of scheduling tasks. A large s
 
 Once the scheduled tasks are defined, they need to be effectively executed at the right time and pace.
 The recommended way is a cron configuration entry running the `artisan schedule:run` command schedule for every minute.
-However, on Platform.sh the [minimum time between cron jobs](../../../create-apps/app-reference.md#cron-job-timing)
+However, on {{% vendor/name %}} the [minimum time between cron jobs](../../../create-apps/app-reference.md#cron-job-timing)
 depends on your plan. Task scheduling may then be contradicted by the cron minimum frequency. Schedules outside the
 specified cron frequency are ignored and the related tasks aren't triggered.
 


### PR DESCRIPTION

## Why

Closes #3555 

## What's changed

- Removes section on cron jobs
- Replaces crons with workers
- Adds warning that workers require medium plan
- Adds warning that workers inherit top-level properties from parent application 
- Closes #3555

The https://docs.platform.sh/guides/laravel/deploy/configure.html#configure-apps-in-platformappyaml section will be updated once the [PR for the laravel template](https://github.com/platformsh-templates/laravel/pull/54) has been accepted. 

It's unclear if crons in Upsun share the same restrictions as the ones in Platform.sh. Once we have clarification, we may need to update the Upsun docs in a similar fashtion. 
