### PR TITLE
Remove mention of DDEV integration in Upsun docs

### DIFF
--- a/sites/friday/src/development/local/ddev.md
+++ b/sites/friday/src/development/local/ddev.md
@@ -36,11 +36,7 @@ Follow the prompts to add the correct DDEV configuration files to your repositor
 
 {{% ddev/token %}}
 
-## 4. Connect DDEV to your project
-
-{{% ddev/connect %}}
-
-## 5. Optional: Get your project data
+## 4. Optional: Get your project data
 
 To get your environment data (files, database), run the following command:
 
@@ -51,7 +47,7 @@ ddev pull {{% vendor/cli %}}
 To skip pulling files, add `--skip-files` to the command.
 To skip pulling a database, add `--skip-db` to the command.
 
-## 6. Run your project
+## 5. Run your project
 
 Now your project is ready to run:
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Upsun docs mentioned `ddev get ddev/ddev-upsun` which isn't working yet. We don't know when the integration might be ready, so it's best to remove the related section.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Section on how to connect DDEV to an Upsun project via the integration has been removed.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
