### PR TITLE
Fix meilisearch grabbing wrong description.

### DIFF
--- a/search/main.py
+++ b/search/main.py
@@ -26,9 +26,9 @@ class Search:
         # Below are Platform.sh custom settings for how the search engine functions.
 
         # Data available to the dropdown React app in docs, used to fill out autocomplete results.
-        self.displayed_attributes = ['keywords', 'title', 'text', 'url', 'site', 'section']
+        self.displayed_attributes = ['keywords', 'title', 'description', 'url', 'site', 'section']
         # Data actually searchable by our queries.
-        self.searchable_attributes = ['keywords', 'title', 'pageUrl', 'section', 'text', 'url']
+        self.searchable_attributes = ['keywords', 'title', 'pageUrl', 'section', 'description', 'url']
 
         # Show results for one query with the listed pages, when they by default would not show up as best results.
         # Note: these aren't automatically two-way, which is why they're all defined twice.

--- a/search/main.py
+++ b/search/main.py
@@ -28,7 +28,7 @@ class Search:
         # Data available to the dropdown React app in docs, used to fill out autocomplete results.
         self.displayed_attributes = ['keywords', 'title', 'description', 'url', 'site', 'section']
         # Data actually searchable by our queries.
-        self.searchable_attributes = ['keywords', 'title', 'pageUrl', 'section', 'description', 'url']
+        self.searchable_attributes = ['keywords', 'title', 'pageUrl', 'section', 'text', 'url']
 
         # Show results for one query with the listed pages, when they by default would not show up as best results.
         # Note: these aren't automatically two-way, which is why they're all defined twice.

--- a/sites/platform/static/scripts/xss/src/components/SuggestionsPrimary.js
+++ b/sites/platform/static/scripts/xss/src/components/SuggestionsPrimary.js
@@ -40,7 +40,7 @@ const SuggestionsPrimary = ({ hits, title }) => {
         </p>
         )}
       {/* eslint-disable-next-line no-underscore-dangle, react/no-danger */}
-      <p className="truncate mb-2" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(r._formatted.text) }} />
+      <p className="truncate mb-2" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(r._formatted.description) }} />
     </li>
   ))
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes https://github.com/platformsh/platformsh-docs/issues/3138
<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

Displayed attribute s/text/description