### PR TITLE
Using default endpoints in service reference pages.

### DIFF
--- a/themes/psh-docs/layouts/partials/examples/relationship.html
+++ b/themes/psh-docs/layouts/partials/examples/relationship.html
@@ -13,6 +13,8 @@
   {{- $serviceName = .servName -}}
 {{- end -}}
 {{ $relationshipComment := "# Relationships enable access from this app to a given service." }}
+{{ $relationshipComment = printf "%s\n# The example below shows simplified configuration leveraging default endpoints." $relationshipComment}}
+{{ $relationshipComment = printf "%s\n# See the Application reference for all options for defining relationships and endpoints." $relationshipComment}}
 
 {{- $l1 := printf "\n%s\nrelationships:" $relationshipComment}}
 
@@ -23,5 +25,6 @@
 {{- end -}}
 
 {{- $l2 := printf "%s%s: \"%s:%s\"" $apiIndent $relationshipName $serviceName $endpoint -}}
+{{- $l2_updated := printf "%s%s: " $apiIndent $serviceName -}}
 
-{{- printf "%s\n%s" $l1 $l2 | safeHTML -}}
+{{- printf "%s\n%s" $l1 $l2_updated | safeHTML -}}

--- a/themes/psh-docs/layouts/partials/examples/servicedefn.html
+++ b/themes/psh-docs/layouts/partials/examples/servicedefn.html
@@ -44,4 +44,4 @@
 
 {{- end -}}
 
-{{ printf "%s\n%s%s%s%s" $l1 $l2 $l3 $l4 $l5 | safeHTML }}
+{{ printf "%s%s%s%s%s" $l1 $l2 $l3 $l4 $l5 | safeHTML }}

--- a/themes/psh-docs/layouts/partials/snippet.html
+++ b/themes/psh-docs/layouts/partials/snippet.html
@@ -127,7 +127,6 @@
             {{- $servicesKey = printf "%s:\n" .context.Site.Params.vendor.config.prefix.services -}}
         {{- end -}}
 
-
         {{- if and (eq $placeholder "true") (not .Inner) -}}
             {{- $prepend = printf "# %s#    %s" $servicesKey "..." -}}
         {{- else -}}

--- a/themes/psh-docs/layouts/shortcodes/endpoint-description.md
+++ b/themes/psh-docs/layouts/shortcodes/endpoint-description.md
@@ -86,12 +86,17 @@ in step 1](#1-configure-the-service){{ else }}`{{ $data.endpoint }}` endpoint{{ 
 ```
 
 <!-- Adds a note about naming conventions between relationship and service names. Keep em unique. -->
-You can define `<SERVICE_NAME>` and `<RELATIONSHIP_NAME>` as you like, but it's best if they're distinct.
+You can define `<SERVICE_NAME>` as you like, so long as it's unique between all defined services 
+and matches in both the application and services configuration.
+The example above leverages [default endpoint](/create-apps/app-reference#relationships) configuration for relationships.
+That is, it uses default endpoints behind-the-scenes, providing a [relationship](/create-apps/app-reference#relationships)
+(the network address a service is accessible from) that is identical to the _name_ of that service. 
+
 With this definition, the application container {{ if eq $docVersion 2 }}(`<APP_NAME>`) {{ end }}
 {{- if ne (.Get "noApp" ) true -}}
-now has [access to the service](#use-in-app) via the relationship `<RELATIONSHIP_NAME>`.
+now has [access to the service](#use-in-app) via the relationship `<SERVICE_NAME>`.
 {{- else -}}
-now has access to the service via the relationship `<RELATIONSHIP_NAME>`.
+now has access to the service via the relationship `<SERVICE_NAME>`.
 {{- end -}}
 
 <!-- For services with a PHP extension -->


### PR DESCRIPTION
Makes small adjustments to showcase `default endpoints` or `simplified relationships` in the main services pages. It's meant to be an addition to the primary Simplified relationships PR (https://github.com/platformsh/platformsh-docs/pull/3590).