### PR TITLE
Update A records doc to link to correct IPs

### DIFF
--- a/sites/platform/src/domains/steps/dns.md
+++ b/sites/platform/src/domains/steps/dns.md
@@ -100,11 +100,7 @@ Until you do, your site can appear offline because requests are lost.
 
 To use `A` records, follow these steps:
 
-1.  To get the IP addresses of your project's production environment, run the following command:
-
-    ```bash
-    dig +short $({{% vendor/cli %}} environment:info edge_hostname)
-    ```
+1.  [Get the IP addresses](/development/regions.md#public-ip-addresses) of your project's production environment.
      
 2.  Follow the instructions on [how to set up a custom domain](./_index.md).
     When you come to configuring your DNS provider, instead of a `CNAME` record,

--- a/sites/upsun/src/domains/steps/dns.md
+++ b/sites/upsun/src/domains/steps/dns.md
@@ -100,11 +100,7 @@ Until you do, your site can appear offline because requests are lost.
 
 To use `A` records, follow these steps:
 
-1.  To get the IP addresses of your project's production environment, run the following command:
-
-    ```bash
-    dig +short $({{% vendor/cli %}} environment:info edge_hostname)
-    ```
+1.  [Get the IP addresses](/development/regions.md#public-ip-addresses) of your project's production environment.
      
 2.  Follow the instructions on [how to set up a custom domain](./_index.md).
     When you come to configuring your DNS provider, instead of a `CNAME` record,


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Doc on A records mentioned using a `dig` command to get the project's production environment IP addresses, but this can return IP addresses from mitigation gateways and create confusion for customers.

It's better to link to the Public IP addresses per region so customers use the correct IPs to set up their custom domains.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Removed the `dig` command and replaced it with a link to the Public IP addresses section instead.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
