### PR TITLE
missing spaces between 'Upsun/Platform' and 'and'

### DIFF
--- a/sites/platform/src/increase-observability/logs/forward-logs.md
+++ b/sites/platform/src/increase-observability/logs/forward-logs.md
@@ -179,7 +179,7 @@ follow these steps:
 
 Some third-party services, such as [Elasticsearch](../../add-services/elasticsearch.md) and [OpenSearch](../../add-services/opensearch.md),
 support ingesting log messages through an HTTP endpoint.
-You can use HTTP forwarding to forward {{% vendor/name %}}and Blackfire logs to such third-party services.
+You can use HTTP forwarding to forward {{% vendor/name %}} and Blackfire logs to such third-party services.
 
 HTTP forwarding makes a `POST` HTTP request with an `application/json` body while forwarding the log messages to the endpoint.
 

--- a/sites/upsun/src/increase-observability/logs/forward-logs.md
+++ b/sites/upsun/src/increase-observability/logs/forward-logs.md
@@ -179,7 +179,7 @@ follow these steps:
 
 Some third-party services, such as [Elasticsearch](../../add-services/elasticsearch.md) and [OpenSearch](../../add-services/opensearch.md),
 support ingesting log messages through an HTTP endpoint.
-You can use HTTP forwarding to forward {{% vendor/name %}}and Blackfire logs to such third-party services.
+You can use HTTP forwarding to forward {{% vendor/name %}} and Blackfire logs to such third-party services.
 
 HTTP forwarding makes a `POST` HTTP request with an `application/json` body while forwarding the log messages to the endpoint.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
https://docs.upsun.com/increase-observability/logs/forward-logs.html#forward-to-an-http-endpoint
`Upsun` and `Platform` were concat to the rest of the sentence.
```
You can use HTTP forwarding to forward Upsunand Blackfire logs...
``` 
Closes #{ISSUE_NUMBER}

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
