### PR TITLE
Removes json_pp from docs

### DIFF
--- a/sites/platform/src/guides/drupal/redis.md
+++ b/sites/platform/src/guides/drupal/redis.md
@@ -203,7 +203,7 @@ To configure your Redis service, follow these steps:
 To verify that Redis is running, run the following command:
 
 ```bash
-{{% vendor/cli %}} 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq'
+{{% vendor/cli %}} ssh 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq'
 ```
 
 In the output, retrieve the value of the `host` property for your Redis relationship.

--- a/sites/platform/src/guides/drupal/redis.md
+++ b/sites/platform/src/guides/drupal/redis.md
@@ -203,7 +203,7 @@ To configure your Redis service, follow these steps:
 To verify that Redis is running, run the following command:
 
 ```bash
-{{% vendor/cli %}} 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq '''.''''
+{{% vendor/cli %}} 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq'
 ```
 
 In the output, retrieve the value of the `host` property for your Redis relationship.

--- a/sites/platform/src/guides/drupal/redis.md
+++ b/sites/platform/src/guides/drupal/redis.md
@@ -203,7 +203,7 @@ To configure your Redis service, follow these steps:
 To verify that Redis is running, run the following command:
 
 ```bash
-{{% vendor/cli %}} ssh 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | json_pp'
+{{% vendor/cli %}} 'echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq '''.''''
 ```
 
 In the output, retrieve the value of the `host` property for your Redis relationship.

--- a/sites/platform/src/guides/micronaut/mongodb.md
+++ b/sites/platform/src/guides/micronaut/mongodb.md
@@ -34,11 +34,11 @@ In your [app configuration](../../create-apps/app-reference.md), use the service
 Connection credentials for services are exposed to the application container through the `PLATFORM_RELATIONSHIPS` environment variable from the deploy hook onward. Since this variable is a base64 encoded JSON object of all of your project's services, you'll likely want a clean way to extract the information specific to the database into it's own environment variables that can be used by Micronaut. On {{% vendor/name %}}, custom environment variables can be defined programmatically in a `.environment` file using `jq` to do just that:
 
 ```text
-export MONGO_PORT=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].port"`
-export MONGO_HOST=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].host"`
-export MONGO_PASSWORD=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].password"`
-export MONGO_USER=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].username"`
-export MONGO_DATABASE=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].path"`
+export MONGO_PORT=`echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".mongodb[0].port"`
+export MONGO_HOST=`echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".mongodb[0].host"`
+export MONGO_PASSWORD=`echo $PLATFORM_RELATIONSHIPS |base64 --decode | jq -r ".mongodb[0].password"`
+export MONGO_USER=`echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".mongodb[0].username"`
+export MONGO_DATABASE=`echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".mongodb[0].path"`
 export MONGO_URL=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DATABASE}
 export JAVA_OPTS="-Xmx$(jq .info.limits.memory /run/config.json)m -XX:+ExitOnOutOfMemoryError"
 ```

--- a/sites/platform/src/guides/micronaut/mongodb.md
+++ b/sites/platform/src/guides/micronaut/mongodb.md
@@ -7,10 +7,10 @@ description: |
     Configure a Micronaut application with MongoDB.
 ---
 
-To activate MongoDB and then have it accessed by the Micronaut application already in {{% vendor/name %}}, it is necessary to modify two files. 
+To activate MongoDB and then have it accessed by the Micronaut application already in {{% vendor/name %}}, it is necessary to modify two files.
 
 {{< note >}}
-This guide only covers the *addition* of a MongoDB service configuration to an existing Micronaut project already configured to deploy on {{% vendor/name %}}. Please see the [deployment guide](/guides/micronaut/deploy/_index.md) for more detailed instructions for setting up app containers and initial projects. 
+This guide only covers the *addition* of a MongoDB service configuration to an existing Micronaut project already configured to deploy on {{% vendor/name %}}. Please see the [deployment guide](/guides/micronaut/deploy/_index.md) for more detailed instructions for setting up app containers and initial projects.
 {{< /note >}}
 
 ## 1. Add the MongoDB service
@@ -34,11 +34,11 @@ In your [app configuration](../../create-apps/app-reference.md), use the service
 Connection credentials for services are exposed to the application container through the `PLATFORM_RELATIONSHIPS` environment variable from the deploy hook onward. Since this variable is a base64 encoded JSON object of all of your project's services, you'll likely want a clean way to extract the information specific to the database into it's own environment variables that can be used by Micronaut. On {{% vendor/name %}}, custom environment variables can be defined programmatically in a `.environment` file using `jq` to do just that:
 
 ```text
-export MONGO_PORT=`echo $PLATFORM_RELATIONSHIPS|base64 -d|json_pp|jq -r ".mongodb[0].port"`
-export MONGO_HOST=`echo $PLATFORM_RELATIONSHIPS|base64 -d|json_pp|jq -r ".mongodb[0].host"`
-export MONGO_PASSWORD=`echo $PLATFORM_RELATIONSHIPS|base64 -d|json_pp|jq -r ".mongodb[0].password"`
-export MONGO_USER=`echo $PLATFORM_RELATIONSHIPS|base64 -d|json_pp|jq -r ".mongodb[0].username"`
-export MONGO_DATABASE=`echo $PLATFORM_RELATIONSHIPS|base64 -d|json_pp|jq -r ".mongodb[0].path"`
+export MONGO_PORT=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].port"`
+export MONGO_HOST=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].host"`
+export MONGO_PASSWORD=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].password"`
+export MONGO_USER=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].username"`
+export MONGO_DATABASE=`echo $PLATFORM_RELATIONSHIPS|base64 -d|jq -r ".mongodb[0].path"`
 export MONGO_URL=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DATABASE}
 export JAVA_OPTS="-Xmx$(jq .info.limits.memory /run/config.json)m -XX:+ExitOnOutOfMemoryError"
 ```


### PR DESCRIPTION
## Why

Closes #3863 
jq is installed in all our images negating the need for json_pp. 

## What's changed

* removes json_pp from mongo db section in micronaut guide
* adds spacing to the mongodb section of micronaut guides, changes `-d` to `--decode` for `base64` example to match the style used in the rest of the docs
* removes json_pp, adds jq in guides drupal redis