### PR TITLE
pins vale version to 2.30.0 in reviewdog prose workflow

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Vale
         uses: errata-ai/vale-action@reviewdog
         with:
+          version: 2.30.0
           fail_on_error: true
           reporter: github-check
           files: sites/platform/src


### PR DESCRIPTION
vale jumped versions from 2.30.0 to 3.0.0 which includes a breaking change of moving config and layout file locations. 