### PR TITLE
docs: add pdo_firebird from 8.2 to 8.4

### DIFF
--- a/shared/data/php_extensions.yaml
+++ b/shared/data/php_extensions.yaml
@@ -1294,6 +1294,7 @@ grid:
       - openswoole
       - opentelemetry
       - pdo_dblib
+      - pdo_firebird
       - pdo_odbc
       - pdo_pgsql
       - pdo_sqlsrv
@@ -1386,6 +1387,7 @@ grid:
       - openswoole
       - opentelemetry
       - pdo_dblib
+      - pdo_firebird
       - pdo_odbc
       - pdo_pgsql
       - pdo_sqlsrv
@@ -1477,6 +1479,7 @@ grid:
       # - openswoole
       # - opentelemetry
       - pdo_dblib
+      - pdo_firebird
       - pdo_odbc
       - pdo_pgsql
       # - pdo_sqlsrv


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

pdo_firebird php extention has be re-added to php 8.2 8.3 and 8.4

## What's changed

pdo_firebird php extention has be re-added to php 8.2 8.3 and 8.4

## Where are changes

pdo_firebird php extention has be re-added to php 8.2 8.3 and 8.4

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
