### PR TITLE
Update wording about `fetch-branches` option

### DIFF
--- a/sites/platform/src/integrations/source/bitbucket.md
+++ b/sites/platform/src/integrations/source/bitbucket.md
@@ -92,7 +92,7 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
+| `fetch-branches` | `true`  | Whether to update branches on {{% vendor/name %}} with changes pushed to Bitbucket and create new branches as inactive environments. |
 | `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the Bitbucket repository. Automatically disabled when fetching branches is disabled. |
 | `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
 | `resync-pull-requests` | `false` | Whether to sync data from the parent environment on every push to a pull request. |

--- a/sites/platform/src/integrations/source/github.md
+++ b/sites/platform/src/integrations/source/github.md
@@ -114,7 +114,7 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
+| `fetch-branches` | `true`  | Whether to update branches on {{% vendor/name %}} with changes pushed to GitHub and create new branches as inactive environments. |
 | `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitHub repository. Automatically disabled when fetching branches is disabled. |
 | `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
 | `build-draft-pull-requests` | `true` | Whether to also track and build draft pull requests. Automatically disabled when pull requests aren’t built. |

--- a/sites/platform/src/integrations/source/gitlab.md
+++ b/sites/platform/src/integrations/source/gitlab.md
@@ -95,7 +95,7 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to track all branches and create inactive environments from them. |
+| `fetch-branches` | `true`  | Whether to update branches on {{% vendor/name %}} with changes pushed to GitLab and create new branches as inactive environments. |
 | `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitLab repository. Automatically disabled when fetching branches is disabled. |
 | `build-merge-requests` | `true` | Whether to track all merge requests and create active environments from them, which builds the merge request. |
 | `build-wip-merge-requests` | `true` | Whether to also track and build draft merge requests. Automatically disabled when merge requests aren’t built. |

--- a/themes/psh-docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/themes/psh-docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -184,7 +184,7 @@ title=In the Console
 {{ $OptionsTable := print `
 | CLI flag | Default | Description |
 | -------- | ------- | ----------- |
-| <code>fetch-branches</code> | <code>true</code> | Whether to track all branches and create inactive environments from them. |
+| <code>fetch-branches</code> | <code>true</code> | Whether to update branches on ` .Site.Params.vendor.name ` with changes pushed to ` $source ` and create new branches as inactive environments. |
 | <code>prune-branches</code> | <code>true</code> | Whether to delete branches from ` .Site.Params.vendor.name ` that don't exist in the ` $source ` repository. Automatically disabled when fetching branches is disabled. |
 | <code>build-` $pull `-requests</code> | <code>true</code> | Whether to track all ` $pull ` requests and create active environments from them, which builds the ` $pull ` request. | ` $draftOption `
 ` $cloneOption $extraOption }}


### PR DESCRIPTION
## Why

It's not clear that `fetch-branches` also controls the integration in fetching _existing_ branches and not just new branches.  

## What's changed

Update option wording for `fetch-branches` option where listed on source integration pages.