### PR TITLE
opensearch: remove lang-python also from elasticsearch

### DIFF
--- a/sites/platform/src/add-services/elasticsearch.md
+++ b/sites/platform/src/add-services/elasticsearch.md
@@ -282,7 +282,6 @@ elasticsearch:
     configuration:
         plugins:
             - analysis-icu
-            - lang-python
 ```
 
 If you're using a [premium version](#supported-versions),

--- a/sites/platform/src/add-services/opensearch.md
+++ b/sites/platform/src/add-services/opensearch.md
@@ -261,7 +261,6 @@ opensearch:
     configuration:
         plugins:
             - analysis-icu
-            - lang-python
 ```
 
 In this example you'd have the ICU analysis plugin and the size mapper plugin.

--- a/sites/upsun/src/add-services/elasticsearch.md
+++ b/sites/upsun/src/add-services/elasticsearch.md
@@ -296,7 +296,6 @@ To enable them, list them under the `configuration.plugins` key in your `{{< ven
     configuration:
         plugins:
             - analysis-icu
-            - lang-python
 {{% /snippet %}}
 ```
 

--- a/sites/upsun/src/add-services/opensearch.md
+++ b/sites/upsun/src/add-services/opensearch.md
@@ -300,7 +300,6 @@ services:
         configuration:
             plugins:
                 - analysis-icu
-                - lang-python
 ```
 
 In this example you'd have the ICU analysis plugin and the size mapper plugin.


### PR DESCRIPTION
the plugin is obsolete for some time now

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Remove obsolete plugin from examples

## What's changed

Remove lang-python from examples