### PR TITLE
Removes vendor name from composable image beta notification

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/composable/disclaimer.md
+++ b/themes/psh-docs/layouts/shortcodes/composable/disclaimer.md
@@ -1,4 +1,4 @@
 {{ $title := "Note" }}
 {{ $theme := "info" }}
-{{ $inner := "You can now use the Upsun composable image (BETA) to install runtimes and tools in your application container. To find out more, see the [dedicated documentation page](/create-apps/app-reference/composable-image.md)." }}
+{{ $inner := "You can now use composable image (BETA) to install runtimes and tools in your application container. To find out more, see the [dedicated documentation page](/create-apps/app-reference/composable-image.md)." }}
 {{ partial "note" (dict "context" . "title" $title "theme" $theme "Inner" $inner) }}


### PR DESCRIPTION
## Why

Closes #3944 

## What's changed

Removes vendor name from composable image disclaimer shortcode
