### PR TITLE
Workflow updates

### DIFF
--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -95,6 +95,10 @@ const verify = async () => {
         return response
       } catch (reqerr) {
         //core.warning(`issue encountered with path ${path}!!! Returned status is ${reqerr.status}`)
+        // core.debug(`issue encountered with path ${path}!!! Returned status is ${reqerr.status}. More info: `)
+        // core.debug(reqerr.toJSON())
+        core.info(`issue encountered with path ${path}!!! Returned status is ${reqerr.status}. More info: `)
+        core.info(reqerr.toJSON())
         let row = [{data: linkify(path, axios.defaults.baseURL)},{data: linkify( anchors[path].to, axios.defaults.baseURL) }]
         tableData.push(row)
       }

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -48,8 +48,13 @@ jobs:
         site: ['platform', 'upsun']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+        with:
+          # we need to checkout the PR repo/branch even if it's a fork because the action in the next step needs to
+          # check the markdown from the PR itself. Plus, we're only running this job if a PR from fork has been approved
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: ./.github/actions/redirection-verification
       - name: Vale
         uses: errata-ai/vale-action@reviewdog
         with:


### PR DESCRIPTION
## Why

Workflow updates to correct false positives, and debug failed states

## What's changed

The lint-prose job is part of a workflow that uses `pull_request_target`. This means that the workflow, for checkouts, will default to using the PR _target_, not the contents from the PR itself. For the first job in the worflow, this is exactly what we want, but for the lint-prose job, we need to evaluate the markdown in the PR. For this job, we'll update the checkout to use the PR sha. 

Occasionally, our redirection verification action will fail, showing all redirects as broken. However, our access logs in the PR environment shows the requests and responses as `200`. This PR adds extra logging to the action in an effort to diagnose what is happening between the action runner and our PR environment. 