### PR TITLE
removes drupal9, adds drupal10 to shared/data/remote-examples/templat…

### DIFF
--- a/shared/data/remote-examples/templates/routes.yaml
+++ b/shared/data/remote-examples/templates/routes.yaml
@@ -12,7 +12,7 @@ repos:
     - spring-mvc-maven-mongodb
     - micronaut
     - gatsby
-    - drupal9
+    - drupal10
     - wordpress-vanilla
     - wordpress-composer
     - typo3


### PR DESCRIPTION
## Why

Closes #3819 


## What's changed
* removes drupal9, adds drupal10 to shared/data/remote-examples/templates/routes.yaml
