### PR TITLE
Vendorize form partial for neg feedback path.

### DIFF
--- a/themes/psh-docs/layouts/partials/feedback/form.html
+++ b/themes/psh-docs/layouts/partials/feedback/form.html
@@ -35,7 +35,7 @@
     const currentUrl =
       location.protocol + "//" + location.host + location.pathname;
     {{ with page.File }}
-      const repoURL = {{ printf "https://github.com/platformsh/platformsh-docs/blob/main/sites/%s" (substr (index ( split .Filename "sites") 1) 1 ) }}
+      const repoURL = {{ printf "%sblob/main/sites/%s" site.Params.repo (substr (index ( split .Filename "sites") 1) 1 ) }}
     {{ end }}
     return {
       feedbackSubmitted: false,

--- a/themes/psh-docs/layouts/partials/feedback/form.html
+++ b/themes/psh-docs/layouts/partials/feedback/form.html
@@ -34,13 +34,14 @@
   function FeedbackForm() {
     const currentUrl =
       location.protocol + "//" + location.host + location.pathname;
-    const repoURL = {{ printf "https://github.com/platformsh/platformsh-docs/blob/main/%s/src" site.Params.folder }}
+    {{ with page.File }}
+      const repoURL = {{ printf "https://github.com/platformsh/platformsh-docs/blob/main/sites/%s" (substr (index ( split .Filename "sites") 1) 1 ) }}
+    {{ end }}
     return {
       feedbackSubmitted: false,
       feedback: "",
       editPageUrl:
-        repoURL + 
-        location.pathname.replace(".html", ".md"),
+        repoURL,
       issueUrl:
         "https://github.com/platformsh/platformsh-docs/issues/new?template=improvements.yml&where_on_docs_platform_sh_should_be_changed=" +
         currentUrl +

--- a/themes/psh-docs/layouts/partials/feedback/form.html
+++ b/themes/psh-docs/layouts/partials/feedback/form.html
@@ -34,11 +34,12 @@
   function FeedbackForm() {
     const currentUrl =
       location.protocol + "//" + location.host + location.pathname;
+    const repoURL = {{ printf "https://github.com/platformsh/platformsh-docs/blob/main/%s/src" site.Params.folder }}
     return {
       feedbackSubmitted: false,
       feedback: "",
       editPageUrl:
-        "https://github.com/platformsh/platformsh-docs/blob/main/docs/src" +
+        repoURL + 
         location.pathname.replace(".html", ".md"),
       issueUrl:
         "https://github.com/platformsh/platformsh-docs/issues/new?template=improvements.yml&where_on_docs_platform_sh_should_be_changed=" +


### PR DESCRIPTION
## Why

Reported that "suggest a change" (thumbs down) feedback path on path is 404, cause by lack of vendorized path update. This PR fixes that path via site Params. 