### PR TITLE
Flatten enable-integration shortcode

### DIFF
--- a/sites/platform/src/integrations/source/bitbucket.md
+++ b/sites/platform/src/integrations/source/bitbucket.md
@@ -33,7 +33,71 @@ Copy the **Key** and **Secret** for your consumer.
 
 ### 2. Enable the Cloud integration
 
-{{< source-integration/enable-integration source="Bitbucket" >}}
+To enable the integration, use either the [CLI](/administration/cli.html) or the [Console](/administration/web.html).
+
+{{< codetabs >}}
+
++++
+title=Using the CLI
++++
+
+Run the following command:
+
+```bash
+platform integration:add \
+  --project {{% variable "PROJECT_ID" %}} \
+  --type bitbucket \
+  --repository {{% variable "OWNER/REPOSITORY" %}} \
+  --key {{% variable "CONSUMER_KEY" %}} \
+  --secret {{% variable "CONSUMER_SECRET" %}}
+```
+
+- `PROJECT_ID` is the ID of your {{% vendor/name %}} project.
+- `OWNER/REPOSITORY` is the name of your repository in Bitbucket.
+- `CONSUMER_KEY` is is the key of the [OAuth consumer you created](#1-create-an-oauth-consumer).
+- `CONSUMER_SECRET` is the secret of the [OAuth consumer you created](#1-create-an-oauth-consumer).
+
+For example, if your repository is located at `https://bitbucket.org/platformsh/platformsh-docs`,
+the command is similar to the following:
+
+```bash
+platform integration:add \
+  --project abcdefgh1234567 \
+  --type bitbucket \
+  --repository platformsh/platformsh-docs \
+  --key abc123 \
+  --secret abcd1234 \
+```
+
+<--->
+
++++
+title=In the Console
++++
+
+1. Select the project where you want to enable the integration.
+1. Click **{{< icon settings >}} Settings**.
+1. Under **Project settings**, click **Integrations**.
+1. Click **+ Add integration**.
+1. Under **Bitbucket**, click **+ Add**.
+1. Complete the form with:
+   - The repository in the form `owner/repository`
+   - The [key and secret you generated](#1-create-an-oauth-consumer)
+1. Check that the other options match what you want.
+1. Click **Add integration**.
+
+{{< /codetabs >}}
+
+In both the CLI and Console, you can choose from the following options:
+
+| CLI flag         | Default | Description                                                               |
+| ---------------- | ------- | ------------------------------------------------------------------------- |
+| `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
+| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the Bitbucket repository. Automatically disabled when fetching branches is disabled. |
+| `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
+| `resync-pull-requests` | `false` | Whether to sync data from the parent environment on every push to a pull request. |
+
+To [keep your repository clean](/learn/bestpractices/clean-repository) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 
 {{% source-integration/validate source="Bitbucket" %}}
 1. Follow the [Bitbucket instructions to create a webhook](https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/#Create-webhooks)

--- a/sites/platform/src/integrations/source/bitbucket.md
+++ b/sites/platform/src/integrations/source/bitbucket.md
@@ -44,7 +44,7 @@ title=Using the CLI
 Run the following command:
 
 ```bash
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project {{% variable "PROJECT_ID" %}} \
   --type bitbucket \
   --repository {{% variable "OWNER/REPOSITORY" %}} \
@@ -61,7 +61,7 @@ For example, if your repository is located at `https://bitbucket.org/platformsh/
 the command is similar to the following:
 
 ```bash
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project abcdefgh1234567 \
   --type bitbucket \
   --repository platformsh/platformsh-docs \

--- a/sites/platform/src/integrations/source/github.md
+++ b/sites/platform/src/integrations/source/github.md
@@ -65,7 +65,7 @@ title=Using the CLI
 Run the following command:
 
 ```bash
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project {{% variable "PROJECT_ID" %}} \
   --type github \
   --repository {{% variable "OWNER/REPOSITORY" %}} \
@@ -83,7 +83,7 @@ For example, if your repository is located at `https://github.com/platformsh/pla
 the command is similar to the following:
 
 ```bash
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project abcdefgh1234567 \
   --type github \
   --repository platformsh/platformsh-docs \

--- a/sites/platform/src/integrations/source/github.md
+++ b/sites/platform/src/integrations/source/github.md
@@ -54,7 +54,74 @@ generate and copy your token.
 
 ## 2. Enable the integration
 
-{{< source-integration/enable-integration source="GitHub" >}}
+To enable the integration, use either the [CLI](/administration/cli.html) or the [Console](/administration/web.html).
+
+{{< codetabs >}}
+
++++
+title=Using the CLI
++++
+
+Run the following command:
+
+```bash
+platform integration:add \
+  --project {{% variable "PROJECT_ID" %}} \
+  --type github \
+  --repository {{% variable "OWNER/REPOSITORY" %}} \
+  --token {{% variable "GITHUB_ACCESS_TOKEN" %}} \
+  --base-url {{% variable "GITHUB_URL" %}}
+```
+
+- `PROJECT_ID` is the ID of your {{% vendor/name %}} project.
+- `OWNER/REPOSITORY` is the name of your repository in GitHub.
+- `GITHUB_ACCESS_TOKEN` is the [token you generated](#1-generate-a-token).
+- `GITHUB_URL` is the base URL for your GitHub server if you self-host.
+   If you use the public `https://github.com`, omit the `--base-url` flag when running the command.
+
+For example, if your repository is located at `https://github.com/platformsh/platformsh-docs`,
+the command is similar to the following:
+
+```bash
+platform integration:add \
+  --project abcdefgh1234567 \
+  --type github \
+  --repository platformsh/platformsh-docs \
+  --token abc123
+```
+
+<--->
+
++++
+title=In the Console
++++
+
+1. Select the project where you want to enable the integration.
+1. Click **{{< icon settings >}} Settings**.
+1. Under **Project settings**, click **Integrations**.
+1. Click **+ Add integration**.
+1. Under **GitHub**, click **+ Add**.
+1. Add the [token you generated](#1-generate-a-token).
+1. Optional: If your GitHub project isn’t hosted at `github.com`, enter your GitHub custom domain.
+1. Click **Continue**.
+1. Choose the repository to use for the project.
+1. Check that the other options match what you want.
+1. Click **Add integration**.
+
+{{< /codetabs >}}
+
+In both the CLI and Console, you can choose from the following options:
+
+| CLI flag         | Default | Description                                                               |
+| ---------------- | ------- | ------------------------------------------------------------------------- |
+| `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
+| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitHub repository. Automatically disabled when fetching branches is disabled. |
+| `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
+| `build-draft-pull-requests` | `true` | Whether to also track and build draft pull requests. Automatically disabled when pull requests aren’t built. |
+| `pull-requests-clone-parent-data` | `true` | 	Whether to clone data from the parent environment when creating a pull request environment. |
+| `build-pull-requests-post-merge`| `false` | Whether to build what would be the result of merging each pull request. Turning it on forces rebuilds any time something is merged to the target branch. |
+
+To [keep your repository clean](/learn/bestpractices/clean-repository) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 
 {{% source-integration/validate source="GitHub" %}}
 1. In your GitHub repository, click **Settings** > **Webhooks** > **Add webhook**.

--- a/sites/platform/src/integrations/source/gitlab.md
+++ b/sites/platform/src/integrations/source/gitlab.md
@@ -46,7 +46,7 @@ title=Using the CLI
 Run the following command:
 
 ```bash
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project {{% variable "PROJECT_ID" %}} \
   --type gitlab \
   --server-project {{% variable "PROJECT/SUBPROJECT" %}} \
@@ -64,7 +64,7 @@ For example, if your repository is located at `https://gitlab.com/platformsh/pla
 the command is similar to the following:
 
 ```bash
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project abcdefgh1234567 \
   --type gitlab \
   --server-project platformsh/platformsh-docs \

--- a/sites/platform/src/integrations/source/gitlab.md
+++ b/sites/platform/src/integrations/source/gitlab.md
@@ -51,7 +51,7 @@ platform integration:add \
   --type gitlab \
   --server-project {{% variable "PROJECT/SUBPROJECT" %}} \
   --token {{% variable "GITLAB_ACCESS_TOKEN" %}} \
-  --base-url {{% variable "GITLAB_URL" %}} \
+  --base-url {{% variable "GITLAB_URL" %}}
 ```
 
 - `PROJECT_ID` is the ID of your {{% vendor/name %}} project.
@@ -60,7 +60,7 @@ platform integration:add \
 - `GITLAB_URL` is the base URL for your GitLab server if you self-host.
    If you use the public `https://gitlab.com`, omit the `--base-url` flag when running the command.
 
-For example, if your repository is located at `https://example.com/platformsh/platformsh-docs`,
+For example, if your repository is located at `https://gitlab.com/platformsh/platformsh-docs`,
 the command is similar to the following:
 
 ```bash
@@ -96,12 +96,12 @@ In both the CLI and Console, you can choose from the following options:
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
 | `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
-| `prune-branches` | `true`  | Whether to delete branches from Platform.sh that don’t exist in the GitLab repository. Automatically disabled when fetching branches is disabled. |
+| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitLab repository. Automatically disabled when fetching branches is disabled. |
 | `build-merge-requests` | `true` | Whether to track all merge requests and create active environments from them, which builds the merge request. |
 | `build-wip-merge-requests` | `true` | Whether to also track and build draft merge requests. Automatically disabled when merge requests aren’t built. |
 | `merge-requests-clone-parent-data` | `true` | Whether to clone data from the parent environment when creating a merge request environment. |
 
-To [keep your repository clean](/learn/bestpractices/clean-repository) and avoid performance issues, make sure you enable both the fetch-branches and prune-branches options.
+To [keep your repository clean](/learn/bestpractices/clean-repository) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 
 {{% source-integration/validate source="GitLab" %}}
 1. In your GitLab repository, click **Settings** > **Webhooks**.

--- a/sites/platform/src/integrations/source/gitlab.md
+++ b/sites/platform/src/integrations/source/gitlab.md
@@ -35,7 +35,73 @@ and grants more permissions.
 
 ## 2. Enable the integration
 
-{{< source-integration/enable-integration source="GitLab" >}}
+To enable the integration, use either the [CLI](/administration/cli.html) or the [Console](/administration/web.html).
+
+{{< codetabs >}}
+
++++
+title=Using the CLI
++++
+
+Run the following command:
+
+```bash
+platform integration:add \
+  --project {{% variable "PROJECT_ID" %}} \
+  --type gitlab \
+  --server-project {{% variable "PROJECT/SUBPROJECT" %}} \
+  --token {{% variable "GITLAB_ACCESS_TOKEN" %}} \
+  --base-url {{% variable "GITLAB_URL" %}} \
+```
+
+- `PROJECT_ID` is the ID of your {{% vendor/name %}} project.
+- `PROJECT/SUBPROJECT` is the name of your repository in GitLab.
+- `GITLAB_ACCESS_TOKEN` is the [token you generated](#1-generate-a-token).
+- `GITLAB_URL` is the base URL for your GitLab server if you self-host.
+   If you use the public `https://gitlab.com`, omit the `--base-url` flag when running the command.
+
+For example, if your repository is located at `https://example.com/platformsh/platformsh-docs`,
+the command is similar to the following:
+
+```bash
+platform integration:add \
+  --project abcdefgh1234567 \
+  --type gitlab \
+  --server-project platformsh/platformsh-docs \
+  --token abc123
+```
+
+<--->
+
++++
+title=In the Console
++++
+
+1. Select the project where you want to enable the integration.
+1. Click **{{< icon settings >}} Settings**.
+1. Under **Project settings**, click **Integrations**.
+1. Click **+ Add integration**.
+1. Under **GitLab**, click **+ Add**.
+1. Add the [token you generated](#1-generate-a-token).
+1. Optional: If your GitLab project isn’t hosted at `gitlab.com`, enter your GitLab custom domain.
+1. Click **Continue**.
+1. Choose the repository to use for the project.
+1. Check that the other options match what you want.
+1. Click **Add integration**.
+
+{{< /codetabs >}}
+
+In both the CLI and Console, you can choose from the following options:
+
+| CLI flag         | Default | Description                                                               |
+| ---------------- | ------- | ------------------------------------------------------------------------- |
+| `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
+| `prune-branches` | `true`  | Whether to delete branches from Platform.sh that don’t exist in the GitLab repository. Automatically disabled when fetching branches is disabled. |
+| `build-merge-requests` | `true` | Whether to track all merge requests and create active environments from them, which builds the merge request. |
+| `build-wip-merge-requests` | `true` | Whether to also track and build draft merge requests. Automatically disabled when merge requests aren’t built. |
+| `merge-requests-clone-parent-data` | `true` | Whether to clone data from the parent environment when creating a merge request environment. |
+
+To [keep your repository clean](/learn/bestpractices/clean-repository) and avoid performance issues, make sure you enable both the fetch-branches and prune-branches options.
 
 {{% source-integration/validate source="GitLab" %}}
 1. In your GitLab repository, click **Settings** > **Webhooks**.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The `enable-integration.html` shortcode has become too complex, hindering maintenance. 

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

- [x] Hardcode `Enable the integration` step on GitLab page.
- [x] Change `--repository` flag to `--server-project` for GitLab.
- [x] Hardcode `Enable the integration` step on GitHub page.
- [x] Hardcode `Enable the Cloud integration` step on Bitbucket page.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
