### PR TITLE
Fix: remove irrelevant local dev section on Upsun doc

### DIFF
--- a/sites/platform/src/development/local/_index.md
+++ b/sites/platform/src/development/local/_index.md
@@ -81,6 +81,7 @@ If your app requires services to run, you have two options for developing locall
 
 Choose the option that works for you and get your services running.
 
+{{% version/specific %}}
 ## 3. Build your site locally
 
 If you want your local development environment to be enclosed 
@@ -103,3 +104,5 @@ To build your site locally:
 
 3.  To check that the build was successful, move to the `_www` directory
     and run a web server.
+<--->
+{{% /version/specific %}}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

Adding shortcodes to make sure this section is only displayed for Platform.sh doc, as the command still exists there and should be documented.