### PR TITLE
Add warning about `nix` commands

### DIFF
--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -79,6 +79,19 @@ myapp:
 To add a language to your stack, use the `<nixpackage>@<version>` format.</br>
 To add a tool to your stack, use the `<nixpackage>` format, as no version is needed.
 
+{{% note theme=warning title="Warning" %}}
+It is not recommended to experiment with `nix` commands as it may result in technical issues.
+
+When using the {{% vendor/name %}} composable image, you don't need `nix` commands.
+Everything you install using the `stack` key is readily available to you,
+and can be retrieved via the `$PATH` environment variable.
+
+For instance, to [start a secondary runtime](#primary-runtime),
+use a [`start` command](/create-apps/app-reference/composable-image.md#web-commands) instead of the `nix run` command.
+
+Also, while technically available during the build phase, `nix` commands aren't supported at runtime as the image becomes read-only.
+{{% /note %}}
+
 #### Primary runtime
 
 If you add multiple runtimes to your application container,

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -80,16 +80,13 @@ To add a language to your stack, use the `<nixpackage>@<version>` format.</br>
 To add a tool to your stack, use the `<nixpackage>` format, as no version is needed.
 
 {{% note theme=warning title="Warning" %}}
-It is not recommended to experiment with `nix` commands as it may result in technical issues.
+While technically available during the build phase, `nix` commands aren't supported at runtime as the image becomes read-only.
 
 When using the {{% vendor/name %}} composable image, you don't need `nix` commands.
-Everything you install using the `stack` key is readily available to you,
-and can be retrieved via the `$PATH` environment variable.
+Everything you install using the `stack` key is readily available to you as the binaries are linked and included in `$PATH`.
 
 For instance, to [start a secondary runtime](#primary-runtime),
-use a [`start` command](/create-apps/app-reference/composable-image.md#web-commands) instead of the `nix run` command.
-
-Also, while technically available during the build phase, `nix` commands aren't supported at runtime as the image becomes read-only.
+just issue the command (e.g. in the [`start` command](/create-apps/app-reference/composable-image.md#web-commands)) instead of the `nix run` command.
 {{% /note %}}
 
 #### Primary runtime

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -103,16 +103,13 @@ To add a language to your stack, use the `<nixpackage>@<version>` format.</br>
 To add a tool to your stack, use the `<nixpackage>` format, as no version is needed.
 
 {{% note theme=warning title="Warning" %}}
-It is not recommended to experiment with `nix` commands as it may result in technical issues.
+While technically available during the build phase, `nix` commands aren't supported at runtime as the image becomes read-only.
 
 When using the {{% vendor/name %}} composable image, you don't need `nix` commands.
-Everything you install using the `stack` key is readily available to you,
-and can be retrieved via the `$PATH` environment variable.
+Everything you install using the `stack` key is readily available to you as the binaries are linked and included in `$PATH`.
 
 For instance, to [start a secondary runtime](#primary-runtime),
-use a [`start` command](/create-apps/app-reference/composable-image.md#web-commands) instead of the `nix run` command.
-
-Also, while technically available during the build phase, `nix` commands aren't supported at runtime as the image becomes read-only.
+just issue the command (e.g. in the [`start` command](/create-apps/app-reference/composable-image.md#web-commands)) instead of the `nix run` command.
 {{% /note %}}
 
 #### Primary runtime

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -102,6 +102,19 @@ applications:
 To add a language to your stack, use the `<nixpackage>@<version>` format.</br>
 To add a tool to your stack, use the `<nixpackage>` format, as no version is needed.
 
+{{% note theme=warning title="Warning" %}}
+It is not recommended to experiment with `nix` commands as it may result in technical issues.
+
+When using the {{% vendor/name %}} composable image, you don't need `nix` commands.
+Everything you install using the `stack` key is readily available to you,
+and can be retrieved via the `$PATH` environment variable.
+
+For instance, to [start a secondary runtime](#primary-runtime),
+use a [`start` command](/create-apps/app-reference/composable-image.md#web-commands) instead of the `nix run` command.
+
+Also, while technically available during the build phase, `nix` commands aren't supported at runtime as the image becomes read-only.
+{{% /note %}}
+
 #### Primary runtime
 
 If you add multiple runtimes to your application container,


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Users shouldn't need to use `nix` commands when using a composable image, but they are technically available at the build stage. So we need to let them know that they shouldn't need them, that experimenting with them may cause issues, and that they're not available at runtime.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added a warning with an example.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
