### PR TITLE
Fix composable image xdebug configuration.

### DIFF
--- a/sites/platform/src/languages/php/_index.md
+++ b/sites/platform/src/languages/php/_index.md
@@ -617,7 +617,6 @@ This section is only relevant when using the Upsun [composable image (BETA)](/cr
 
 The following table presents the possible modifications you can make to your PHP primary runtime using the `stack` key and composable image.
 Each modification should be listed below the stack chosen (i.e. `extensions` are enabled under `.applications.frontend.stack[0]["php@8.3"].extensions` for PHP 8.3).
-Xdebug is an exception, and should be configured from its extension listing.
 See the example below for more details.
 
 | Name                        | Type                                                       | Description                                                                                |
@@ -636,21 +635,22 @@ name: frontend
 stack:
     - "php@8.3":
         extensions:
-        - apcu # A PHP extension made available to the PHP runtime
-        - sodium
-        - xsl
-        - pdo_sqlite
-        - xdebug:
-            idekey: YOUR_KEY
+          - apcu # A PHP extension made available to the PHP runtime
+          - sodium
+          - xsl
+          - pdo_sqlite
+
+        xdebug:
+          idekey: YOUR_KEY
 
         disabled_extensions:
-        - gd
+          - gd
 
         request_terminate_timeout: 200
 
         sizing_hints:
-        request_memory: 45
-        reserved_memory: 70
+          request_memory: 45
+          reserved_memory: 70
 
     - "php83Extensions.apcu" # A PHP extension made available to all runtimes.
     - "python@3.12"

--- a/sites/upsun/src/languages/php/_index.md
+++ b/sites/upsun/src/languages/php/_index.md
@@ -641,7 +641,6 @@ This section is only relevant when using the Upsun [composable image (BETA)](/cr
 
 The following table presents the possible modifications you can make to your PHP primary runtime using the `stack` key and composable image.
 Each modification should be listed below the stack chosen (i.e. `extensions` are enabled under `.applications.frontend.stack[0]["php@8.3"].extensions` for PHP 8.3).
-Xdebug is an exception, and should be configured from its extension listing.
 See the example below for more details.
 
 | Name                        | Type                                                       | Description                                                                                |
@@ -666,8 +665,9 @@ applications:
             - sodium
             - xsl
             - pdo_sqlite
-            - xdebug:
-                idekey: YOUR_KEY
+
+          xdebug:
+            idekey: YOUR_KEY
 
           disabled_extensions:
             - gd


### PR DESCRIPTION
## Why

Xdebug configuration was incorrect for the composable image. This corrects that. 