### PR TITLE
feat: changed php extensions grid

### DIFF
--- a/shared/data/php_extensions.yaml
+++ b/shared/data/php_extensions.yaml
@@ -1489,7 +1489,7 @@ grid:
       - redis
       - shmop
       # - snmp
-      # - sodium
+      - sodium
       - sourceguardian
       # - sqlsrv
       # - ssh2


### PR DESCRIPTION
**Adjusted php-extensions yaml file to reflect sodium 8.4 being available now**

## Why

Closes #4313 

## What's changed

Adjusted php-extensions.yaml to reflect that Sodium 8.4 is available as a php extension in the grid on the Php extensions page.

## Where are changes

I changed the php-extensions.yaml but the changes should be seen in the grid here: 

- https://docs.platform.sh/languages/php/extensions.html

- https://docs.upsun.com/languages/php/extensions.html

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
