### PR TITLE
Revert "Revert instance mounts and temporary alias doc" for Git 26

### DIFF
--- a/sites/friday/src/create-apps/app-reference.md
+++ b/sites/friday/src/create-apps/app-reference.md
@@ -188,7 +188,7 @@ See how to [troubleshoot the warning](./troubleshoot-mounts.md#overlapping-folde
 
 | Name          | Type                 | Required | Description |
 | ------------- | -------------------- | -------- | ----------- |
-| `source`      | `storage`, `tmp`, or `service` | Yes | Specifies the type of the mount:<br/><br/>- By design, `storage` mounts can be shared between instances of the same app. You can also configure them so they are [shared between different apps](#share-a-mount-between-several-apps).<br/><br/>- `tmp` mounts are local ephemeral mounts, where an external directory is mounted to the `/tmp` directory of your app.<br/>The content of a `tmp` mount **may be removed during infrastructure maintenance operations**. Therefore, `tmp` mounts allow you to **store files that you’re not afraid to lose**, such as your application cache that can be seamlessly rebuilt.<br/>Note that the `/tmp` directory has **a maximum allocation of 8 GB**.<br/><br/>- `service` mounts can be useful if you want to explicitly define and use a [Network Storage](/add-services/network-storage.md) service to share data between different apps (instead of using a `storage` mount).|
+| `source`      | `storage`, `instance`, `tmp` (also called `temporary`), or `service` | Yes | Specifies the type of the mount:<br/><br/>- By design, `storage` mounts can be shared between instances of the same app. You can also configure them so they are [shared between different apps](#share-a-mount-between-several-apps).<br/><br/>-`instance` mounts are local mounts. Unique to your app, they are useful to store files that remain local to the app instance, such as application logs.<br/><br/>- `tmp` (or `temporary`) mounts are local ephemeral mounts, where an external directory is mounted to the `/tmp` directory of your app.<br/>The content of a `tmp` mount **may be removed during infrastructure maintenance operations**. Therefore, `tmp` mounts allow you to **store files that you’re not afraid to lose**, such as your application cache that can be seamlessly rebuilt.<br/>Note that the `/tmp` directory has **a maximum allocation of 8 GB**.<br/><br/>- `service` mounts can be useful if you want to explicitly define and use a [Network Storage](/add-services/network-storage.md) service to share data between different apps (instead of using a `storage` mount).|
 | `source_path` | `string`             | No      | Specifies where the mount points **inside the [external directory](#mounts)**.<br/><br/> - If you explicitly set a `source_path`, your mount points to a specific subdirectory in the external directory. <br/><br/> - If the `source_path` is an empty string (`""`), your mount points to the entire external directory.<br/><br/> - If you don't define a `source_path`, {{% vendor/name %}} uses the {{< variable "MOUNT_PATH" >}} as default value, without leading or trailing slashes.</br>For example, if your mount lives in the `/web/uploads/` directory in your app container, it will point to a directory named `web/uploads` in the external directory.  </br></br> **WARNING:** Changing the name of your mount affects the `source_path` when it's undefined. See [how to ensure continuity](#ensure-continuity-when-changing-the-name-of-your-mount) and maintain access to your files. |
 | `service`     | `string`             |         | The purpose of the `service` key depends on your use case.</br></br> In a multi-app context where a `storage` mount is shared between apps, `service` is required. Its value is the name of the app whose mount you want to share. See how to [share a mount between several apps](#share-a-mount-between-several-apps).</br></br> In a multi-app context where a [Network Storage service](../add-services/network-storage.md) (`service` mount) is shared between apps, `service` is required and specifies the name of that Network Storage. |
 
@@ -333,20 +333,6 @@ Follow these steps:
 {{% /note %}}
 
 Note that another way to share data between apps through a mount is by explicitly [defining a Network Storage service](/add-services/network-storage.md).
-
-### Local mounts
-
-If you need a local mount (i.e. unique per container),
-{{% vendor/name %}} allows you to mount a directory within the `/tmp` directory of your app.
-However, the following limitations apply:
-
-- Content from `tmp` mounts is removed when your app container is moved to another host during an infrastructure maintenance operation
-- The `/tmp` directory has a [maximum allocation of 8 GB](/create-apps/troubleshoot-disks.md#no-space-left-on-device)
-
-Therefore, `tmp` mounts are ideal to store non-critical data, such as your application cache which can be seamlessly rebuilt,
-but aren't suitable for storing files that are necessary for your app to run smoothly.
-
-Note that {{% vendor/name %}} will provide new local mounts in the near future.
 
 ## Web
 

--- a/sites/friday/src/create-apps/workers.md
+++ b/sites/friday/src/create-apps/workers.md
@@ -264,7 +264,7 @@ and, if appropriate, adjust its behavior accordingly.
 When defining a [worker](../create-apps/app-reference.md#workers) instance,
 keep in mind what mount behavior you want.
 
-`tmp` local mounts are a separate storage area for each instance,
+`tmp` and `instance` local mounts are a separate storage area for each instance,
 while `storage` mounts can be shared between instances.
 
 For example, you can define a `storage` mount (called `shared_dir`) to be used by a `web` instance,


### PR DESCRIPTION
Reverts platformsh/platformsh-docs#3788 to reinstate `temporary` and `instance` mounts doc.