### PR TITLE
Revert "missing P.sh guide on Upsun side"

### DIFF
--- a/sites/friday/config/_default/config.yaml
+++ b/sites/friday/config/_default/config.yaml
@@ -53,7 +53,7 @@ module:
         - source: "../platform/src"
           target: "content"
           excludeFiles:
-              - "_index.md"
+
               # - "add-services/*"
               - "add-services/network-storage.md"
 


### PR DESCRIPTION
Reverts platformsh/platformsh-docs#3762