### PR TITLE
Add MariaDB 10.11 to DG2 supported

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -460,6 +460,7 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "10.11 Galera",
         "10.8 Galera",
         "10.7 Galera",
         "10.6 Galera",


### PR DESCRIPTION
## Why

Support added; Slack request.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
