### PR TITLE
removes size property from search container

### DIFF
--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -52,5 +52,3 @@ mounts:
     "dumps":
         source: local
         source_path: "dumps"
-
-size: L


### PR DESCRIPTION
removes size property from search container so system will dynamically allocate remaining memory to it

