### PR TITLE
Remove obsolete php.ini limitation on DG2 clusters

### DIFF
--- a/sites/platform/src/dedicated-gen-2/overview/grid.md
+++ b/sites/platform/src/dedicated-gen-2/overview/grid.md
@@ -36,22 +36,6 @@ open a support ticket.
 
 {{< php-extensions/dedicated >}}
 
-### Configuration options
-
-You can't use custom `php.ini` files on your Production/Staging environments.
-You can still change all PHP options that can be changed at runtime.
-For example, change the memory limit using `ini_set('memory_limit','1024M');`
-
-For other PHP options, such as the following, open a support ticket:
-
-* `max_execution_time`
-* `max_input_time`
-* `max_input_vars`
-* `memory_limit`
-* `post_max_size`
-* `request_order`
-* `upload_max_filesize`
-
 ### Xdebug
 
 All {{% names/dedicated-gen-2 %}} clusters that have [Xdebug](../../languages/php/xdebug.md) enabled have a second PHP-FPM process.

--- a/sites/platform/src/languages/php/_index.md
+++ b/sites/platform/src/languages/php/_index.md
@@ -522,10 +522,6 @@ To see the settings used on your environment:
 
 ### Customize PHP settings
 
-{{< version/only "1" >}}
-For {{% names/dedicated-gen-2 %}}, see the [configuration options](../../dedicated-gen-2/overview/grid.md#configuration-options).
-{{< /version/only >}}
-
 You can customize PHP values for your app in two ways.
 The recommended method is to use variables.
 


### PR DESCRIPTION
The inability to use custom php.ini is valid only for a few clusters (~2%) on which the necessary configuration on our side has not been made (yet). Most clusters (~98%) support setting PHP configuration via this file.