### PR TITLE
changes instances of 'Slack' to 'Discord'

### DIFF
--- a/sites/platform/src/_index.md
+++ b/sites/platform/src/_index.md
@@ -94,11 +94,11 @@ Looking for a way to contribute?
 
 <div style="margin-top: 3rem; text-align: center;">
     <a class="start-cta font-semibold text-sm xl:text-base px-4 py-2 bg-skye rounded text-white hover:bg-skye-dark focus:bg-skye-dark"
-    href="https://chat.platform.sh" rel="noopener">Join us on Slack</a>
+    href="https://chat.platform.sh" rel="noopener">Join us on Discord</a>
 </div>
 
 ### Contribute
-Feel free to open an issue or pull request for any of the repositories below, or let us know on [Slack](https://chat.platform.sh) if you find a problem we can help with:
+Feel free to open an issue or pull request for any of the repositories below, or let us know on [Discord](https://chat.platform.sh) if you find a problem we can help with:
 
 {{< home/links-github >}}
 

--- a/sites/platform/src/learn/overview/get-support.md
+++ b/sites/platform/src/learn/overview/get-support.md
@@ -29,10 +29,10 @@ Note that once you submit the ticket, you can't modify or delete the submission.
 If you have any additional information, you can select the submitted ticket and write a message.
 
 <!-- vale off -->
-## Slack
+## Discord
 
 To talk about app development or framework-related questions,
-join other customers and engineers in the [public Slack channel](https://chat.platform.sh/).
+join other customers and engineers in the [public Discord channel](https://chat.platform.sh/).
 
 ## Community
 
@@ -53,7 +53,7 @@ To permanently delete your {{% vendor/name %}} account, follow these steps:
 
 Deleting your {{% vendor/name %}} account automatically deletes any linked Upsun, Ibexa Cloud, Pimcore PaaS, or Shopware PaaS accounts you may hold.
 
-{{% /note %}} 
+{{% /note %}}
 
 1. [Open the Console](https://console.{{< vendor/urlraw "host" >}}/).
 2. Open the user menu (your name or profile picture) and select **My Profile**.


### PR DESCRIPTION
## Why

Closes #4197 

## What's changed

Public slack channels are being moved to Discord

## Where are changes

Updates are for:
[X] platform (`sites/platform` templates)
[] upsun (`sites/upsun` templates)
