### PR TITLE
Update CLI installation information

### DIFF
--- a/sites/platform/src/administration/cli/_index.md
+++ b/sites/platform/src/administration/cli/_index.md
@@ -243,7 +243,7 @@ To update to the latest version, use the same tool as for [installation](#1-inst
 title=Homebrew
 highlight=bash
 +++
-brew upgrade {{% vendor/altname %}}-cli
+brew upgrade {{% vendor/alt-name %}}-cli
 <--->
 +++
 title=Scoop

--- a/sites/platform/src/administration/cli/_index.md
+++ b/sites/platform/src/administration/cli/_index.md
@@ -243,7 +243,7 @@ To update to the latest version, use the same tool as for [installation](#1-inst
 title=Homebrew
 highlight=bash
 +++
-brew upgrade {{% vendor/cli %}}-cli
+brew upgrade {{% vendor/altname %}}-cli
 <--->
 +++
 title=Scoop


### PR DESCRIPTION
## What's changed

There is no such package as "platform-cli" in brew. Use "platformsh-cli" instead.
