### PR TITLE
Update vertical scaling and backup restoration

### DIFF
--- a/sites/upsun/src/manage-resources/adjust-resources.md
+++ b/sites/upsun/src/manage-resources/adjust-resources.md
@@ -13,27 +13,30 @@ keywords:
   - "scaling"
 ---
 
-When you first deploy your project or add a new app or service to it,
+When you first deploy your project, or add a new app or service to it,
 {{% vendor/name %}} allocates [default resources](/manage-resources/resource-init.md#default-resources) to each of your containers.
 If you don't want to use those default resources, define a different [resource initialization strategy](/manage-resources/resource-init#specify-a-resource-initialization-strategy).
 
 After the initial deployment, or if you opt for the `Manual` [resource initialization strategy](/manage-resources/resource-init#specify-a-resource-initialization-strategy),
 you can adjust container resources manually.
-To do, follow the instructions on this page.
+To do so, follow the instructions on this page.
 
-{{% vendor/name %}} allows you to configure resources (CPU, RAM, and disk) per environment for each of your apps and services.
-You can also add instances for each of your apps depending on your needs.
+{{% vendor/name %}} allows you to configure resources (CPU, RAM, and disk) per environment for each app and service.
+You can also add instances for each app depending on your needs.
 
 For example, you can scale vertically and allocate more resources to your production and staging environments
 than to your development environments.
 This flexibility allows you to optimize performance and costs.
 
-You can even scale horizontally if your apps are struggling with high load, or if you're expecting a traffic spike,
+You can also scale horizontally if your apps are struggling with high load, or if you're expecting a traffic spike,
 by adding more instances for your apps and workers.
 
-For information on costs related to resource usage, see the [{{% vendor/name %}} pricing page](https://upsun.com/pricing/).
+{{< note >}}
 
-Note that you can [monitor these costs](/administration/billing/monitor-billing.md) in the Console.
+For information on costs related to resource usage, see the [{{% vendor/name %}} pricing page](https://upsun.com/pricing/).
+You can [monitor these costs](/administration/billing/monitor-billing.md) in the Console.
+
+{{< /note >}}
 
 ## Vertical scaling
 
@@ -46,12 +49,16 @@ follow these steps:
 title= Using the CLI
 +++
 
-Run the `{{% vendor/cli %}} resources:set` command, and follow the prompts to set resources for each of your apps and services.
+To set resources for each of your apps and services,
+you can use the {{% vendor/name %}} CLI interactive prompts, or run commands manually.
+
+- **Interactive prompts:**
+
+Run the `{{% vendor/cli %}} resources:set` command, and follow the prompts to set resources for each app and service.
 
 {{< note >}}
 
 For further guidance on how to set resources using the CLI, run the `{{% vendor/cli %}} resources:set --help` command.
-
 Note that if the deployment fails after you've run `{{% vendor/cli %}} resources:set`,
 you may need to set the resources again.
 
@@ -59,6 +66,41 @@ you may need to set the resources again.
 
 After you've set resources, your environment is redeployed,
 which causes a short downtime.
+
+- **Manual commands:**
+
+Use the following CLI flags:
+
+| CLI flag        | Description                     | 
+| --------------- | --------------------------------|
+| `size`          | Allows you to define how much CPU you want to allocate to each app or service.</br>The amount of CPU then determines how much RAM is also allocated, based on the [container profile](#advanced-container-profiles). |
+| `disk`          | Allows you to define how much disk/storage you want to allocate to each app or service. |
+
+_Example 1:_
+
+The following command allocates `0.1` CPU to the `frontend` app, `0.25` CPU to the `backend` app, and `1` CPU to the `database` service.
+The amount of RAM these settings translate into depends on each [container profile](#advanced-container-profiles).
+
+```bash {location="Terminal"}
+{{% vendor/cli %}} resources:set --size frontend:0.1,backend:0.25,database:1
+```
+
+_Example 2:_
+
+The following command allocates `640 MB` of disk to the `backend` app, and `2048 MB` to the `database` service:
+
+```bash {location="Terminal"}
+{{% vendor/cli %}} resources:set --disk backend:640,database:2048
+```
+
+_Example 3:_
+
+You can also use wildcards. For example, if you have two apps named `frontend` and `backend`,
+you could allocate the same CPU and RAM combination to both by using the following command:
+
+```bash {location="Terminal"}
+{{% vendor/cli %}} resources:set --size '*end:0.1'
+```
 
 <--->
 
@@ -104,7 +146,7 @@ or run commands manually.
 
 - **Interactive prompts:**
 
-  Run the `{{% vendor/cli %}} resources:set` command, and follow the prompts to set resources for each of your apps and services.
+  Run the `{{% vendor/cli %}} resources:set` command, and follow the prompts to set resources for each app and service.
 
   {{% note %}}
   For further guidance on how to set resources using the CLI, run the `{{% vendor/cli %}} resources:set --help` command.

--- a/sites/upsun/src/manage-resources/resource-init.md
+++ b/sites/upsun/src/manage-resources/resource-init.md
@@ -37,7 +37,7 @@ You can also [adjust resources](/manage-resources/adjust-resources.md) after you
 {{% note %}}
 
 For information on costs related to resource usage, see the [{{% vendor/name %}} pricing page](https://upsun.com/pricing/).
-Note that you can [monitor these costs](/administration/billing/monitor-billing.md) in the Console.
+You can [monitor these costs](/administration/billing/monitor-billing.md) in the Console.
 
 {{% /note %}}
 
@@ -52,7 +52,7 @@ Note that you can [monitor these costs](/administration/billing/monitor-billing.
 | `minimum`  | Initializes new containers using the {{% vendor/name %}} minimum resources (see below). |
 | `parent`   | Initializes new containers using the same resources as on the parent environment.</br>If there is no parent environment, or if the container doesn't already exist on the parent, the `default` strategy applies instead. |
 | `child`    | Initializes new containers using the same resources as on the child environment. Only relevant during merge activities. |
-| `backup`   | When restoring a backup, initializes new containers using the same resources as when the backup was taken. |
+| `backup`   | When restoring a backup, all containers are restored using the same resources as when the backup was taken. |
 
 {{% note theme="info" title="More information on..."%}} 
 <details>
@@ -353,12 +353,12 @@ you can restore it to your current environment or a different environment.
 
 ## Backup restoration to your current environment
 
-Each container already running on the environment keeps its existing resources.
+By default, when you [restore a backup](/environments/restore.md) using the CLI, it is restored to your current environment.
 
-You may have deleted containers between the moment you took the backup, and the moment you restore it.</br>
-By default, code is restored as part of the backup.
-Therefore, previously deleted containers are restored using the `backup` strategy,
-which grants them the same resources they were using when the backup was taken.
+Containers are restored using the `backup` strategy, meaning:
+- Each container that's already running on the environment sees its resources restored to what they were when the backup was taken.
+- If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
+  using the resources from when the backup was taken.
 
 {{% note %}}
 If you don't want to restore previously deleted containers,
@@ -397,18 +397,15 @@ title=In the Console
 
 When you [restore a backup](/environments/restore.md) using the Console, it is restored to your current environment.
 
-Each container already running on your current environment keeps its existing resources.
-Therefore, you don't need to specify a resource initialization strategy. 
+Containers are restored using the `backup` strategy, meaning:
+- Each container that's already running on the environment sees its resources restored to what they were when the backup was taken.
+- If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
+  using the resources from when the backup was taken.
 
 {{% note %}}
-You may have deleted containers between the moment you took the backup, and the moment you restore it.</br>
-By default, code is restored as part of the backup.
-Therefore, previously deleted containers are restored using the `backup` strategy,
-which grants them the same resources they were using when the backup was taken.
-
 If you don't want to restore previously deleted containers,
 opt out of restoring the code.
-To do so, when you restore your backup, use the `--no-code` flag.
+To do so, restore the backup using the CLI and use the `--no-code` flag.
 {{% /note %}}
 
 {{< /codetabs >}}

--- a/sites/upsun/src/manage-resources/resource-init.md
+++ b/sites/upsun/src/manage-resources/resource-init.md
@@ -356,7 +356,7 @@ you can restore it to your current environment or a different environment.
 By default, when you [restore a backup](/environments/restore.md) using the CLI, it is restored to your current environment.
 
 Containers are restored using the `backup` strategy, meaning:
-- The resources of each container running on the environment are restored to what they were when the backup was taken.
+- The resources of every container running on the environment are reverted to their original state when the backup was taken.
 - If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
   using the resources from when the backup was taken.
 
@@ -398,7 +398,7 @@ title=In the Console
 When you [restore a backup](/environments/restore.md) using the Console, it is restored to your current environment.
 
 Containers are restored using the `backup` strategy, meaning:
-- The resources of each container running on the environment are restored to what they were when the backup was taken.
+- The resources of every container running on the environment are reverted to their original state when the backup was taken.
 - If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
   using the resources from when the backup was taken.
 

--- a/sites/upsun/src/manage-resources/resource-init.md
+++ b/sites/upsun/src/manage-resources/resource-init.md
@@ -356,7 +356,7 @@ you can restore it to your current environment or a different environment.
 By default, when you [restore a backup](/environments/restore.md) using the CLI, it is restored to your current environment.
 
 Containers are restored using the `backup` strategy, meaning:
-- Each container that's already running on the environment sees its resources restored to what they were when the backup was taken.
+- The resources of each container already running on the environment are restored to what they were when the backup was taken.
 - If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
   using the resources from when the backup was taken.
 
@@ -398,7 +398,7 @@ title=In the Console
 When you [restore a backup](/environments/restore.md) using the Console, it is restored to your current environment.
 
 Containers are restored using the `backup` strategy, meaning:
-- Each container that's already running on the environment sees its resources restored to what they were when the backup was taken.
+- The resources of each container already running on the environment are restored to what they were when the backup was taken.
 - If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
   using the resources from when the backup was taken.
 

--- a/sites/upsun/src/manage-resources/resource-init.md
+++ b/sites/upsun/src/manage-resources/resource-init.md
@@ -356,7 +356,7 @@ you can restore it to your current environment or a different environment.
 By default, when you [restore a backup](/environments/restore.md) using the CLI, it is restored to your current environment.
 
 Containers are restored using the `backup` strategy, meaning:
-- The resources of each container already running on the environment are restored to what they were when the backup was taken.
+- The resources of each container running on the environment are restored to what they were when the backup was taken.
 - If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
   using the resources from when the backup was taken.
 
@@ -398,7 +398,7 @@ title=In the Console
 When you [restore a backup](/environments/restore.md) using the Console, it is restored to your current environment.
 
 Containers are restored using the `backup` strategy, meaning:
-- The resources of each container already running on the environment are restored to what they were when the backup was taken.
+- The resources of each container running on the environment are restored to what they were when the backup was taken.
 - If you deleted a container between the moment you took the backup and the moment you restore it, that container is relaunched
   using the resources from when the backup was taken.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #3854

Vertical scaling section can now mirror the horizontal scaling one, detailing CLI commands/flags.
`backup` strategy for backup restoration now means that all containers, including containers that are currently running on the environment, are restored to the resources from when the backup was taken.

<!-- 
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Updated **Vertical scaling** section on **Resource configuration** page, and updated **Backup restoration** section on **Resource initialisation** page. Made a few tweaks to shorten sentences/improve readability.

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
