### PR TITLE
feat: removed 'prevent service information'

### DIFF
--- a/sites/platform/src/learn/overview/build-deploy.md
+++ b/sites/platform/src/learn/overview/build-deploy.md
@@ -64,7 +64,7 @@ but the file system is read-only.
 ### Deploy steps
 
 1. **Hold requests**:
-   Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH`, etc.) are held to prevent service interruption.
+   Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH` etc.) are held.
 1. **Unmount current containers**:
    Any previous containers are disconnected from their file system mounts.
 1. **Mount file systems**:

--- a/sites/upsun/src/learn/overview/build-deploy.md
+++ b/sites/upsun/src/learn/overview/build-deploy.md
@@ -64,7 +64,7 @@ but the file system is read-only.
 ### Deploy steps
 
 1. **Hold requests**:
-   Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH` etc.) are held to prevent service interruption.
+   Incoming [idempotent requests](https://www.iana.org/assignments/http-methods/http-methods.xhtml) (like `GET`, `PUT`, `DELETE` but **not** `POST`, `PATCH` etc.) are held.
 1. **Unmount current containers**:
    Any previous containers are disconnected from their file system mounts.
 1. **Mount file systems**:


### PR DESCRIPTION
**Removed 'prevent service information'**

Closes #4260 

Just removed part of a sentence in the Deploy steps section of the Build-Deploy overview. Now the sentence reads: "Hold requests: Incoming idempotent requests (like `GET`, `PUT, `DELETE` but **not** `POST`, `PATCH` etc.) are held."

## Where are changes
In the build-deploy overview of the Upsun and Platform docs.

Updates are for:
[] platform (`sites/platform` templates)
[] upsun (`sites/upsun` templates)
