### PR TITLE
Clarify potential override of authentication method

### DIFF
--- a/sites/platform/src/environments/http-access-control.md
+++ b/sites/platform/src/environments/http-access-control.md
@@ -7,7 +7,7 @@ keywords:
 
 When developing your site, you might want to hide your preview environments from outside viewers.
 Or you may find you have performance issues from [excessive bot access](https://community.platform.sh/t/diagnosing-and-resolving-issues-with-excessive-bot-access/792).
-You can control access either with a username and password or by allowing/denying specific IP addresses or networks.
+You can control access with a username and password **or** by allowing/denying specific IP addresses or networks.
 This setting applies to the entire environment.
 
 The settings for a specific environment are inherited by all of its children.
@@ -57,7 +57,7 @@ For example, to add the username `name` with the password `12321` to the `test` 
 
 ## Filter IP addresses
 
-You can control access to environments by allowing or denying specific IP addresses or ranges of IP addresses.
+Alternatively, you can control access to environments by allowing or denying specific IP addresses or ranges of IP addresses.
 The addresses should be in the [CIDR format](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 Both`4.5.6.7` and `4.5.6.0/8` are accepted formats.
 
@@ -69,6 +69,16 @@ For example, the following configuration allows only the IP `198.51.100.0` to ac
 198.51.100.0 allow
 0.0.0.0/0 deny
 ```
+
+{{% note theme=warning title="Pick your authentication method"%}}
+
+When you set up IP filtering authentication,
+make sure no [username and password are defined](#use-a-username-and-password) for your environment.
+
+Otherwise, your environment will remain accessible through the defined username and password combination,
+regardless of your IP filtering settings.
+
+{{% /note %}}
 
 To control access based on IP address, follow these steps:
 

--- a/sites/upsun/src/environments/http-access-control.md
+++ b/sites/upsun/src/environments/http-access-control.md
@@ -7,7 +7,7 @@ keywords:
 
 When developing your site, you might want to hide your preview environments from outside viewers.
 Or you may find you have performance issues from [excessive bot access](https://community.platform.sh/t/diagnosing-and-resolving-issues-with-excessive-bot-access/792).
-You can control access either with a username and password or by allowing/denying specific IP addresses or networks.
+You can control access with a username and password **or** by allowing/denying specific IP addresses or networks.
 This setting applies to the entire environment.
 
 The settings for a specific environment are inherited by all of its children.
@@ -57,7 +57,7 @@ For example, to add the username `name` with the password `12321` to the `test` 
 
 ## Filter IP addresses
 
-You can control access to environments by allowing or denying specific IP addresses or ranges of IP addresses.
+Alternatively, you can control access to environments by allowing or denying specific IP addresses or ranges of IP addresses.
 The addresses should be in the [CIDR format](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
 Both`4.5.6.7` and `4.5.6.0/8` are accepted formats.
 
@@ -69,6 +69,16 @@ For example, the following configuration allows only the IP `198.51.100.0` to ac
 198.51.100.0 allow
 0.0.0.0/0 deny
 ```
+
+{{% note theme=warning title="Pick your authentication method"%}}
+
+When you set up IP filtering authentication,
+make sure no [username and password are defined](#use-a-username-and-password) for your environment.
+
+Otherwise, your environment will remain accessible through the defined username and password combination,
+regardless of your IP filtering settings.
+
+{{% /note %}}
 
 To control access based on IP address, follow these steps:
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Current doc didn't insist on users picking an authentic method and sticking to it. If an IP is denied but a username and pwd are defined on the environment, this overrides the `deny` of the IP and the environment remains accessible through the use of the username/pwd combination. Needed to clarify that point.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added a warning and slight rewording here and there. 

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
