### PR TITLE
quotes workflow name since the name includes a comma

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -5,7 +5,7 @@
 name: Comment on PR
 on:
   workflow_run:
-    workflows: [Get PR URL, dependent jobs]
+    workflows: ["Get PR URL, dependent jobs"]
     types:
       - completed
 


### PR DESCRIPTION
## Why

PR #4244 introduced an issue with PR comments workflow

## What's changed

TL;DR - adds quotes to the name of dependency workflow

The workflow that adds PR comments (comment-on-pr.yaml) is triggered based on the conclusion of the (formerly named) get-pr-info,yaml workflow. Github uses the `name` property of the parent workflow to identify it. I changed that property to `Get PR URL, start dependent jobs` to more accurately reflect what it does, but now the comment workflow sees that as two different workflows. Quoting the workflow `name` corrects the issue.


