### PR TITLE
Only run CLI docs generation on this repo.

### DIFF
--- a/.github/workflows/generate-cli-commands-page.yaml
+++ b/.github/workflows/generate-cli-commands-page.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.workflow_dispatch.head.repo.id == 21975579
+    if: github.event.schedule.head.repo.id == 21975579
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-cli-commands-page.yaml
+++ b/.github/workflows/generate-cli-commands-page.yaml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.workflow_dispatch.head.repo.id == 21975579
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-cli-commands-page.yaml
+++ b/.github/workflows/generate-cli-commands-page.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.schedule.head.repo.id == 21975579
+    if: ${{ github.repository_owner == 'platformsh' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

Prevent forks from running this/sending notifications.

Closes https://github.com/platformsh/platformsh-docs/issues/4276

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
