### PR TITLE
Update references to trial length

### DIFF
--- a/sites/upsun/src/glossary/_index.md
+++ b/sites/upsun/src/glossary/_index.md
@@ -217,7 +217,7 @@ even though it has mostly replaced SSL for online encrypted connections.
 When you create your first organization on {{% vendor/name %}}, you are also activating your trial for that organization.
 This trial grants you a certain amount of time and resources to try out the {{% vendor/name %}} platform, and comes with the following restrictions:
 
-1. A trial lasts for **5 days**, which starts automatically from creating your first organization.
+1. A trial lasts for **15 days**, which starts automatically from creating your first organization.
 1. A trial allows for **one (1)** active [project](#project) at a time.
 1. For a trial project, the trial allows for **two (2)** [active environments](#active-environment).
 1. At the organization level, there is a limit on the amount of [resources available to your project](/manage-resources):
@@ -229,6 +229,6 @@ This trial grants you a certain amount of time and resources to try out the {{% 
 If your trial ends before adding payment details, there are additional things to keep in mind:
 
 - When a trial expires, both the organization and the project are suspended.
-- Projects where no code has been pushed are deleted **1 day** after a trial expires. 
+- Projects where no code has been pushed are deleted **1 day** after a trial expires.
 - Projects where code _has_ been pushed are deleted **5 days** after the trial expires.
 - Even with the trial expiration, organizations and user accounts are preserved, [rather than deleted](/learn/overview/get-support#delete-your-account).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes 4163

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Identified one reference to the trial duration in `src/glossary/_index.md`. Updated `5` to `15`.

## Where are changes

Updates are for:
- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
