### PR TITLE
chore: uv extension is available on PHP 8.3 grid

### DIFF
--- a/shared/data/php_extensions.yaml
+++ b/shared/data/php_extensions.yaml
@@ -1407,6 +1407,7 @@ grid:
       - sybase
       - tidy
       - uuid
+      - uv
       - xdebug
       - xmlrpc
       - xsl


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes IMG-1776 ([Linear](https://linear.app/platformsh/issue/IMG-1776/ensure-extensions-are-publicly-documented))

Ensure UV extension is publicly documented as available on the PHP 8.3 Grid image.

## What's changed

The UV extension is now available on Grid PHP 8.3.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
