### PR TITLE
Replacing YOUR_ID_HERE text for both commands with the appropriate YOUR_TOKEN_HERE text for the FASTLY_KEY variable

### DIFF
--- a/sites/platform/src/guides/ibexa/fastly.md
+++ b/sites/platform/src/guides/ibexa/fastly.md
@@ -13,9 +13,9 @@ description: |
 In Ibexa DXP, Varnish is enabled by default when deploying on {{% vendor/name %}}
 To use Fastly, Varnish must be disabled:
 
- - Remove environment variable `TRUSTED_PROXIES: "REMOTE_ADDR"` in [`{{< vendor/configfile "app" >}}](https://github.com/ezsystems/ezplatform/blob/master/.platform.app.yaml)
- - Remove the Varnish service in [`{{< vendor/configfile "services" >}}`](https://github.com/ezsystems/ezplatform/blob/master/.platform/services.yaml)
- - In [`{{< vendor/configfile "routes" >}}`](https://github.com/ezsystems/ezplatform/blob/master/.platform/routes.yaml),
+- Remove environment variable `TRUSTED_PROXIES: "REMOTE_ADDR"` in [`{{< vendor/configfile "app" >}}](https://github.com/ezsystems/ezplatform/blob/master/.platform.app.yaml)
+- Remove the Varnish service in [`{{< vendor/configfile "services" >}}`](https://github.com/ezsystems/ezplatform/blob/master/.platform/services.yaml)
+- In [`{{< vendor/configfile "routes" >}}`](https://github.com/ezsystems/ezplatform/blob/master/.platform/routes.yaml),
    change routes to use `app` instead of the `varnish` service you removed in previous step:
 
 ```diff
@@ -42,7 +42,7 @@ Using the CLI, run the following commands to set the configuration on your produ
 ```bash
 {{% vendor/cli %}} variable:create -e main --level environment env:HTTPCACHE_PURGE_TYPE --value 'fastly'
 {{% vendor/cli %}} variable:create -e main --level environment env:FASTLY_SERVICE_ID --value 'YOUR_ID_HERE'
-{{% vendor/cli %}} variable:create -e main --level environment env:FASTLY_KEY --value 'YOUR_ID_HERE'
+{{% vendor/cli %}} variable:create -e main --level environment env:FASTLY_KEY --value 'YOUR_TOKEN_HERE'
 ```
 
 Replacing `YOUR_ID_HERE` with the Fastly Service ID and Key obtained from Fastly.
@@ -52,7 +52,7 @@ Note: On a {{% names/dedicated-gen-2 %}} cluster, set those values on the `produ
 ```bash
 {{% vendor/cli %}} variable:set -e production env:HTTPCACHE_PURGE_TYPE fastly
 {{% vendor/cli %}} variable:set -e production env:FASTLY_SERVICE_ID YOUR_ID_HERE
-{{% vendor/cli %}} variable:set -e production env:FASTLY_KEY YOUR_ID_HERE
+{{% vendor/cli %}} variable:set -e production env:FASTLY_KEY YOUR_TOKEN_HERE
 ```
 
 ## Setup the correct VCL files
@@ -62,7 +62,6 @@ you can find them in `vendor/ibexa/fastly/fastly/ez_*.vcl`.
 A VCL snippet can be found in `vendor/ibexa/fastly/fastly/snippet_re_enable_shielding.vcl`.
 They handle varying cache by user context hash _(permissions)_
 as well as several other needs by Ibexa DXP and it's underlying HttpCache system.
-
 
 ## Configure Fastly
 


### PR DESCRIPTION
Replaced the text YOUR_ID_HERE for FASTLY_KEY variable with the correct text YOUR_TOKEN_HERE. Presently, for both `FASTLY_SERVICE_ID` and `FASTLY_KEY` the hint text is `YOUR_ID_HERE` which might be confusing, hence updated the hint text for `FASTLY_KEY` with the appropriate text `YOUR_TOKEN_HERE`. 

## What's changed

- modified:   sites/platform/src/guides/ibexa/fastly.md
