### PR TITLE
refactor: improve visibility of TXT affecting apex domain

### DIFF
--- a/sites/platform/src/domains/steps/subdomains.md
+++ b/sites/platform/src/domains/steps/subdomains.md
@@ -19,6 +19,15 @@ You need to add a DNS record to make it clear you explicitly allow multiple proj
 
 ## Enable subdomains across multiple projects
 
+{{< note theme="warning" title="Apex domain cannot be re-added" >}}
+
+With the `TXT` record, restrictions apply on the apex domain.
+For example, you can't add the apex domain to another project until you remove the `TXT` record.
+
+You can see an error like `'{{<variable "YOUR_APEX_DOMAIN" >}}' is a root domain`.
+
+{{< /note >}}
+
 To ensure multiple projects can use subdomains of the same apex domain,
 add a specific `TXT` DNS record for your apex domain.
 
@@ -35,9 +44,6 @@ This ensures no other users can possibly add a subdomain of your domain to their
 
 Even if you don’t remove the record, your DNS records should prevent others from using a subdomain
 as long as you don’t use wildcards records pointing at {{% vendor/name %}}.
-
-However, if you don't remove the `TXT` record, restrictions apply on the apex domain.
-For example, you can't add the apex domain to another project until you remove the `TXT` record.
 
 ## Bypass locked domains
 


### PR DESCRIPTION
## Why

Yesterday I wanted to migrate the apex domain to a new project, from an old project.

I completely forgot about the subdomains protection as this was done years ago.

I struggled yesterday with this, causing annoyance to one of my clients and not being able to re-add the apex domain again to either project. It wasn't until support was able to re-add (which I now know it was because eventually I removed this TXT record even without knowing about this and the DNS spread hit the API server).

## What's changed

This just make it visually more obvious.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
