### PR TITLE
Restore simplified relationships (updated)

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -3,8 +3,8 @@
     "description": "",
     "disk": false,
     "docs": {
-      "relationship_name": "chromeheadlessbrowser",
-      "service_name": "chromeheadless",
+      "relationship_name": "chrome-headless",
+      "service_name": "chrome-headless",
       "url": "/add-services/headless-chrome.html"
     },
     "endpoint": "http",
@@ -100,7 +100,7 @@
     "description": "A manufacture service for Elasticsearch",
     "disk": true,
     "docs": {
-      "relationship_name": "essearch",
+      "relationship_name": "elasticsearch",
       "service_name": "elasticsearch",
       "url": "/add-services/elasticsearch.html"
     },
@@ -276,7 +276,7 @@
     "description": "",
     "disk": true,
     "docs": {
-      "relationship_name": "influxdbdatabase",
+      "relationship_name": "influxdb",
       "service_name": "influxdb",
       "url": "/add-services/influxdb.html"
     },
@@ -355,7 +355,7 @@
     "description": "",
     "disk": true,
     "docs": {
-      "relationship_name": "kafkaqueue",
+      "relationship_name": "kafka",
       "service_name": "kafka",
       "url": "/add-services/kafka.html"
     },
@@ -431,7 +431,7 @@
     "repo_name": "mariadb",
     "disk": true,
     "docs": {
-      "relationship_name": "mariadbdatabase",
+      "relationship_name": "mariadb",
       "service_name": "mariadb",
       "url": "/add-services/mysql.html"
     },
@@ -491,7 +491,7 @@
     "repo_name": "mariadb",
     "disk": true,
     "docs": {
-      "relationship_name": "mysqldatabase",
+      "relationship_name": "mysql",
       "service_name": "mysql",
       "url": "/add-services/mysql.html"
     },
@@ -547,7 +547,7 @@
     "repo_name": "memcached",
     "disk": false,
     "docs": {
-      "relationship_name": "memcachedcache",
+      "relationship_name": "memcached",
       "service_name": "memcached",
       "url": "/add-services/memcached.html"
     },
@@ -573,7 +573,7 @@
     "repo_name": "mongodb",
     "disk": true,
     "docs": {
-      "relationship_name": "mongodbdatabase",
+      "relationship_name": "mongodb",
       "service_name": "mongodb",
       "url": "/add-services/mongodb.html"
     },
@@ -598,8 +598,8 @@
     "repo_name": "mongodb",
     "disk": true,
     "docs": {
-      "relationship_name": "mongodbdatabase",
-      "service_name": "mongodb",
+      "relationship_name": "mongodb-enterprise",
+      "service_name": "mongodb-enterprise",
       "url": "/add-services/mongodb.html"
     },
     "endpoint": "mongodb",
@@ -712,7 +712,7 @@
     "description": "A manufacture service for OpenSearch",
     "disk": true,
     "docs": {
-      "relationship_name": "ossearch",
+      "relationship_name": "opensearch",
       "service_name": "opensearch",
       "url": "/add-services/opensearch.html"
     },
@@ -754,7 +754,7 @@
     "repo_name": "oracle-mysql",
     "disk": true,
     "docs": {
-      "relationship_name": "oracledatabase",
+      "relationship_name": "oracle-mysql",
       "service_name": "oracle-mysql",
       "url": "/add-services/mysql.html"
     },
@@ -844,7 +844,7 @@
     "repo_name": "postgresql",
     "disk": true,
     "docs": {
-      "relationship_name": "postgresqldatabase",
+      "relationship_name": "postgresql",
       "service_name": "postgresql",
       "url": "/add-services/postgresql.html"
     },
@@ -946,7 +946,7 @@
     "repo_name": "rabbitmq",
     "disk": true,
     "docs": {
-      "relationship_name": "rabbitmqqueue",
+      "relationship_name": "rabbitmq",
       "service_name": "rabbitmq",
       "url": "/add-services/rabbitmq.html"
     },
@@ -1002,7 +1002,7 @@
     "repo_name": "redis",
     "disk": false,
     "docs": {
-      "relationship_name": "rediscache",
+      "relationship_name": "redis",
       "service_name": "redis",
       "url": "/add-services/redis.html"
     },
@@ -1150,7 +1150,7 @@
     "repo_name": "solr",
     "disk": true,
     "docs": {
-      "relationship_name": "solrsearch",
+      "relationship_name": "solr",
       "service_name": "solr",
       "url": "/add-services/solr.html"
     },
@@ -1206,7 +1206,7 @@
     "repo_name": "varnish",
     "disk": false,
     "docs": {
-      "relationship_name": "varnishstats",
+      "relationship_name": "varnish",
       "service_name": "varnish",
       "url": "/add-services/varnish.html"
     },
@@ -1235,7 +1235,7 @@
     "description": "",
     "disk": true,
     "docs": {
-      "relationship_name": "vault_secret",
+      "relationship_name": "vault-kms",
       "service_name": "vault-kms",
       "url": "/add-services/vault.html"
     },


### PR DESCRIPTION
## Why

Resubmits https://github.com/platformsh/platformsh-docs/pull/3842 to account for changes that need to be made to both the Platform.sh and Upsun sites now. 

Closes https://github.com/platformsh/platformsh-docs/issues/3775


<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

The option for simplified relationships was not ready when originally merged. This reinstates the docs that were reverted.

**TODO:** Since this PR was reverted, there have been major structural changes to the documentation. Namely, the docs for Upsun are not automatically inherited from Platform.sh. Until simplied relationship changes are replicated/confirmed for `sites/upsun`, this PR is a WIP. 