### PR TITLE
Unique Heap configuration for vendors

### DIFF
--- a/themes/psh-docs/layouts/partials/scripts/external.html
+++ b/themes/psh-docs/layouts/partials/scripts/external.html
@@ -11,10 +11,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {{ partial "header/gtm_script" . }} -->
 
 <!-- Heap -->
-{{ $heapID := "2760675333" }}
+<!-- Initialize Heap with a development value -->
+{{ $heapID := "816119933" }}
 <!-- Get Heap ID from environment variable for production-->
-{{ with os.Getenv "HUGO_HEAP_ID" }}
-  {{ $heapID = . }}
+{{ if eq (string .Site.Params.vendor.config.version) "1"}}
+    {{ with os.Getenv "HUGO_HEAP_ID_PLATFORM" }}
+      {{ $heapID = . }}
+    {{ end }}
+{{ end }}
+{{ if eq (string .Site.Params.vendor.config.version) "2"}}
+    {{ with os.Getenv "HUGO_HEAP_ID_UPSUN" }}
+      {{ $heapID = . }}
+    {{ end }}
 {{ end }}
 <script type="text/javascript">
   window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};


### PR DESCRIPTION
## Why

Closes https://github.com/platformsh/platformsh-docs/issues/3613

Unique Heap ID's are required for Platform.sh and Upsun docs. This PR

- Sets a default value for Heap used on non-production environments
- Pulls `HUGO_HEAP_ID_PLATFORM|UPSUN` environment variables from the production environment
- Behind the scenes on the Platform.sh environment, those ID values have been set