### PR TITLE
Fix display issues in PSH guides

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/guides/data-migration.md
+++ b/themes/psh-docs/layouts/shortcodes/guides/data-migration.md
@@ -24,7 +24,7 @@ symfony cloud:sql < dump.sql
 ```
 {{ else }}
 ```bash
-{{ `{{< vendor/cli >}}` | .Page.RenderString }} sql < dump.sql
+{{ `{{% vendor/cli %}}` | .Page.RenderString }} sql < dump.sql
 ```
 {{ end }}
 
@@ -42,18 +42,18 @@ all of your user files to your local `files/user` directory and your public file
 {{ end }}, but adjust accordingly for their actual locations.
 
 Next, upload your files to your mounts
-using the {{ if $isSymfony }}`symfony cloud:mount:upload`{{ else }}`{{ `{{< vendor/cli >}}` | .Page.RenderString }} mount:upload`{{ end }} command.
+using the {{ if $isSymfony }}`symfony cloud:mount:upload`{{ else }}`{{ `{{% vendor/cli %}}` | .Page.RenderString }} mount:upload`{{ end }} command.
 Run the following command from your local Git repository root,
 modifying the `--source` path if needed.
 
 {{ if $isWordPress }}
 ```bash
-{{ `{{< vendor/cli >}}` | .Page.RenderString }} mount:upload --mount wordpress/wp-content/uploads --source ./wordpress/wp-content/uploads
+{{ `{{% vendor/cli %}}` | .Page.RenderString }} mount:upload --mount wordpress/wp-content/uploads --source ./wordpress/wp-content/uploads
 ```
 {{ else }}
 ```bash
-{{ `{{< vendor/cli >}}` | .Page.RenderString }} mount:upload --mount src/main/resources/files/user --source ./files/user
-{{ `{{< vendor/cli >}}` | .Page.RenderString }} mount:upload --mount src/main/resources/files/public --source ./files/public
+{{ `{{% vendor/cli %}}` | .Page.RenderString }} mount:upload --mount src/main/resources/files/user --source ./files/user
+{{ `{{% vendor/cli %}}` | .Page.RenderString }} mount:upload --mount src/main/resources/files/public --source ./files/public
 ```
 {{ end }}
 

--- a/themes/psh-docs/layouts/shortcodes/guides/deployment.md
+++ b/themes/psh-docs/layouts/shortcodes/guides/deployment.md
@@ -1,6 +1,6 @@
 <!-- shortcode start {{ .Name }} -->
 {{ $isSymfony := .Get "Symfony" }}
-{{ $cliCommand := `{{< vendor/cli >}}` | .Page.RenderString }}
+{{ $cliCommand := `{{% vendor/cli %}}` | .Page.RenderString }}
 {{ if $isSymfony }}
   {{ $cliCommand = "symfony cloud:" }}
 {{ end }}

--- a/themes/psh-docs/layouts/shortcodes/guides/initialize.html
+++ b/themes/psh-docs/layouts/shortcodes/guides/initialize.html
@@ -1,6 +1,6 @@
 <!-- shortcode start {{ .Name }} -->
 {{ $isSymfony := eq ( .Get "name" ) "Symfony" }}
-{{ $cliCommand := `{{< vendor/cli >}}` | .Page.RenderString }}
+{{ $cliCommand := `{{% vendor/cli %}}` | .Page.RenderString }}
 {{ if $isSymfony }}
   {{ $cliCommand = "symfony" }}
 {{ end }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

There were display issues in PSH guides due to the use of the ` {{< vendor/cli >}}` syntax in shortcodes.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Changed to `{{% vendor/cli %}}` syntax where needed.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
