### PR TITLE
Introduce mTLS terminology instead of TLS certificates where appropriate

### DIFF
--- a/sites/platform/src/define-routes/https.md
+++ b/sites/platform/src/define-routes/https.md
@@ -109,13 +109,13 @@ Note that when you enable or disable HSTS, the entire domain is affected.
 Make sure you only add the HSTS configuration to a single route.
 Having different routes with conflicting HSTS configurations can cause issues.
 
-### Enable client-authenticated TLS
+### Enable mTLS support
 
 Standard TLS connections are useful to verify the identity of web servers and their certificates.
 But you can also instruct your web server to verify the identity of clients and their certificates.
 This allows you to restrict access to trusted users.
 
-To do so, enable client-authenticated TLS by adding the following configuration:
+To do so, enable mTLS by adding the following configuration:
 
 ```yaml {configFile="routes"}
 tls:

--- a/sites/platform/src/define-routes/https.md
+++ b/sites/platform/src/define-routes/https.md
@@ -109,7 +109,7 @@ Note that when you enable or disable HSTS, the entire domain is affected.
 Make sure you only add the HSTS configuration to a single route.
 Having different routes with conflicting HSTS configurations can cause issues.
 
-### Enable mTLS support
+### Enable mTLS
 
 Standard TLS connections are useful to verify the identity of web servers and their certificates.
 But you can also instruct your web server to verify the identity of clients and their certificates.

--- a/sites/platform/src/domains/cdn/_index.md
+++ b/sites/platform/src/domains/cdn/_index.md
@@ -4,6 +4,8 @@ sidebarTitle: "Content delivery networks"
 weight: 3
 description: Improve performance for distributed end-users of your website with a content delivery network (CDN).
 layout: single
+keywords:
+    - mTLS support
 ---
 
 Using a CDN speeds up the delivery of your site's content to its users.
@@ -87,12 +89,12 @@ Furthermore, IP based filtering will usually be impossible due to the fact that 
 
 Both methods are highly insecure, and we highly recommend against them.
 
-### Client-authenticated TLS
+### Enable mTLS
 
 If your CDN provider supports it,
-you can secure your site through [mTLS](../../define-routes/https.md#enable-mtls-support).
+you can secure your site through [mTLS](../../define-routes/https.md#enable-mtls).
 
-To enable client-authenticated TLS, follow these steps:
+To enable mTLS, follow these steps:
 
 1.  Obtain an Origin Certificate Authority (CA) certificate from your CDN provider.
 
@@ -116,7 +118,7 @@ To enable client-authenticated TLS, follow these steps:
 The procedure can vary depending on your CDN.
 Contact your CDN provider for specific assistance.
 
-Note that client-authenticated TLS is a mutual authentication process.
+Note that mTLS is a mutual authentication process.
 It allows your CDN to check that it's communicating with your {{% vendor/name %}} server
 and vice versa.
 So in addition to the CA certificate supplied by your CDN provider,

--- a/sites/platform/src/domains/cdn/_index.md
+++ b/sites/platform/src/domains/cdn/_index.md
@@ -90,7 +90,7 @@ Both methods are highly insecure, and we highly recommend against them.
 ### Client-authenticated TLS
 
 If your CDN provider supports it,
-you can secure your site through [client-authenticated TLS](../../define-routes/https.md#enable-client-authenticated-tls).
+you can secure your site through [mTLS](../../define-routes/https.md#enable-mtls-support).
 
 To enable client-authenticated TLS, follow these steps:
 

--- a/sites/platform/src/domains/cdn/managed-fastly.md
+++ b/sites/platform/src/domains/cdn/managed-fastly.md
@@ -5,6 +5,8 @@ weight: 2
 description: Bring your content closer to users with a Fastly CDN fully managed by {{% vendor/name %}}.
 banner:
     type: tiered-feature
+keywords:
+  - mTLS
 ---
 
 Instead of starting your own Fastly subscription and [managing your CDN yourself](./fastly.md),

--- a/sites/platform/src/domains/steps/tls.md
+++ b/sites/platform/src/domains/steps/tls.md
@@ -2,6 +2,8 @@
 title: "Configure a third-party TLS certificate"
 weight: 2
 sidebarTitle: "Custom TLS certificates"
+keywords:
+  - mTLS
 ---
 
 {{% vendor/name %}} automatically provides standard Transport Layer Security (TLS) certificates for all sites and environments.

--- a/sites/platform/src/guides/ibexa/fastly.md
+++ b/sites/platform/src/guides/ibexa/fastly.md
@@ -66,5 +66,5 @@ as well as several other needs by Ibexa DXP and it's underlying HttpCache system
 
 ## Configure Fastly
 
-See the alternate [Go-live process for Fastly](/domains/cdn/_index.md#client-authenticated-tls) on {{% vendor/name %}}.
+See the alternate [Go-live process for Fastly](/domains/cdn/_index.md#mTLs) on {{% vendor/name %}}.
 This process is the same for any application.

--- a/sites/platform/src/guides/ibexa/fastly.md
+++ b/sites/platform/src/guides/ibexa/fastly.md
@@ -66,5 +66,5 @@ as well as several other needs by Ibexa DXP and it's underlying HttpCache system
 
 ## Configure Fastly
 
-See the alternate [Go-live process for Fastly](/domains/cdn/_index.md#mTLs) on {{% vendor/name %}}.
+See the alternate [Go-live process for Fastly](/domains/cdn/_index.md#mtls) on {{% vendor/name %}}.
 This process is the same for any application.

--- a/sites/platform/src/guides/ibexa/fastly.md
+++ b/sites/platform/src/guides/ibexa/fastly.md
@@ -66,5 +66,5 @@ as well as several other needs by Ibexa DXP and it's underlying HttpCache system
 
 ## Configure Fastly
 
-See the alternate [Go-live process for Fastly](/domains/cdn/_index.md#mtls) on {{% vendor/name %}}.
+See the alternate [Go-live process for Fastly](/domains/cdn/_index.md#enable-mtls) on {{% vendor/name %}}.
 This process is the same for any application.

--- a/sites/upsun/src/define-routes/https.md
+++ b/sites/upsun/src/define-routes/https.md
@@ -116,7 +116,7 @@ Note that when you enable or disable HSTS, the entire domain is affected.
 Make sure you only add the HSTS configuration to a single route.
 Having different routes with conflicting HSTS configurations can cause issues.
 
-### Enable mTLS support
+### Enable mTLS
 
 Standard TLS connections are useful to verify the identity of web servers and their certificates.
 But you can also instruct your web server to verify the identity of clients and their certificates.

--- a/sites/upsun/src/define-routes/https.md
+++ b/sites/upsun/src/define-routes/https.md
@@ -116,13 +116,13 @@ Note that when you enable or disable HSTS, the entire domain is affected.
 Make sure you only add the HSTS configuration to a single route.
 Having different routes with conflicting HSTS configurations can cause issues.
 
-### Enable client-authenticated TLS
+### Enable mTLS support
 
 Standard TLS connections are useful to verify the identity of web servers and their certificates.
 But you can also instruct your web server to verify the identity of clients and their certificates.
 This allows you to restrict access to trusted users.
 
-To do so, enable client-authenticated TLS by adding the following configuration:
+To do so, enable mTLS by adding the following configuration:
 
 ```yaml {configFile="routes"}
 routes:

--- a/sites/upsun/src/domains/cdn/_index.md
+++ b/sites/upsun/src/domains/cdn/_index.md
@@ -4,6 +4,8 @@ sidebarTitle: "Content delivery networks"
 weight: 3
 description: Improve performance for distributed end-users of your website with a content delivery network (CDN).
 layout: single
+keywords:
+    - mTLS support
 ---
 
 Using a CDN speeds up the delivery of your site's content to its users.
@@ -74,12 +76,12 @@ Furthermore, IP based filtering will usually be impossible due to the fact that 
 
 Both methods are highly insecure, and we highly recommend against them.
 
-### Client-authenticated TLS
+### Enable mTLS
 
 If your CDN provider supports it,
-you can secure your site through [client-authenticated TLS](../../define-routes/https.md#enable-client-authenticated-tls).
+you can secure your site through [mTLS](../../define-routes/https.md#enable-mtls).
 
-To enable client-authenticated TLS, follow these steps:
+To enable mTLS, follow these steps:
 
 1.  Obtain an Origin Certificate Authority (CA) certificate from your CDN provider.
 
@@ -104,7 +106,7 @@ To enable client-authenticated TLS, follow these steps:
 The procedure can vary depending on your CDN.
 Contact your CDN provider for specific assistance.
 
-Note that client-authenticated TLS is a mutual authentication process.
+Note that mTLS is a mutual authentication process.
 It allows your CDN to check that it's communicating with your {{% vendor/name %}} server
 and vice versa.
 So in addition to the CA certificate supplied by your CDN provider,

--- a/sites/upsun/src/domains/steps/tls.md
+++ b/sites/upsun/src/domains/steps/tls.md
@@ -2,6 +2,8 @@
 title: "Configure a third-party TLS certificate"
 weight: 2
 sidebarTitle: "Custom TLS certificates"
+keywords:
+  - mTLS
 ---
 
 {{% vendor/name %}} automatically provides standard Transport Layer Security (TLS) certificates for all sites and environments.


### PR DESCRIPTION
Closes #3982 
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

mTLS is now more widely used than TLS certificates.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
