### PR TITLE
golang: add note about automatic toolchain switching

### DIFF
--- a/sites/platform/src/languages/go.md
+++ b/sites/platform/src/languages/go.md
@@ -46,6 +46,16 @@ type: 'golang:{{% latest "golang" %}}'
 
 {{< image-versions image="golang" status="deprecated" >}}
 
+## Go toolchain auto download
+
+Even though you select a specific version of Go, starting in Go 1.21, the `go` command will automatically download and use a different toolchain version as requested by the `toolchain` directive in `go.mod`, or the `GOTOOLCHAIN` environmental variable (see [Go Toolchains](https://go.dev/doc/toolchain)).
+
+{{< note >}}
+
+Still, It is important to keep your chosen version of Go updated in your yaml configuration file. This will ensure that you are using the most up to date software for your projects.
+
+{{< /note >}}
+
 ## Go modules
 
 The recommended way to handle Go dependencies on {{% vendor/name %}} is using Go module support in Go 1.11 and later. That allows the build process to use `go build` directly without any extra steps, and you can specify an output executable file of your choice. (See the examples below.)

--- a/sites/platform/src/languages/go.md
+++ b/sites/platform/src/languages/go.md
@@ -52,7 +52,7 @@ Even though you select a specific version of Go, starting in Go 1.21, the `go` c
 
 {{< note >}}
 
-Still, It is important to keep your chosen version of Go updated in your yaml configuration file. This will ensure that you are using the most up to date software for your projects.
+Still, it is important to keep your chosen version of Go updated in your yaml configuration file. This will ensure that you are using the most up to date software for your projects.
 
 {{< /note >}}
 

--- a/sites/upsun/src/languages/go.md
+++ b/sites/upsun/src/languages/go.md
@@ -44,7 +44,7 @@ Even though you select a specific version of Go, starting in Go 1.21, the `go` c
 
 {{< note >}}
 
-Still, It is important to keep your chosen version of Go updated in your yaml configuration file. This will ensure that you are using the most up to date software for your projects.
+Still, it is important to keep your chosen version of Go updated in your yaml configuration file. This will ensure that you are using the most up to date software for your projects.
 
 {{< /note >}}
 

--- a/sites/upsun/src/languages/go.md
+++ b/sites/upsun/src/languages/go.md
@@ -38,6 +38,17 @@ applications:
 
 {{< image-versions image="golang" status="deprecated" >}}
 
+## Go toolchain auto download
+
+Even though you select a specific version of Go, starting in Go 1.21, the `go` command will automatically download and use a different toolchain version as requested by the `toolchain` directive in `go.mod`, or the `GOTOOLCHAIN` environmental variable (see [Go Toolchains](https://go.dev/doc/toolchain)).
+
+{{< note >}}
+
+Still, It is important to keep your chosen version of Go updated in your yaml configuration file. This will ensure that you are using the most up to date software for your projects.
+
+{{< /note >}}
+
+
 ## Go modules
 
 The recommended way to handle Go dependencies on {{% vendor/name %}} is using Go module support in Go 1.11 and later. That allows the build process to use `go build` directly without any extra steps, and you can specify an output executable file of your choice. (See the examples below.)


### PR DESCRIPTION
## Why

Because in golang, there is a loose coupling between the version specified by the user, and the version that can be used. Essentially it will download any toolchain version automatically.

But users should still be encouraged to keep the selected version updated, in order to have more up to date software. 

See also internal ticket: https://linear.app/platformsh/issue/IMG-1785

## What's changed

Added a section in both psh and upsun golang docs about this.

What I'm not sure about is how to word the suggestion to keep the golang version in the yaml configuration files up to date.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)

