### PR TITLE
Remove shortcode in links

### DIFF
--- a/sites/platform/src/development/file-transfer.md
+++ b/sites/platform/src/development/file-transfer.md
@@ -191,8 +191,8 @@ You can use `sftp` to copy files to and from a remote environment.
   Instead, access is given to **the whole application directory** and its mounts.
 
 `sftp` is also supported on Dedicated projects with different limitations and requirements.
-For more information, see the [{{% names/dedicated-gen-2 %}}](/dedicated-gen-2/architecture/options.md#sftp)
-and [{{% names/dedicated-gen-3 %}}](/dedicated-gen-3/options.md#sftp) sections.
+For more information, see the [Dedicated Gen 2](/dedicated-gen-2/architecture/options.md#sftp)
+and [Dedicated Gen 3](/dedicated-gen-3/options.md#sftp) sections.
 {{% /note %}}
 
 <--->


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Links featuring a shortcode (for Dedicated infra names) randomly threw errors when building docs locally, which was becoming a real nuisance.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Hardcoded the values to prevent errors.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
