### PR TITLE
github tokens need to be set to "No expiration"

### DIFF
--- a/sites/platform/src/integrations/source/github.md
+++ b/sites/platform/src/integrations/source/github.md
@@ -25,7 +25,7 @@ When you set up or update an integration, it also needs permission to manage its
 This means your user needs to be a repository admin to create the integration.
 You can remove this permission after setup.
 
-Make sure you give your token a description.
+Make sure you give your token a description, and set it to "No expiration".
 
 If you're generating a classic personal access token,
 ensure the token has the appropriate scopes based on what you want to do:


### PR DESCRIPTION
## Why

Because yes, a client just had integration pushes mysteriously stop working a month after following our instructions correctly.


## What's changed

Added a little detail on what to do when creating the token on the github side.