### PR TITLE
Adds support for data output for devcenter search

### DIFF
--- a/sites/platform/config/_default/config.yaml
+++ b/sites/platform/config/_default/config.yaml
@@ -1,5 +1,5 @@
 # Basics
-baseURL: /
+# baseURL: /
 title: Platform.sh Documentation
 author: Platform.sh
 description: Platform.sh User Documentation

--- a/sites/platform/config/_default/config.yaml
+++ b/sites/platform/config/_default/config.yaml
@@ -24,13 +24,20 @@ baseURL: "https://docs.platform.sh"
 summaryLength: 3
 
 outputs:
-    home: 
+    home:
       - HTML
       - JSON
       - RSS
+      - devcenter
     section:
       - HTML
       - RSS
+
+outputFormats:
+  devcenter:
+    mediaType: "application/json"
+    baseName: "json/devcenter"
+    isPlainText: true
 
 # Math typesetting as per 0.125.0 - https://gohugo.io/content-management/mathematics/
 markup:
@@ -64,10 +71,10 @@ module:
 
         - source: "../../shared/data"
           target: "data"
-          
+
         - source: "src"
           target: "content"
-          
+
           lang: "en"
         - source: "static"
           target: "static"
@@ -79,5 +86,5 @@ security:
     - ^GITHUB_
     - ^HUGO_HEAP_ID
   http:
-    methods: 
+    methods:
     - GET

--- a/sites/upsun/config/_default/config.yaml
+++ b/sites/upsun/config/_default/config.yaml
@@ -1,5 +1,5 @@
 # Basics
-baseURL: /
+#baseURL: /
 title: Upsun documentation
 author: Upsun
 description: Upsun User Documentation
@@ -19,7 +19,7 @@ languages:
 
 disableKinds: ["taxonomy"]
 
-#baseURL: "https://docs.upsun.com"
+baseURL: "https://docs.upsun.com"
 
 summaryLength: 3
 

--- a/sites/upsun/config/_default/config.yaml
+++ b/sites/upsun/config/_default/config.yaml
@@ -28,9 +28,16 @@ outputs:
       - HTML
       - JSON
       - RSS
+      - devcenter
     section:
       - HTML
       - RSS
+
+outputFormats:
+  devcenter:
+    mediaType: "application/json"
+    baseName: "json/devcenter"
+    isPlainText: true
 
 # Math typesetting as per 0.125.0 - https://gohugo.io/content-management/mathematics/
 markup:
@@ -52,7 +59,7 @@ markup:
             enable: true
 params:
     math: true
-    
+
 module:
     _merge: deep
     mounts:

--- a/themes/psh-docs/layouts/_default/list.devcenter.json
+++ b/themes/psh-docs/layouts/_default/list.devcenter.json
@@ -1,0 +1,22 @@
+{{/* FlexSearch Data structure for use in devcenter.upsun.com */}}
+{{- $indexType := site.Params.search.flexsearch.index | default "content" -}}
+{{- $baseURL := .Site.BaseURL -}}
+{{- if not (in (slice "content" "summary" "heading" "title" ) $indexType) -}}
+  {{- errorf "unknown flexsearch index type: %s" $indexType -}}
+{{- end -}}
+
+{{- $pages := where .Site.Pages "Kind" "in" (slice "page" "section") -}}
+{{- $pages = where $pages "Params.excludeSearch" "!=" true -}}
+{{- $pages = where $pages "Content" "!=" "" -}}
+
+{{- $output := dict -}}
+
+{{- range $index, $page := $pages -}}
+  {{- $pageTitle := $page.LinkTitle | default $page.File.BaseFileName -}}
+  {{- $pageLink := $page.RelPermalink -}}
+  {{- $fullURL := printf "%s%s" $baseURL $pageLink -}}
+  {{- $data := partial "utils/fragments" (dict "context" $page "type" $indexType) -}}
+  {{- $output = $output | merge (dict $pageLink (dict "title" $pageTitle "data" $data "base" $baseURL "full" $fullURL )) -}}
+{{- end -}}
+
+{{- $output | jsonify -}}

--- a/themes/psh-docs/layouts/_default/list.devcenter.json
+++ b/themes/psh-docs/layouts/_default/list.devcenter.json
@@ -1,6 +1,6 @@
 {{/* FlexSearch Data structure for use in devcenter.upsun.com */}}
 {{- $indexType := site.Params.search.flexsearch.index | default "content" -}}
-{{- $baseURL := .Site.BaseURL -}}
+{{- $baseURL := strings.TrimSuffix "/" .Site.BaseURL  -}}
 {{- if not (in (slice "content" "summary" "heading" "title" ) $indexType) -}}
   {{- errorf "unknown flexsearch index type: %s" $indexType -}}
 {{- end -}}

--- a/themes/psh-docs/layouts/partials/utils/excludeSearch.html
+++ b/themes/psh-docs/layouts/partials/utils/excludeSearch.html
@@ -1,0 +1,19 @@
+{{- $excludeStart := "<!-- excludeSearch -->" -}}
+{{- $excludeEnd := "<!-- /excludeSearch -->" -}}
+{{- $append := true -}}
+{{- $data := slice -}}
+
+{{- $splitC := split .content "\n" -}}
+{{- range $splitC -}}
+    {{- if $append -}}
+        {{- if eq $excludeStart . -}}
+            {{- $append = false -}}
+        {{- else -}}
+            {{- $data = $data | append . -}}
+        {{- end -}}
+    {{- else if eq $excludeEnd . -}}
+        {{- $append = true -}}
+    {{- end -}}
+{{- end -}}
+{{- $final := delimit $data "\n" -}}
+{{- return $final -}}

--- a/themes/psh-docs/layouts/partials/utils/fragments.html
+++ b/themes/psh-docs/layouts/partials/utils/fragments.html
@@ -1,0 +1,62 @@
+{{/* Split page raw content into fragments */}}
+{{ $page := .context }}
+{{ $type := .type | default "content" }}
+{{ $headingKeys := slice }}
+{{ $headingTitles := slice }}
+
+{{ range $h1 := $page.Fragments.Headings }}
+  {{ if eq $h1.Title "" }}
+    {{ $headingKeys = $headingKeys | append $h1.Title }}
+  {{ else }}
+    {{ $headingKeys = $headingKeys | append (printf "%s#%s" $h1.ID $h1.Title) }}
+  {{ end }}
+  {{ $headingTitles = $headingTitles | append (printf "# %s" $h1.Title) }}
+
+  {{ range $h2 := $h1.Headings }}
+    {{ $headingKeys = $headingKeys | append (printf "%s#%s" $h2.ID $h2.Title) }}
+    {{ $headingTitles = $headingTitles | append (printf "## %s" $h2.Title) }}
+  {{ end }}
+{{ end }}
+
+{{ $content := partial "utils/excludeSearch.html" (dict "context" . "content" $page.RawContent) }}
+{{ $len := len $headingKeys }}
+{{ $data := dict }}
+
+{{ if eq $type "content" }}
+  {{/* Include full content of the page */}}
+  {{ if eq $len 0 }}
+    {{ $plainContent := partial "utils/excludeSearch.html" (dict "context" . "content" $page.RawContent) }}
+    {{ $data = $data | merge (dict "" ($plainContent | htmlUnescape | chomp)) }}
+  {{ else }}
+    {{/* Split the raw content from bottom to top */}}
+    {{ range seq $len }}
+      {{ $i := sub $len . }}
+      {{ $headingKey := index $headingKeys $i }}
+      {{ $headingTitle := index $headingTitles $i }}
+
+      {{ if eq $i 0 }}
+        {{ $data = $data | merge (dict $headingKey ($content | $page.RenderString | plainify | htmlUnescape | chomp)) }}
+      {{ else }}
+        {{ $parts := split $content (printf "\n%s\n" $headingTitle) }}
+        {{ $lastPart := index $parts (sub (len $parts) 1) }}
+
+        {{ $data = $data | merge (dict $headingKey ($lastPart | $page.RenderString | plainify | htmlUnescape | chomp)) }}
+        {{ $content = strings.TrimSuffix $lastPart $content }}
+        {{ $content = strings.TrimSuffix (printf "\n%s\n" $headingTitle) $content }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ else if (eq $type "heading" ) }}
+  {{/* Put heading keys with empty content to the data object */}}
+  {{ $data = dict "" "" }}
+  {{ range $headingKeys }}
+    {{ $data = $data | merge (dict . "") }}
+  {{ end }}
+{{ else if (eq $type "title") }}
+  {{/* Use empty data object since title is included in search-data.json */}}
+  {{ $data = $data | merge (dict "" "") }}
+{{ else if (eq $type "summary" ) }}
+  {{ $data = $data | merge (dict "" ($page.Summary | plainify | htmlUnescape | chomp)) }}
+{{ end }}
+
+{{ return $data }}


### PR DESCRIPTION
## Why

The devcenter search requires a specific data structure for its search, that differs considerably from the structure meilisearch requires. In the interest of time, we're going to add a secondary data output for each docs site for the devcenter to consume.

## What's changed

- adds new output format for devcenter-specific search data to config for both sites
- adds new devcenter.json template to layouts
- adds supporting partials to generate the json layout

## Where are changes

Updates are for:
[X] platform (`sites/platform` templates)
[X] upsun (`sites/upsun` templates)
