### PR TITLE
removes hard-coded instances of the project id, option 2

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -7,17 +7,36 @@ on:
 
 env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
-  PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
   SLEEP_TIME: 5
   NUM_TRIES: 30
   BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
 
 jobs:
+  jobs:
+    get_project_id:
+      runs-on: ubuntu-latest
+      outputs:
+        project_id: ${{ steps.get-project-id.outputs.project_id }}
+      steps:
+        - uses: platformsh/gha-retrieve-projectid
+          id: get-project-id
+          with:
+            github_token: ${{ secrets.WORKFLOW_TOKEN }}
   build:
     if: github.event.label.name == 'build-fork' || contains(github.event.pull_request.labels.*.name, 'build-fork')
     runs-on: ubuntu-latest
+    needs: get_project_id
+    env:
+      PLATFORM_PROJECT: ${{ needs.get_project_id.outputs.project_id }}
     steps:
+      - uses: platformsh/gha-retrieve-projectid
+        id: get-project-id
+        with:
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: "set up project env"
+        run: |
+          echo "PLATFORM_PROJECT=${{ steps.get-project-id.outputs.project_id }}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/get-pr-info.yaml
+++ b/.github/workflows/get-pr-info.yaml
@@ -6,11 +6,22 @@ on:
 
 env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
-  PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
   BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
 jobs:
+  get_project_id:
+    runs-on: ubuntu-latest
+    outputs:
+      project_id: ${{ steps.get-project-id.outputs.project_id }}
+    steps:
+      - uses: platformsh/gha-retrieve-projectid
+        id: get-project-id
+        with:
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
   get_pr_info:
+    needs: get_project_id
+    env:
+      PLATFORM_PROJECT: ${{ needs.get_project_id.outputs.project_id }}
     runs-on: ubuntu-latest
     name: Get info on build from PR
     # Run only for PRs from default repo and approved PRs from forks
@@ -34,6 +45,14 @@ jobs:
           fi
           echo "::notice::Setting branch name to ${branch_name}."
           echo "branch_name=${branch_name}" >> $GITHUB_OUTPUT
+
+      - uses: platformsh/gha-retrieve-projectid
+        id: get-project-id
+        with:
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+      - name: "set up project env"
+        run: |
+          echo "PLATFORM_PROJECT=${{ steps.get-project-id.outputs.project_id }}" >> $GITHUB_ENV
 
       # Set up workflow environment to use the Platform.sh CLI
       - name: Set up Platform.sh CLI

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -9,13 +9,25 @@ on:
 
 env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
-  PLATFORM_PROJECT: 652soceglkw4u
   PLATFORMSH_CLI_DEFAULT_TIMEOUT: 60 # Increase timeout for CLI commands
   PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
   BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
 
 jobs:
+  get_project_id:
+    runs-on: ubuntu-latest
+    outputs:
+      project_id: ${{ steps.get-project-id.outputs.project_id }}
+    steps:
+      - uses: platformsh/gha-retrieve-projectid
+        id: get-project-id
+        with:
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+
   activate_environment:
+    needs: get_project_id
+    env:
+      PLATFORM_PROJECT: ${{ needs.get_project_id.outputs.project_id }}
     runs-on: ubuntu-latest
     # Activate when a PR is opened, but not for forks (handled through `build-from-fork` workflow)
     if: >-
@@ -50,6 +62,9 @@ jobs:
         run: platform environment:activate --no-wait ${{ github.event.pull_request.head.ref }}
 
   deactivate_environment:
+    needs: get_project_id
+    env:
+      PLATFORM_PROJECT: ${{ needs.get_project_id.outputs.project_id }}
     runs-on: ubuntu-latest
     # For non-forked PRs
     # Deactivate when a PR is closed
@@ -70,7 +85,10 @@ jobs:
         run: platform environment:deactivate --no-delete-branch ${{ github.event.pull_request.head.ref }}
 
   deactivate_forked_environment:
+    needs: get_project_id
     runs-on: ubuntu-latest
+    env:
+      PLATFORM_PROJECT: ${{ needs.get_project_id.outputs.project_id }}
     # For forked PRs labelled as build-fork
     # Delete branch when a PR is closed
     if: >-


### PR DESCRIPTION
removes hard-coded instances of the project id, replaces with a job that calls an action that dynamically retrieves the project id

**this assumes that `${{ secrets.WORKFLOW_TOKEN }}` has the necessary privileges to access the gh api for this repository.** 

if not, we'll need to update with `WORKFLOW__LABEL_TOKEN` since i know that one does.


