### PR TITLE
Updated templateRepo variable to render the correct Drupal template repository links.

### DIFF
--- a/sites/platform/src/guides/drupal/deploy/_index.md
+++ b/sites/platform/src/guides/drupal/deploy/_index.md
@@ -11,7 +11,7 @@ Drupal is a flexible and extensible PHP-based CMS framework. To deploy Drupal on
 
 This guide assumes you are using the well-supported Composer flavor of Drupal.
 
-{{% guides/starting-point name="Drupal" templateRepo="drupal" composerLink="https://github.com/drupal/recommended-project/" initExample=true %}}
+{{% guides/starting-point name="Drupal" templateRepo="drupal10" composerLink="https://github.com/drupal/recommended-project/" initExample=true %}}
 
 {{% guides/requirements %}}
 


### PR DESCRIPTION
## Why

- A broken link to Drupal template was found on this [page](https://docs.platform.sh/guides/drupal/deploy.html). Updating variable `templateRepo` to `drupal10` should render a valid link. 
- Closes #3550

## What's changed
- Updated variable `templateRepo` in `sites/platform/src/guides/drupal/deploy/_index.md` from `drupal` to `drupal10`
- This should render the correct link in Drupal documentation pages