### PR TITLE
Render shortcodes out of devcenter index.

### DIFF
--- a/themes/psh-docs/layouts/_default/list.devcenter.json
+++ b/themes/psh-docs/layouts/_default/list.devcenter.json
@@ -12,7 +12,7 @@
 {{- $output := dict -}}
 
 {{- range $index, $page := $pages -}}
-  {{- $pageTitle := $page.LinkTitle | default $page.File.BaseFileName -}}
+  {{- $pageTitle := $page.LinkTitle | default $page.File.BaseFileName | markdownify -}}
   {{- $pageLink := $page.RelPermalink -}}
   {{- $fullURL := printf "%s%s" $baseURL $pageLink -}}
   {{- $data := partial "utils/fragments" (dict "context" $page "type" $indexType) -}}

--- a/themes/psh-docs/layouts/partials/utils/fragments.html
+++ b/themes/psh-docs/layouts/partials/utils/fragments.html
@@ -18,15 +18,15 @@
   {{ end }}
 {{ end }}
 
-{{ $content := partial "utils/excludeSearch.html" (dict "context" . "content" $page.RawContent) }}
+{{ $content := partial "utils/excludeSearch.html" (dict "context" . "content" $page.Content) }}
 {{ $len := len $headingKeys }}
 {{ $data := dict }}
 
 {{ if eq $type "content" }}
   {{/* Include full content of the page */}}
   {{ if eq $len 0 }}
-    {{ $plainContent := partial "utils/excludeSearch.html" (dict "context" . "content" $page.RawContent) }}
-    {{ $data = $data | merge (dict "" ($plainContent | htmlUnescape | chomp)) }}
+    {{ $plainContent := partial "utils/excludeSearch.html" (dict "context" . "content" $page.Content) }}
+    {{ $data = $data | merge (dict "" ($plainContent | markdownify | htmlUnescape | chomp)) }}
   {{ else }}
     {{/* Split the raw content from bottom to top */}}
     {{ range seq $len }}


### PR DESCRIPTION
## Why

Dev center index is producing raw, un-rendered shortcodes in search. This makes them render correctly.