### PR TITLE
Fix vendor name in network-storage.md

### DIFF
--- a/sites/platform/src/add-services/network-storage.md
+++ b/sites/platform/src/add-services/network-storage.md
@@ -117,7 +117,7 @@ mounts:
 - `<SERVICE_NAME>` is the name you [defined in step 1](#1-configure-the-service).
 - `<SOURCE_PATH>` specifies where the mount points inside the service.</br>
   If the `source_path` is an empty string (`""`), your mount points to the entire service.</br>
-  If you don’t define a `source_path`, {{ .Site.Params.vendor.name }} uses the `MOUNT_PATH` as default value, without leading or trailing slashes.
+  If you don’t define a `source_path`, {{% vendor/name %}} uses the `MOUNT_PATH` as default value, without leading or trailing slashes.
   For example, if your mount lives in the `/my/files/` directory within your app container, it will point to a `my/files` directory within the service.
 
 ### Example configuration

--- a/sites/upsun/src/add-services/network-storage.md
+++ b/sites/upsun/src/add-services/network-storage.md
@@ -79,7 +79,7 @@ services:
 - `<SERVICE_NAME>` is the name you [defined in step 1](#1-configure-the-service).
 - `<SOURCE_PATH>` specifies where the mount points inside the service.</br>
   If the `source_path` is an empty string (`""`), your mount points to the entire service.</br>
-  If you don’t define a `source_path`, {{ .Site.Params.vendor.name }} uses the `MOUNT_PATH` as default value, without leading or trailing slashes.
+  If you don’t define a `source_path`, {{% vendor/name %}} uses the `MOUNT_PATH` as default value, without leading or trailing slashes.
   For example, if your mount lives in the `/my/files/` directory within your app container, it will point to a `my/files` directory within the service.
 
 ### Example configuration


### PR DESCRIPTION
Reported in https://platformsh.slack.com/archives/C0JHEUHQD/p1722346352046769

I don't understand when `{{ .Site.Params.vendor.name }}` is supposed to work vs `{{% vendor/name %}}`

But the former appears to be not working on https://docs.platform.sh/add-services/network-storage.html#2-add-the-mount and the latter appears elsewhere in this file