### PR TITLE
Clear up confusion around preview env default size

### DIFF
--- a/sites/platform/src/create-apps/app-reference.md
+++ b/sites/platform/src/create-apps/app-reference.md
@@ -179,8 +179,8 @@ The total resources allocated across all apps and services can't exceed what's i
 
 Containers in preview environments don't follow the `size` specification.
 Application containers are set based on the plan's setting for **Environments application size**.
-The default is **{{< partial "plans/default-dev-env-size" >}}**, but you can increase it by editing your plan.
-(Service containers in preview environments are always set to {{< partial "plans/default-dev-env-size" >}} size.)
+The default is size **S**, but you can increase it by editing your plan.
+(Service containers in preview environments are always set to size **S**.)
 
 <--->
 ## Resources


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Client thought that `Standard` referred to the resource allocation you'd get with a Standard Grid plan, instead of the default container size `S`.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Removed partial and replaced `Standard` with `S`.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
