### PR TITLE
Remove disk from app configuration for Upsun

### DIFF
--- a/sites/platform/src/create-apps/_index.md
+++ b/sites/platform/src/create-apps/_index.md
@@ -225,7 +225,7 @@ applications:
         # The key is the relationship name that can be viewed in the app.
         # The value is specific to how the service is configured.
         relationships:
-            database: 'mysqldb:mysql'
+            mysqldb:
 
         # Scripts that are run as part of the build and deploy process.
         hooks:
@@ -263,7 +263,6 @@ applications:
 services:
     mysqldb:
         type: mariadb:{{% latest "mariadb" %}}
-        disk: 256
 ```
 
 {{% /version/specific %}}


### PR DESCRIPTION
## Why

`disk` key remains on Upsun service configuration and should be removed. Also, a remaining relationship definition is rechanged to the simplified syntax.