### PR TITLE
Fix nav buttons display in PSH framework guides

### DIFF
--- a/sites/platform/src/guides/django/deploy/_index.md
+++ b/sites/platform/src/guides/django/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Django on {{% vendor/name %}}
+title: Deploy Django on Platform.sh
 sidebarTitle: Get started
 weight: -130
 layout: single

--- a/sites/platform/src/guides/django/deploy/configure.md
+++ b/sites/platform/src/guides/django/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Django for {{% vendor/name %}}"
+title: "Configure Django for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/django/deploy/customize.md
+++ b/sites/platform/src/guides/django/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize Django for {{% vendor/name %}}"
+title: "Customize Django for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/drupal/deploy/_index.md
+++ b/sites/platform/src/guides/drupal/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Drupal on {{% vendor/name %}}
+title: Deploy Drupal on Platform.sh
 sidebarTitle: Get started
 weight: -110
 layout: single

--- a/sites/platform/src/guides/drupal/deploy/configure.md
+++ b/sites/platform/src/guides/drupal/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Drupal for {{% vendor/name %}}"
+title: "Configure Drupal for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/drupal/deploy/customize.md
+++ b/sites/platform/src/guides/drupal/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize Drupal for {{% vendor/name %}}"
+title: "Customize Drupal for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/gatsby/deploy/_index.md
+++ b/sites/platform/src/guides/gatsby/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Gatsby on {{% vendor/name %}}
+title: Deploy Gatsby on Platform.sh
 sidebarTitle: Get started
 weight: -110
 layout: single

--- a/sites/platform/src/guides/gatsby/deploy/configure.md
+++ b/sites/platform/src/guides/gatsby/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Gatsby for {{% vendor/name %}}"
+title: "Configure Gatsby for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/laravel/deploy/_index.md
+++ b/sites/platform/src/guides/laravel/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Laravel on {{% vendor/name %}}
+title: Deploy Laravel on Platform.sh
 sidebarTitle: Get started
 weight: -110
 layout: single

--- a/sites/platform/src/guides/laravel/deploy/configure.md
+++ b/sites/platform/src/guides/laravel/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Laravel for {{% vendor/name %}}"
+title: "Configure Laravel for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/micronaut/deploy/_index.md
+++ b/sites/platform/src/guides/micronaut/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Micronaut on {{% vendor/name %}}
+title: Deploy Micronaut on Platform.sh
 sidebarTitle: Get started
 weight: -110
 layout: single

--- a/sites/platform/src/guides/micronaut/deploy/configure.md
+++ b/sites/platform/src/guides/micronaut/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Micronaut for {{% vendor/name %}}"
+title: "Configure Micronaut for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/micronaut/deploy/customize.md
+++ b/sites/platform/src/guides/micronaut/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize Micronaut for {{% vendor/name %}}"
+title: "Customize Micronaut for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/quarkus/deploy/_index.md
+++ b/sites/platform/src/guides/quarkus/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Quarkus on {{% vendor/name %}}
+title: Deploy Quarkus on Platform.sh
 sidebarTitle: Get started
 weight: -110
 layout: single

--- a/sites/platform/src/guides/quarkus/deploy/configure.md
+++ b/sites/platform/src/guides/quarkus/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure Quarkus for {{% vendor/name %}}"
+title: "Configure Quarkus for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/quarkus/deploy/customize.md
+++ b/sites/platform/src/guides/quarkus/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize Quarkus for {{% vendor/name %}}"
+title: "Customize Quarkus for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/spring/deploy/_index.md
+++ b/sites/platform/src/guides/spring/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy Spring on {{% vendor/name %}}
+title: Deploy Spring on Platform.sh
 sidebarTitle: Get started
 weight: -110
 layout: single

--- a/sites/platform/src/guides/spring/deploy/customize.md
+++ b/sites/platform/src/guides/spring/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize Spring for {{% vendor/name %}}"
+title: "Customize Spring for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/typo3/deploy/_index.md
+++ b/sites/platform/src/guides/typo3/deploy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy TYPO3 on {{% vendor/name %}}
+title: Deploy TYPO3 on Platform.sh
 sidebarTitle: "Get started"
 weight: -110
 layout: single

--- a/sites/platform/src/guides/typo3/deploy/configure.md
+++ b/sites/platform/src/guides/typo3/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure TYPO3 for {{% vendor/name %}}"
+title: "Configure TYPO3 for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/typo3/deploy/customize.md
+++ b/sites/platform/src/guides/typo3/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize TYPO3 for {{% vendor/name %}}"
+title: "Customize TYPO3 for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/wordpress/deploy/configure.md
+++ b/sites/platform/src/guides/wordpress/deploy/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure WordPress for {{% vendor/name %}}"
+title: "Configure WordPress for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/wordpress/deploy/customize.md
+++ b/sites/platform/src/guides/wordpress/deploy/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize WordPress for {{% vendor/name %}}"
+title: "Customize WordPress for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |

--- a/sites/platform/src/guides/wordpress/vanilla/configure.md
+++ b/sites/platform/src/guides/wordpress/vanilla/configure.md
@@ -1,5 +1,5 @@
 ---
-title: "Configure WordPress for {{% vendor/name %}}"
+title: "Configure WordPress for Platform.sh"
 sidebarTitle: "Configure"
 weight: -100
 description: |

--- a/sites/platform/src/guides/wordpress/vanilla/customize.md
+++ b/sites/platform/src/guides/wordpress/vanilla/customize.md
@@ -1,5 +1,5 @@
 ---
-title: "Customize WordPress for {{% vendor/name %}}"
+title: "Customize WordPress for Platform.sh"
 sidebarTitle: "Customize"
 weight: -90
 description: |


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Navigation buttons within PSH framework guides displayed `{{% vendor/name %}}` instead of `Platform.sh`.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
