### PR TITLE
Bug/debug search prod

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -34,6 +34,9 @@
         deploy: |
             cd $SITE_DIR
             ./deploy.sh
+            bash ./marker.sh "deployed" "${SITE_DIR}"
+        post_deploy:
+            bash ./marker.sh "post_deploy" "${SITE_DIR}"
 
     # The configuration of the application when it is exposed to the web.
     web:
@@ -97,7 +100,9 @@
         deploy: |
             cd $SITE_DIR
             ./deploy.sh
-
+            bash ./marker.sh "deployed" "${SITE_DIR}"
+        post_deploy:
+            bash ./marker.sh "post_deploy" "${SITE_DIR}"
     # The configuration of the application when it is exposed to the web.
     web:
         commands:

--- a/search/post_deploy.sh
+++ b/search/post_deploy.sh
@@ -18,8 +18,23 @@ getDocsData() {
     rm -v data/platform_index.json && echo "data json for platform deleted" || echo "failed to delete data json for platform"
     rm -v data/friday_index.json && echo "data json for upsun deleted" || echo "failed to delete data json for upsun"
 
+    # remove the previous headers log
+    if [ -f "data/platform-headers.txt" ]; then
+      rm data/platform-headers.txt
+    fi
+
+    if [ -f "data/upsun-headers.txt" ]; then
+      rm data/upsun-headers.txt
+    fi
+
     # Get the updated index for docs
-    curl -s "${PLATFORM_DOCS_URL}index.json" >> data/platform_index.json && echo "retrieved psh index" || echo "failed to retrieve psh index"
+    # * change the user agent so we can more easily locate in the apps' access logs
+    # * save the http response as a json file in ./data
+    # * save the response headers in ./data
+    # curl --user-agent "request-to-upsun-docs" -s -D - -o foobar.json "https://docs.upsun.com/index.json" >> headers.txt
+    curl --user-agent "request-search-index-for-platform-docs" -s -D - -o data/platform_index.json "${PLATFORM_DOCS_URL}index.json" >> data/platform-headers.txt
+    #curl -s "${PLATFORM_DOCS_URL}index.json" >> data/platform_index.json && echo "retrieved psh index" || echo "failed to retrieve psh index"
+    curl --user-agent "request-search-index-for-upsun-docs" -s -D - -o data/friday_index.json "${FRIDAY_DOCS_URL}index.json" >> data/upsun-headers.txt
     curl -s "${FRIDAY_DOCS_URL}index.json" >> data/friday_index.json && echo "retrieved upsun index" || echo "failed to retrieve upsun index"
 
     # How many times does Platform.sh appear in the platform index? Should be 3815
@@ -34,6 +49,16 @@ getDocsData() {
     printf "Upsun appears %d times in the platform index.\nUpsun appears %d times in the Upsun index.\n" "${upsunOccurrenceInPsh}" "${upsunOccurrenceInUpsun}"
     printf "Platform appears %d times in the platform index.\nPlatform appears %d times in the Upsun index.\n" "${pshOccurrenceInPsh}" "${pshOccurrenceInUpsun}"
 
+
+    if (( pshOccurrenceInUpsun > 100 )); then
+      echo "Appears our search indexes have flipped. Platform occurs too many times in the Upsun docs! Saving headers... ";
+      save_headers "platform"
+    fi
+
+    if (( upsunOccurrenceInPsh > 0 )); then
+      echo "Appears our search indexes have flipped. Upsun occurs too many times in the Platform docs! Saving headers... ";
+      save_headers "upsun"
+    fi
 
     # Delete templates index in the mount if it exists
     rm -f data/platform_templates.yaml
@@ -56,6 +81,18 @@ update_index(){
     # Update indexes
     $POETRY_LOCATION run python main.py platform
     $POETRY_LOCATION run python main.py friday
+}
+
+save_headers() {
+  docs="${1}"
+  timestamp=$(date +%Y-%m-%d-%H-%M-%S)
+  if [ -f "./data/${docs}-headers.txt" ]; then
+    #rename the file so we can examine it
+    mv "./data/${docs}-headers.txt" "./data/${docs}-headers-${timestamp}.txt"
+    echo "Header responses for ${docs} saved."
+  else
+    echo "Header response log file for ${docs} is missing! Unable to save."
+  fi
 }
 
 set -e

--- a/sites/friday/marker.sh
+++ b/sites/friday/marker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Adds an entry into the access log file so we determine when the app is up and when requests for the search index occur
+
+event="deployed"
+if [ -n "${1}" ]; then
+  event="${1}"
+fi
+
+site="unknown"
+if [ -n "${2}" ]; then
+  site="${2}"
+fi
+
+theTime=$(date +"%d/%b/%Y:%T %z")
+ipAddres="0.0.0.0"
+request="GET /event: ${event}"
+
+printf '%s - - [%s] "%s" 000 0 "-" "%s"\n' "${ipAddres}" "${theTime}" "${request}" "${site}" >> /var/log/access.log

--- a/sites/platform/marker.sh
+++ b/sites/platform/marker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Adds an entry into the access log file so we determine when the app is up and when requests for the search index occur
+
+event="deployed"
+if [ -n "${1}" ]; then
+  event="${1}"
+fi
+
+site="unknown"
+if [ -n "${2}" ]; then
+  site="${2}"
+fi
+
+theTime=$(date +"%d/%b/%Y:%T %z")
+ipAddres="0.0.0.0"
+request="GET /event: ${event}"
+
+printf '%s - - [%s] "%s" 000 0 "-" "%s"\n' "${ipAddres}" "${theTime}" "${request}" "${site}" >> /var/log/access.log


### PR DESCRIPTION
In trying to debug why the search indexes are sometimes flipped:
* adds small shell script in both friday and platform apps 
* script above adds a marker entry in access log
* script is called from both the deploy and post_deploy hooks in both docs apps
* changes the post_deploy.sh script in the search app to 
  * use a custom user agent 
  * stores response headers from curl request
  * adds function to save response headers if we determine we're in a flipped index situation