### PR TITLE
Upsun migrate security

### DIFF
--- a/sites/friday/config/_default/config.yaml
+++ b/sites/friday/config/_default/config.yaml
@@ -83,8 +83,7 @@ module:
               - "create-apps/workers.md"
               - "create-apps/flexible-resources.md"
               - "environments/scalability.md"
-              - "security/web-application-firewall/*"
-              - "security/project-isolation.md"
+              - "security/*
           lang: "en"
 
         - source: "../platform/static/images"

--- a/sites/friday/config/_default/config.yaml
+++ b/sites/friday/config/_default/config.yaml
@@ -83,7 +83,7 @@ module:
               - "create-apps/workers.md"
               - "create-apps/flexible-resources.md"
               - "environments/scalability.md"
-              - "security/*
+              - "security/*"
           lang: "en"
 
         - source: "../platform/static/images"

--- a/sites/friday/src/security/_index.md
+++ b/sites/friday/src/security/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Security and compliance"
+weight: -50
+description: |
+  Learn how {{% vendor/name %}} ensures your data is handled with appropriate care and according to industry standards.
+banner:
+   title: Note
+   body: Your main source of information about the security, privacy,
+         and compliance of the {{% vendor/name %}} products and services,
+         is now the Platform.sh [Trust Center](https://platform.sh/trust-center/).
+keywords:
+- pen-test
+- penetration test
+- load test
+- vulnerability
+- Intrusion Prevention System (IPS)
+---

--- a/sites/friday/src/security/backups.md
+++ b/sites/friday/src/security/backups.md
@@ -1,0 +1,29 @@
+---
+title: "Backup and restore"
+description: See backup policies and the recovery point objective (RPO) and recovery time objective (RTO) for various schedules.
+---
+
+<!-- Upsun -->
+The following standard backup policy is applied to your projects and defines how many backups you can take advantage of.
+
+**Production environments:**
+- 1 automated backup per day, with a [2-day retention](/security/data-retention.md) (2 days worth of backups are retained at any given point).
+  Automated backups are always [live](/environments/backup.md#live-backups).
+- 2 manual backups maximum at any given point (the third manual backup replaces the oldest manual backup).
+
+**Preview environments (development and staging):**
+- No automated backups.
+- 2 manual backups maximum at any given point (the third manual backup replaces the oldest manual backup).
+
+Note that the number of backups is limited per [environment **type**](/glossary/_index.md#preview-environment) and not per project.
+Therefore, a {{< vendor/name >}} project can have up to 6 backups at once (2 automated backups and 2 manual backups of the production environment,
+plus 2 manual backups of any preview environments).
+
+{{< note >}}
+
+This policy applies during the beta phase of {{< vendor/name >}},
+during which backups are provided free of charge.
+In the future, you'll be able to customize your backup policy depending on your needs and budget.
+
+{{< /note >}}
+

--- a/sites/friday/src/security/data-retention.md
+++ b/sites/friday/src/security/data-retention.md
@@ -1,0 +1,49 @@
+---
+title: Data retention
+description: |
+  {{% vendor/name %}} logs and stores various types of data as a normal part of its business. This information is only retained as needed to perform relevant business functions. Retention periods vary depending on the type of data stored. If a legal obligation, law enforcement request, or ongoing business need so requires, data may be retained after the original purpose for which it was collected ceases to exist.
+---
+
+{{% description %}}
+
+## Account information
+
+Information relating to customer accounts (login information, billing information, etc.) is retained for as long as the account is active with {{% vendor/name %}}.
+
+Customers may request that their account be deleted and all related data be purged by opening a [support ticket](/learn/overview/get-support).
+
+## System logs
+
+System level access and security logs are maintained by {{% vendor/name %}} for diagnostic purposes.
+These logs aren't customer-accessible.
+These logs are retained for at least 6 months and at most 2 years depending upon legal and standards compliance required for each system.
+
+## Application logs
+
+Application logs on each customer environment are retained with the environment.
+Individual log files are truncated at 100 MB, regardless of their age.
+See how to [access logs](../increase-observability/logs/access-logs.md).
+
+When an environment is deleted, its application logs are deleted as well.
+
+
+## Backups
+
+[Automated backups](../environments/backup.md#use-automated-backups) are retained for 2 days
+(meaning, 2 days worth of backups are retained at any given point).
+
+[Manual backups](../environments/backup.md#create-a-manual-backup) are retained until you delete them or replace them with another backup.</br>
+As {{< vendor/name >}} provides a maximum of [2 manual backups per environment type](/security/backups.md),
+the third manual backup automatically replaces the oldest backup.
+
+## Tombstone backups
+
+When a project is deleted, {{% vendor/name %}} takes a final backup of active environments, as well as the Git repository holding user code.
+This final backup is to allow {{% vendor/name %}} to recover a recently deleted project in case of accident.
+
+These "tombstone" backups are retained for between 7 days and 6 months depending upon legal and standards compliance required for each system.
+
+## Analytics
+
+{{% vendor/name %}} uses Google Analytics on various web pages, and so Google Analytics stores collected data for a period of time.
+We have configured our Google Analytics account to store data for 14 months from the time you last accessed our site, which is the minimum Google allows.

--- a/sites/platform/src/security/backups.md
+++ b/sites/platform/src/security/backups.md
@@ -3,8 +3,6 @@ title: "Backup and restore"
 description: See backup policies and the recovery point objective (RPO) and recovery time objective (RTO) for various schedules.
 ---
 
-{{% version/specific %}}
-<!-- Platform.sh -->
 The frequency of backups varies based on the [backup schedule](../environments/backup.md#backup-schedule).
 Retention is governed by the [data retention policy](./data-retention.md).
 This section details the recovery point objective (RPO) and recovery time objective (RTO) for each option.
@@ -43,29 +41,3 @@ Dedicated environments are backed up every 6 hours.
 
 **RTO**: Variable.
 Recovery time depends on the size of the data being recovered.
-
-<--->
-<!-- Upsun -->
-The following standard backup policy is applied to your projects and defines how many backups you can take advantage of.
-
-**Production environments:**
-- 1 automated backup per day, with a [2-day retention](/security/data-retention.md) (2 days worth of backups are retained at any given point).
-  Automated backups are always [live](/environments/backup.md#live-backups).
-- 2 manual backups maximum at any given point (the third manual backup replaces the oldest manual backup).
-
-**Preview environments (development and staging):**
-- No automated backups.
-- 2 manual backups maximum at any given point (the third manual backup replaces the oldest manual backup).
-
-Note that the number of backups is limited per [environment **type**](/glossary/_index.md#preview-environment) and not per project.
-Therefore, a {{< vendor/name >}} project can have up to 6 backups at once (2 automated backups and 2 manual backups of the production environment,
-plus 2 manual backups of any preview environments).
-
-{{< note >}}
-
-This policy applies during the beta phase of {{< vendor/name >}},
-during which backups are provided free of charge.
-In the future, you'll be able to customize your backup policy depending on your needs and budget.
-
-{{< /note >}}
-{{% /version/specific %}}

--- a/sites/platform/src/security/data-retention.md
+++ b/sites/platform/src/security/data-retention.md
@@ -26,8 +26,6 @@ See how to [access logs](../increase-observability/logs/access-logs.md).
 
 When an environment is deleted, its application logs are deleted as well.
 
-{{% version/specific %}}
-<!-- Platform.sh -->
 ## Grid Backups
 
 [Automated backups](../environments/backup.md#use-automated-backups) are retained for a specific amount of time
@@ -47,7 +45,7 @@ you keep all 10 manual backups until there are 15 automated backups.
 Then the automated backups start replacing the manual ones until you have only your allocated 4 manual backups.
 
 Backups associated with an environment are retained according to the [backup cycles](#backup-cycles) outlined below, so long as the environment still exists in the project.
-That is, backups are deleted when the corresponding environment is deleted.  
+That is, backups are deleted when the corresponding environment is deleted.
 
 ### Backup cycles
 
@@ -97,18 +95,6 @@ Backups for {{% names/dedicated-gen-2 %}} environments are retained based on whe
 | Weeks 12--22 | One backup per month |
 
 See more about [backups of {{% names/dedicated-gen-2 %}} environments](../dedicated-gen-2/overview/backups.md).
-
-<--->
-<!-- Upsun -->
-## Backups
-
-[Automated backups](../environments/backup.md#use-automated-backups) are retained for 2 days
-(meaning, 2 days worth of backups are retained at any given point).
-
-[Manual backups](../environments/backup.md#create-a-manual-backup) are retained until you delete them or replace them with another backup.</br>
-As {{< vendor/name >}} provides a maximum of [2 manual backups per environment type](/security/backups.md),
-the third manual backup automatically replaces the oldest backup.
-{{% /version/specific %}}
 
 ## Tombstone backups
 


### PR DESCRIPTION
## Why
Prepares security section for repository separation

## What's changed
* Copies the following from the platform docs src to the upsun docs src:
  * _index.md
  * backups.md
  * data-retention.md
* Updates the src and the copies above to remove the toggled sections between the vendors
* Updates Upsun config to exclude the entire security section when sourcing from platform/src
