### PR TITLE
rabbitmq: sequential upgrades need their own deployment

### DIFF
--- a/sites/platform/src/add-services/rabbitmq.md
+++ b/sites/platform/src/add-services/rabbitmq.md
@@ -284,4 +284,4 @@ To create virtual hosts, add them to your configuration as in the following exam
 ## Upgrading
 
 When upgrading RabbitMQ, skipping major versions (e.g. 3.7 -> 3.11) [is not supported](https://www.rabbitmq.com/upgrade.html#rabbitmq-version-upgradability).
-Make sure you upgrade sequentially (3.7 -> 3.8 -> 3.9 -> 3.10 -> 3.11).
+Make sure you upgrade sequentially (3.7 -> 3.8 -> 3.9 -> 3.10 -> 3.11) and that each upgrade commit translates into an actual deployment.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Sequential upgrades work only if they're followed by an actual deployment (`git push`), otherwise it results in skipping versions (and a stuck deployment).
## What's changed
docs
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
