### PR TITLE
adjusts resources to allocate more ram to search

### DIFF
--- a/search/.platform.app.yaml
+++ b/search/.platform.app.yaml
@@ -52,3 +52,7 @@ mounts:
     "dumps":
         source: local
         source_path: "dumps"
+
+resources:
+  base_memory: 1024
+  memory_ratio: 1024


### PR DESCRIPTION
## Why
Meilisearch is running out of memory in the search container when trying to build the search indices. This adds a `resource` property to allocate a bit more memory to the container. 

## What's changed

```
resources:
  base_memory: 1024
  memory_ratio: 1024
```

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
- [X] search
