### PR TITLE
Remove reference to plan for Upsun.

### DIFF
--- a/sites/upsun/src/projects/region-migration.md
+++ b/sites/upsun/src/projects/region-migration.md
@@ -31,8 +31,7 @@ Before starting the migration process, you need to plan for it:
 
 In the target region, [create a new project from scratch]({{% create-project-link scratch=true %}}).
 
-If you plan to test for long, start with a Development plan and upsize it before switching the DNS.
-Otherwise, use the desired plan size from the start.
+If you plan to test for long, start with the least amount of resources on the project and then upsize it before switching the DNS.
 
 ## 3. Add code and environments
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes https://github.com/platformsh/platformsh-docs/issues/3452

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

Region migration for Upsun still referenced plans, which is no longer relevant.
