### PR TITLE
Fix redirect for Resources section

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -281,7 +281,7 @@ https://docs.upsun.com/:
   redirects:
     paths:
       # Console tooltips
-      "/anchors/resources/configuration.html": { "to": "/adjust-resources.html", "code": 301, "prefix": false }
+      "/anchors/resources/configuration.html": { "to": "/manage-resources/adjust-resources.html", "code": 301, "prefix": false }
       "/anchors/scaling/down.html": { "to": "/administration/pricing.html", "code": 301, "prefix": false }
       "/anchors/organizations/admin.html": { "to": "/administration/organizations.html", "code": 301, "prefix": false }
       "/anchors/resources/green.html": { "to": "/administration/pricing.html", "code": 301, "prefix": false }


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Anchor links for the Manage Resources section in Upsun docs weren't working, resulting in 404s from the Console.
It turns out that the target URL for the related redirect was erroneous.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Fixed the target URL in `routes.yaml` so the anchor links would point to `/manage-resources/adjust-resources.html` instead of `adjust-resources.html`.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
