### PR TITLE
Add link to the Django blog post in the Django get started guide

### DIFF
--- a/sites/friday/src/get-started/django/_index.md
+++ b/sites/friday/src/get-started/django/_index.md
@@ -3,4 +3,4 @@ title: Django
 description: Learn how to deploy your Django app on {{% vendor/name %}}
 ---
 
-Coming soon!
+To get started with Upsun and Django, read our [dedicated blog post](https://github.com/platformsh/platformsh-docs).

--- a/sites/friday/src/get-started/django/_index.md
+++ b/sites/friday/src/get-started/django/_index.md
@@ -3,4 +3,4 @@ title: Django
 description: Learn how to deploy your Django app on {{% vendor/name %}}
 ---
 
-To get started with Upsun and Django, read our [dedicated blog post](https://github.com/platformsh/platformsh-docs).
+To get started with Upsun and Django, read our [dedicated blog post](https://upsun.com/blog/setting-up-django-on-upsun/).


### PR DESCRIPTION
I'm not sure about the exact sentence to use, but we need to remove the current "coming soon" page ASAP.
