### PR TITLE
Remove unnecessary closing parenthesis on App reference page

### DIFF
--- a/sites/platform/src/create-apps/app-reference.md
+++ b/sites/platform/src/create-apps/app-reference.md
@@ -121,7 +121,7 @@ That is, if a custom value for `source.root` is not provided in your configurati
 
 {{% /version/specific %}}
 
-To specify another directory, for example for a [multi-app project](./multi-app/_index.md)),
+To specify another directory, for example for a [multi-app project](./multi-app/_index.md),
 use the [`source.root` property](#source).
 
 ## Types


### PR DESCRIPTION


## Why

Typo fix on https://docs.platform.sh/create-apps/app-reference.html

## What's changed

Fixes minor typo removing unnecessary closing parenthesis, from:

> To specify another directory, for example for a [multi-app project](https://docs.platform.sh/create-apps/multi-app.html))

to:

> To specify another directory, for example for a [multi-app project](https://docs.platform.sh/create-apps/multi-app.html)

