### PR TITLE
add note about Memcached not being HA on DG2

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -561,7 +561,7 @@
       ]
     },
     "versions-dedicated-gen-2": {
-      "supported": ["1.4"]
+      "supported": ["1.4*"]
     }
   },
   "mongodb": {

--- a/sites/platform/src/add-services/memcached.md
+++ b/sites/platform/src/add-services/memcached.md
@@ -42,6 +42,8 @@ Both Memcached and Redis can be used for application caching. As a general rule,
     </tbody>
 </table>
 
+\* No High-Availability on {{% names/dedicated-gen-2 %}}.
+
 <--->
 <!-- API Version 2 -->
 


### PR DESCRIPTION
## Why

Similar to [PostgreSQL](https://docs.platform.sh/add-services/postgresql.html), Memcached on Dedicated Gen 2 is not a high availability setup. It only runs on a single machine. If that machines reboots/is removed from the cluster during an upsize/etc. the cache will have to be rebuild completely on a new machine. We usually recommend using Redis Sentinel instead on DG2.

## What's changed

Added the same note that we have for PostgreSQL to the Memcached page.
