### PR TITLE
Fix the workflow fixes

### DIFF
--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -112,11 +112,8 @@ const verify = async () => {
 
     Promise.all(validateRedirects).then(() => {
       if(tableData.length > 1) {
-
         core.error('There was an error with one or more redirects.')
-
         core.summary.addTable(tableData)
-
         core.summary.write()
         core.setFailed('There was an error with one or more contracted redirects.')
       } else  {

--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -100,6 +100,7 @@ const verify = async () => {
           // core.debug(reqerr.toJSON())
           core.info(reqerr.toJSON())
         } else {
+          console.log(reqerr)
           core.info(JSON.stringify(reqerr))
         }
 

--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -100,7 +100,7 @@ const verify = async () => {
           // core.debug(reqerr.toJSON())
           core.info(reqerr.toJSON())
         } else {
-          core.info(reqerr)
+          core.info(JSON.stringify(reqerr))
         }
 
         let row = [{data: linkify(path, axios.defaults.baseURL)},{data: linkify( anchors[path].to, axios.defaults.baseURL) }]

--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -94,11 +94,15 @@ const verify = async () => {
         core.debug(`Response for our check of ${path} is ${response.status}`)
         return response
       } catch (reqerr) {
-        //core.warning(`issue encountered with path ${path}!!! Returned status is ${reqerr.status}`)
         // core.debug(`issue encountered with path ${path}!!! Returned status is ${reqerr.status}. More info: `)
-        // core.debug(reqerr.toJSON())
         core.info(`issue encountered with path ${path}!!! Returned status is ${reqerr.status}. More info: `)
-        core.info(reqerr.toJSON())
+        if(axios.isAxiosError(reqerr)) {
+          // core.debug(reqerr.toJSON())
+          core.info(reqerr.toJSON())
+        } else {
+          core.info(reqerr)
+        }
+
         let row = [{data: linkify(path, axios.defaults.baseURL)},{data: linkify( anchors[path].to, axios.defaults.baseURL) }]
         tableData.push(row)
       }

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -54,7 +54,7 @@ jobs:
           # check the markdown from the PR itself. Plus, we're only running this job if a PR from fork has been approved
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/redirection-verification
+
       - name: Vale
         uses: errata-ai/vale-action@reviewdog
         with:


### PR DESCRIPTION
## Why

Previous workflow update introduce an erroneous call to the redirection action in the lint-prose workflow

Axios docs state an axios error object should be thrown when a request fails. That error object should contain a `toJSON()` method, but in a run of the action, node is reporting it's undefined. Adds a check to make sure the error object is an instance of the axios error before attempting to call the method.

