### PR TITLE
refactor of redirection verification

### DIFF
--- a/.github/actions/redirection-verification/action.yaml
+++ b/.github/actions/redirection-verification/action.yaml
@@ -5,9 +5,13 @@ inputs:
     description: 'Pull Request Environment URL'
     required: true
   number_retries:
-    description: 'The number of attempts we should make to contact the target environment URL. 1 second delay between attempt.'
+    description: 'The number of attempts we should make to contact the target environment URL.'
     required: false
     default: '100'
+  retry_sleep:
+    description: 'The length of time (in ms) to pause between each attempt at trying the redirect.'
+    required: false
+    default: '1000'
 
 ####
 #outputs:


### PR DESCRIPTION
## Why

There is something between GitHub and our infrastructure that is dropping/blocking requests to the PR environment when we attempt to verify the contracted redirects. This causes the redirection verification action to fail, even though the redirections are all valid (tested manually). Also, subsequent reruns of the action may pass without issues even though nothing in the code has changed.

## What's changed

* adds `retry_sleep` input to the redirection verification action
* refactors redirection checks action to add a number of retries with a pause delay between each retry attempt of a redirection check

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
