### PR TITLE
Update requested GTM/heap changes.

### DIFF
--- a/sites/upsun/config/_default/params.yaml
+++ b/sites/upsun/config/_default/params.yaml
@@ -58,7 +58,7 @@ logolinksto: "https://upsun.com"
 logoAlt: "Upsun"
 favicon: "images/favicon.ico"
 
-gtm: "GTM-NN9T4G2T"
+gtm: "GTM-KJ4F382K"
 
 # Actions in main header
 headerActions:

--- a/themes/psh-docs/layouts/partials/scripts/external.html
+++ b/themes/psh-docs/layouts/partials/scripts/external.html
@@ -9,23 +9,4 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
 <!--
 {{ partial "header/gtm_script" . }} -->
-
-<!-- Heap -->
-<!-- Initialize Heap with a development value -->
-{{ $heapID := "816119933" }}
-<!-- Get Heap ID from environment variable for production-->
-{{ if eq (string site.Params.vendor.config.version) "1"}}
-    {{ with os.Getenv "HUGO_HEAP_ID_PLATFORM" }}
-      {{ $heapID = . }}
-    {{ end }}
-{{ end }}
-{{ if eq (string site.Params.vendor.config.version) "2"}}
-    {{ with os.Getenv "HUGO_HEAP_ID_UPSUN" }}
-      {{ $heapID = . }}
-    {{ end }}
-{{ end }}
-<script type="text/javascript">
-  window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
-  heap.load("{{ $heapID }}");
-</script>
-<!-- End Heap -->
+ 


### PR DESCRIPTION
## Why

Observed that our GTM settings are outdated. This PR:

- Updates the Upsun GTM code
- removes Heap scripting, as it's now bundled into GTM handling

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
