### PR TITLE
Chore/3565 flask resources

### DIFF
--- a/sites/friday/src/get-started/flask/deploy/configure.md
+++ b/sites/friday/src/get-started/flask/deploy/configure.md
@@ -102,7 +102,7 @@ To do so, make the following changes to the `{{% vendor/configfile "app" %}}` fi
    {{< /note >}}
 
 2. Configure some writable disk space to hold the static assets that `flask-static-digest` generates and `npm` builds.</br>
-   To do so, define the `./APP_NAME/static` directory as [a mount](/create-apps/app-reference.md#mounts).
+   To do so, define the `./<APP_NAME>/static` directory as [a mount](/create-apps/app-reference.md#mounts).
    Locate the section dedicated to mounts:
 
    ```yaml {configFile="app"}
@@ -110,7 +110,7 @@ To do so, make the following changes to the `{{% vendor/configfile "app" %}}` fi
    # More information: https://docs.upsun.com/create-apps/app-reference.html#mounts
    # mounts:
    #   "/.cache": # Represents the path in the app.
-   #     source: "local" # "local" sources are unique to the app, while "service" sources can be shared among apps.
+   #     source: "storage" # "local" sources are unique to the app, while "service" sources can be shared among apps.
    #     source_path: "cache" # The subdirectory within the mounted disk (the source) where the mount should point.
    ```
 
@@ -118,10 +118,11 @@ To do so, make the following changes to the `{{% vendor/configfile "app" %}}` fi
 
    ```yaml {configFile="app"}
    mounts:
-       "app_name/static":
-           source: "local"
+       "<APP_NAME>/static":
+           source: "storage"
            source_path: "static_assets"
    ```
+  Replacing `<APP_NAME>` above with the `app_name` you [defined previously](#1-optional-generate-a-flask-project-with-cookiecutter).
 
 3. Instruct {{% vendor/name %}} to automatically run `npm install` when building the application container.</br>
    To do so, customize your [build hook](/create-apps/hooks/hooks-comparison.html#build-hook).

--- a/sites/friday/src/get-started/flask/deploy/configure.md
+++ b/sites/friday/src/get-started/flask/deploy/configure.md
@@ -23,16 +23,16 @@ and [authenticated with your {{% vendor/name %}} account](/administration/cli/_i
    This command is also available as `{{% vendor/cli %}} ify`.
 
 2. Follow the prompts to determine your project requirements:
-   
+
    - Select Python as the language for your project.</br>
      {{% vendor/name %}} then automatically detects your dependency manager.
 
    - Enter the name of your app.
 
-   - Select the services you need.
+   - Select the services you need (for this guide, select `PostgreSQL` as we'll use it later)
 
    - Hit **Enter**.</br>
-   
+
    Your {{% vendor/name %}} configuration files are generated.
 
 3. Add all the generated files to your Git repository.
@@ -56,7 +56,7 @@ you need to create and configure a {{% vendor/name %}} project first.
    ```
 
 2. To configure your {{% vendor/name %}} project, follow the prompts:
-   
+
    - Create or select your organization.
 
    - Name your project.
@@ -122,7 +122,7 @@ To do so, make the following changes to the `{{% vendor/configfile "app" %}}` fi
            source: "local"
            source_path: "static_assets"
    ```
-   
+
 3. Instruct {{% vendor/name %}} to automatically run `npm install` when building the application container.</br>
    To do so, customize your [build hook](/create-apps/hooks/hooks-comparison.html#build-hook).
    Locate the section dedicated to it:

--- a/sites/friday/src/get-started/flask/deploy/deploy.md
+++ b/sites/friday/src/get-started/flask/deploy/deploy.md
@@ -14,7 +14,7 @@ After your app is deployed, you can [adjust those resources](/manage-resources.m
    ```bash {location="Terminal"}
    {{% vendor/cli %}} environment:push
    ```
-   
+
    The following question is displayed:
 
    ```bash
@@ -22,18 +22,17 @@ After your app is deployed, you can [adjust those resources](/manage-resources.m
    ```
 
 2. To activate your initial environment, answer `Y`.</br>
-   {{% vendor/name %}} reads your configuration files and builds your application container. 
-   
+   {{% vendor/name %}} reads your configuration files and builds your application container.
+
    {{< note theme="warning">}}
-   When you first deploy your Upsun project, you get notified that you need to configure the resources on your environment:
+   When you first deploy your Upsun project, you get notified that you need to provide a disk size, and you will receive a notice:
 
    ```bash
-   The push completed but resources must be configured before deployment can succeed.
+   The push completed but there was a deployment error ("Invalid deployment")..
    ```
-
-   This is because {{% vendor/name %}} doesn't know the exact amount of resources your project needs to run smoothly.
-   Therefore, your app can only be successfully deployed after you've configured those resources
-   through the {{% vendor/name %}} CLI or [through the Console](/manage-resources.md#configure-resources).
+  {{% vendor/name %}} doesn't know how much disk your application requires for the PostgreSQL service. Therefore, your app can only
+   be successfully deployed after you've configured the disk amount for the PostgreSQL service through the
+   {{% vendor/name %}} CLI or [through the Console](/manage-resources.md#configure-resources).
 
    {{< /note >}}
 
@@ -45,14 +44,14 @@ After your app is deployed, you can [adjust those resources](/manage-resources.m
 
 4. Follow the prompts to set resources for your app:
 
-   - Define which CPU and RAM combination you want to allocate to your application container. 
+   - Define which CPU and RAM combination you want to allocate to your application container.
    - Define how many instances of our application container you want to deploy.
    - Define how much disk space you want to allocate to the mount
      [previously defined](/get-started/flask/deploy/configure.md#configure-your-upsun-project) in `{{< vendor/configfile "app" >}}`.
 
 5. Now follow the prompts to set resources for your services, one by one:
-   
-   - Define which CPU and RAM combination you want to allocate to your service container.  
+
+   - Define which CPU and RAM combination you want to allocate to your service container.
    - If the service is a database, it needs persistent disk storage to save your data.
      Define how much disk space you want to allocate to your database.</br>
      Note that each {{% vendor/name %}} project starts with 5GB of data that is shared across all services.

--- a/sites/friday/src/get-started/flask/deploy/deploy.md
+++ b/sites/friday/src/get-started/flask/deploy/deploy.md
@@ -36,7 +36,7 @@ After your app is deployed, you can [adjust those resources](/manage-resources.m
 
    {{< /note >}}
 
-3. To set project resources using the CLI, run the following command:
+3. To [set project resources](/manage-resources.md) using the CLI, run the following command:
 
    ```shell
    {{% vendor/cli %}} resources:set

--- a/sites/friday/src/get-started/flask/deploy/prepare.md
+++ b/sites/friday/src/get-started/flask/deploy/prepare.md
@@ -18,7 +18,7 @@ To do so, make the following changes to the `.environment` file automatically ge
 
    And amend it to specify the type of your database.
    For instance, if you have a PostgreSQL database, change the line to:
-   
+
    ```bash {location=".environment"}
    export DATABASE_URL="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}"
    ```
@@ -46,7 +46,7 @@ To do so, make the following changes to the `.environment` file automatically ge
    ```
 
    This command sets the log level to `info` for your production environment, and to `debug` for your preview environments.
-   
+
 5. To adjust the cache control maximum age depending on the type of environment, add the following line:
 
 	```bash {location=".environment"}
@@ -56,6 +56,10 @@ To do so, make the following changes to the `.environment` file automatically ge
    This command sets the maximum age to `31556926` for your production environment, and to `0` for your preview environments.
 
 6. Point the `SECRET_KEY` environment variable to the {{% vendor/name %}}-provided [ `PLATFORM_PROJECT_ENTROPY` variable](/development/variables/use-variables.md#use-provided-variables).</br>
+   ```bash {location=".environment"}
+   export SECRET_KEY="${PLATFORM_PROJECT_ENTROPY}"
+    ```
+
    The `SECRET_KEY` environment variable ensures the session cookie is signed securely,
    and can be used for any other security-related needs by extensions or your app.
 
@@ -64,7 +68,7 @@ To do so, make the following changes to the `.environment` file automatically ge
 
 	 ```bash {location=".environment"}
      export GUNICORN_WORKERS=1
-     ```   
+     ```
 
 8. To commit and push your changes, run the following command:
 


### PR DESCRIPTION
## Why

Closes #3565 

## What's changed

- re-adds mention of selecting PostgreSQL for purposes of the guide when selecting services
- readds missing export of `SECRET_KEY` to step 6 when configuring environment variables
- updates reference to `app_name`
- changes `source:local` to `source:storage` for mounts in configuration file
- updates message concerning failure on first push given changes to how resources are handled


