### PR TITLE
feat: Updated build deploy docs

### DIFF
--- a/sites/platform/src/learn/overview/build-deploy.md
+++ b/sites/platform/src/learn/overview/build-deploy.md
@@ -64,7 +64,7 @@ but the file system is read-only.
 ### Deploy steps
 
 1. **Hold requests**:
-   Incoming requests are held to prevent service interruption.
+   Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH`, etc.) are held to prevent service interruption.
 1. **Unmount current containers**:
    Any previous containers are disconnected from their file system mounts.
 1. **Mount file systems**:

--- a/sites/upsun/src/learn/overview/build-deploy.md
+++ b/sites/upsun/src/learn/overview/build-deploy.md
@@ -64,7 +64,7 @@ but the file system is read-only.
 ### Deploy steps
 
 1. **Hold requests**:
-   Incoming requests are held to prevent service interruption.
+   Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH` etc.) are held to prevent service interruption.
 1. **Unmount current containers**:
    Any previous containers are disconnected from their file system mounts.
 1. **Mount file systems**:


### PR DESCRIPTION
**Updated build deploy docs**

## Why

Closes #4164 

https://github.com/platformsh/platformsh-docs/issues/4164

## What's changed

Replaced existing hold request sentence with this sentence:  Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH` etc.) are held to prevent service interruption. 

Pages with the intended changes are the build-deploy overviews on Platform.sh and Upsun.

## Where are changes

Updates are for:
[] platform (`sites/platform` templates)
[] upsun (`sites/upsun` templates)
