### PR TITLE
Update demo link in stack guides.

### DIFF
--- a/sites/friday/src/get-started/flask/deploy/_index.md
+++ b/sites/friday/src/get-started/flask/deploy/_index.md
@@ -6,7 +6,7 @@ description: This guide provides instructions for deploying, and working with Fl
 layout: single
 banner:
    title: Recommended
-   body: To get your Flask project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project/demo) before following this guide.
+   body: To get your Flask project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project) before following this guide.
 ---
 
 Flask is a lightweight and popular web framework for building web applications using Python.

--- a/sites/friday/src/get-started/laravel/deploy/_index.md
+++ b/sites/friday/src/get-started/laravel/deploy/_index.md
@@ -11,7 +11,7 @@ description: |
 
 {{< note title= "Tip" >}}
 
-To get your Laravel project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project/demo) before following this guide.
+To get your Laravel project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project) before following this guide.
 
 {{< /note >}}
 

--- a/sites/friday/src/get-started/nextjs/_index.md
+++ b/sites/friday/src/get-started/nextjs/_index.md
@@ -10,7 +10,7 @@ Anything included in these guides applies not only to [Next.js](https://nextjs.o
 {{% guides/link-philosophy %}}
 
 {{< note title= "Tip" >}}
-To get your Next.js project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project/demo) before following this guide.
+To get your Next.js project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project) before following this guide.
 {{< /note >}}
 
 {{% guides/requirements name="Next.js" %}}

--- a/sites/friday/src/get-started/strapi/_index.md
+++ b/sites/friday/src/get-started/strapi/_index.md
@@ -10,7 +10,7 @@ Anything included in these guides applies not only to [Strapi](https://strapi.io
 {{% guides/link-philosophy %}}
 
 {{< note title= "Tip" >}}
-To get your Strapi project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project/demo) before following this guide.
+To get your Strapi project up and running as quickly as possible, experiment with the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project) before following this guide.
 {{< /note >}}
 
 {{% guides/requirements name="Strapi" %}}


### PR DESCRIPTION
## Why

Create project from demo link should be replaced with the generic create project landing page, where demo is an option.
