### PR TITLE
feat: pushing template changes

### DIFF
--- a/shared/data/templates.yaml
+++ b/shared/data/templates.yaml
@@ -419,6 +419,34 @@ php:
       Automatic TLS certificates<br />
       Composer-based build<br />
     runtime: php
+  - shortname: drupal11
+    name: Drupal 11
+    repo: https://github.com/platformsh-templates/drupal11
+    description: >
+      <p>This template builds Drupal 11 using the "Drupal Recommended" Composer
+      project.  It is pre-configured to use MariaDB and Redis for caching.  The
+      Drupal installer will skip asking for database credentials as they are
+      already provided.</p>
+
+      <p>Drupal is a flexible and extensible PHP-based CMS framework.</p>
+    image: >-
+      data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'
+      width='186.52541' height='243.71308' viewBox='0 0 186.52541
+      243.71308'%3E%3Ctitle%3ERisorsa 85%3C/title%3E%3Cg id='Livello_2'
+      data-name='Livello 2'%3E%3Cg id='Livello_1-2' data-name='Livello
+      1'%3E%3Cpath
+      d='M131.64024,51.90954C114.49124,34.76866,98.12945,18.42858,93.26,0,88.39024,18.42858,72.02583,34.76866,54.8797,51.90954,29.16037,77.61263,0,106.7432,0,150.434a93.26271,93.26271,0,1,0,186.52541,0c0-43.688-29.158-72.8214-54.88517-98.52449M39.63956,172.16578c-5.71847-.19418-26.82308-36.57089,12.32937-75.303l25.90873,28.30088a2.21467,2.21467,0,0,1-.173,3.30485c-6.18245,6.34085-32.53369,32.7658-35.809,41.90292-.676,1.886-1.66339,1.81463-2.25619,1.79436M93.26283,220.1092a32.07521,32.07521,0,0,1-32.07544-32.07543A33.42322,33.42322,0,0,1,69.1821,166.8471c5.7836-7.07224,24.07643-26.96358,24.07643-26.96358s18.01279,20.18332,24.03326,26.89607a31.36794,31.36794,0,0,1,8.04647,21.25418A32.07551,32.07551,0,0,1,93.26283,220.1092m61.3923-52.015c-.69131,1.51192-2.25954,4.036-4.37617,4.113-3.77288.13741-4.176-1.79579-6.96465-5.92291-6.12235-9.06007-59.55167-64.89991-69.54517-75.69925-8.79026-9.49851-1.23783-16.195,2.26549-19.70431C80.42989,66.47768,93.25949,53.656,93.25949,53.656s38.25479,36.29607,54.19029,61.09626,10.44364,46.26024,7.20535,53.342'
+      style='fill:%23009cde'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E
+    deploy: >-
+      https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/drupal11/.platform.template.yaml
+    content: |
+      PHP 8.3<br />
+      MariaDB 10.6<br />
+      Redis 7.2<br />
+      Drush included<br />
+      Automatic TLS certificates<br />
+      Composer-based build<br />
+    runtime: php
   - shortname: drupal9-govcms9
     name: GovCMS 9
     repo: https://github.com/platformsh-templates/drupal9-govcms9

--- a/sites/platform/.yaml
+++ b/sites/platform/.yaml
@@ -782,6 +782,7 @@ rabbitmq:
       - '3.6'
       - '3.5'
     supported:
+      - '4.0'
       - '3.13'
       - '3.12'
     legacy:

--- a/sites/platform/src/guides/django/deploy/configure.md
+++ b/sites/platform/src/guides/django/deploy/configure.md
@@ -388,6 +388,41 @@ db:
   disk: 1024
 ```
 
-{{% guides/config-routes template="django4" name="Django" %}}
+## Define routes
+
+All HTTP requests sent to your app are controlled through the routing and caching you define in a `.platform/routes.yaml` file.
+
+The two most important options are the main route and its caching rules.
+A route can have a placeholder of `{default}`,
+which is replaced by your domain name in production and environment-specific names for your preview environments.
+The main route has an `upstream`, which is the name of the app container to forward requests to.
+
+You can enable [HTTP cache](/define-routes/cache.md).
+The router includes a basic HTTP cache.
+By default, HTTP caches includes all cookies in the cache key.
+So any cookies that you have bust the cache.
+The `cookies` key allows you to select which cookies should matter for the cache.
+
+You can also set up routes as [HTTP redirects](define-routes/redirects.md).
+In the following example, all requests to `www.{default}` are redirected to the equivalent URL without `www`.
+HTTP requests are automatically redirected to HTTPS.
+
+If you don't include a `.platform/routes.yaml` file, a single default route is used. This is equivalent to the following:
+
+```yaml {configFile="routes"}
+https://{default}/:
+  type: upstream
+  upstream: <APP_NAME>:http
+```
+
+Where `<APP_NAME>` is the `name` you've defined in your [app configuration](#configure-apps-in-platformappyaml).
+
+The following example presents a complete definition of a main route for a Django app:
+
+```yaml {configFile="routes"}
+"https://www.{default}/":
+  type: redirect
+  to: "https://{default}/"
+```
 
 {{< guide-buttons previous="Back" next="Customize Django" >}}

--- a/sites/platform/static/files/fetch/examples/relationships/elasticsearch
+++ b/sites/platform/static/files/fetch/examples/relationships/elasticsearch
@@ -1,18 +1,22 @@
 {
     "username": null,
-    "scheme": "http",
-    "service": "elasticsearch77",
     "fragment": null,
     "ip": "169.254.169.232",
-    "hostname": "jmgjydr275pkj5v7prdj2asgxm.elasticsearch77.service._.eu-3.platformsh.site",
-    "port": 9200,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "elasticsearch.internal",
-    "rel": "elasticsearch",
     "path": null,
     "query": [],
     "password": null,
+    "port": 9200,
+    "host_mapped": false,
+    "service": "elasticsearch77",
+    "hostname": "jmgjydr275pkj5v7prdj2asgxm.elasticsearch77.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "247.229.144.158"
+    ],
+    "rel": "elasticsearch",
+    "scheme": "http",
     "type": "elasticsearch:7.7",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/headlesschrome
+++ b/sites/platform/static/files/fetch/examples/relationships/headlesschrome
@@ -2,8 +2,11 @@
     "service": "headlesschrome",
     "ip": "169.254.91.5",
     "hostname": "gvbo7vktgmou2mplnzt4b54hgi.headlesschrome.service._.eu-3.platformsh.site",
-    "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "headlesschrome.internal",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "instance_ips": [
+        "247.10.176.5"
+    ],
     "rel": "http",
     "scheme": "http",
     "type": "chrome-headless:73",

--- a/sites/platform/static/files/fetch/examples/relationships/influxdb
+++ b/sites/platform/static/files/fetch/examples/relationships/influxdb
@@ -2,8 +2,11 @@
     "service": "influxdb18",
     "ip": "169.254.244.110",
     "hostname": "duqbjfn7t4dwr2fi2o7bsvqafy.influxdb18.service._.eu-3.platformsh.site",
-    "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "influxdb.internal",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "instance_ips": [
+        "247.142.80.141"
+    ],
     "rel": "influxdb",
     "scheme": "http",
     "type": "influxdb:1.8",

--- a/sites/platform/static/files/fetch/examples/relationships/kafka
+++ b/sites/platform/static/files/fetch/examples/relationships/kafka
@@ -2,8 +2,11 @@
     "service": "kafka25",
     "ip": "169.254.27.10",
     "hostname": "t7lv3t3ttyh3vyrzgqguj5upwy.kafka25.service._.eu-3.platformsh.site",
-    "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "kafka.internal",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "instance_ips": [
+        "247.229.144.8"
+    ],
     "rel": "kafka",
     "scheme": "kafka",
     "type": "kafka:2.5",

--- a/sites/platform/static/files/fetch/examples/relationships/memcached
+++ b/sites/platform/static/files/fetch/examples/relationships/memcached
@@ -2,8 +2,11 @@
     "service": "memcached16",
     "ip": "169.254.228.111",
     "hostname": "3sdm72jgaxge2b6aunxdlzxyea.memcached16.service._.eu-3.platformsh.site",
-    "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "memcached.internal",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "instance_ips": [
+        "247.142.80.7"
+    ],
     "rel": "memcached",
     "scheme": "memcached",
     "type": "memcached:1.6",

--- a/sites/platform/static/files/fetch/examples/relationships/mongodb
+++ b/sites/platform/static/files/fetch/examples/relationships/mongodb
@@ -4,8 +4,11 @@
     "service": "mongodb36",
     "ip": "169.254.150.147",
     "hostname": "blbczy5frqpkt2sfkj2w3zk72q.mongodb36.service._.eu-3.platformsh.site",
-    "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "mongodb.internal",
+    "cluster": "rjify4yjcwxaa-master-7rqtwti",
+    "instance_ips": [
+        "246.207.64.200"
+    ],
     "rel": "mongodb",
     "query": {
         "is_master": true

--- a/sites/platform/static/files/fetch/examples/relationships/mysql
+++ b/sites/platform/static/files/fetch/examples/relationships/mysql
@@ -1,20 +1,24 @@
 {
     "username": "user",
-    "scheme": "mysql",
-    "service": "mariadb104",
     "fragment": null,
     "ip": "169.254.255.221",
-    "hostname": "e3wffyxtwnrxujeyg5u3kvqi6y.mariadb104.service._.eu-3.platformsh.site",
-    "port": 3306,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "mysql.internal",
-    "rel": "mysql",
     "path": "main",
     "query": {
         "is_master": true
     },
     "password": "",
+    "port": 3306,
+    "host_mapped": false,
+    "service": "mariadb104",
+    "hostname": "e3wffyxtwnrxujeyg5u3kvqi6y.mariadb104.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "246.85.48.128"
+    ],
+    "rel": "mysql",
+    "scheme": "mysql",
     "type": "mariadb:10.4",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/opensearch
+++ b/sites/platform/static/files/fetch/examples/relationships/opensearch
@@ -1,18 +1,22 @@
 {
     "username": null,
-    "scheme": "http",
-    "service": "opensearch12",
     "fragment": null,
     "ip": "169.254.99.100",
-    "hostname": "2e36wpnescmc5ffcddczsnhnai.opensearch12.service._.eu-3.platformsh.site",
-    "port": 9200,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "opensearch.internal",
-    "rel": "opensearch",
     "path": null,
     "query": [],
     "password": null,
+    "port": 9200,
+    "host_mapped": false,
+    "service": "opensearch12",
+    "hostname": "2e36wpnescmc5ffcddczsnhnai.opensearch12.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "246.207.64.37"
+    ],
+    "rel": "opensearch",
+    "scheme": "http",
     "type": "opensearch:1.2",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/oraclemysql
+++ b/sites/platform/static/files/fetch/examples/relationships/oraclemysql
@@ -1,20 +1,24 @@
 {
     "username": "user",
-    "scheme": "mysql",
-    "service": "oraclemysql",
     "fragment": null,
     "ip": "169.254.150.190",
-    "hostname": "7q5hllmmhoeuthu6th7qovoone.oraclemysql.service._.eu-3.platformsh.site",
-    "port": 3306,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "oraclemysql.internal",
-    "rel": "mysql",
     "path": "main",
     "query": {
         "is_master": true
     },
     "password": "",
+    "port": 3306,
+    "host_mapped": false,
+    "service": "oraclemysql",
+    "hostname": "7q5hllmmhoeuthu6th7qovoone.oraclemysql.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "246.180.32.9"
+    ],
+    "rel": "mysql",
+    "scheme": "mysql",
     "type": "oracle-mysql:8.0",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/postgresql
+++ b/sites/platform/static/files/fetch/examples/relationships/postgresql
@@ -1,20 +1,24 @@
 {
     "username": "main",
-    "scheme": "pgsql",
-    "service": "postgresql12",
     "fragment": null,
     "ip": "169.254.38.66",
-    "hostname": "zydalrxgkhif2czr3xqth3qkue.postgresql12.service._.eu-3.platformsh.site",
-    "port": 5432,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "postgresql.internal",
-    "rel": "postgresql",
     "path": "main",
     "query": {
         "is_master": true
     },
     "password": "main",
+    "port": 5432,
+    "host_mapped": false,
+    "service": "postgresql12",
+    "hostname": "zydalrxgkhif2czr3xqth3qkue.postgresql12.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "247.229.144.9"
+    ],
+    "rel": "postgresql",
+    "scheme": "pgsql",
     "type": "postgresql:12",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/rabbitmq
+++ b/sites/platform/static/files/fetch/examples/relationships/rabbitmq
@@ -1,18 +1,22 @@
 {
     "username": "guest",
-    "scheme": "amqp",
-    "service": "rabbitmq39",
     "fragment": null,
     "ip": "169.254.220.199",
-    "hostname": "453lqa3dz2ekflsrm7whfdhbiq.rabbitmq39.service._.eu-3.platformsh.site",
-    "port": 5672,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "rabbitmq.internal",
-    "rel": "rabbitmq",
     "path": null,
     "query": [],
     "password": "guest",
+    "port": 5672,
+    "host_mapped": false,
+    "service": "rabbitmq39",
+    "hostname": "453lqa3dz2ekflsrm7whfdhbiq.rabbitmq39.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "247.229.144.230"
+    ],
+    "rel": "rabbitmq",
+    "scheme": "amqp",
     "type": "rabbitmq:3.9",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/redis
+++ b/sites/platform/static/files/fetch/examples/relationships/redis
@@ -1,18 +1,22 @@
 {
     "username": null,
-    "scheme": "redis",
-    "service": "redis6",
     "fragment": null,
     "ip": "169.254.22.75",
-    "hostname": "7mnenhdiz7ecraovljrba6pmiy.redis6.service._.eu-3.platformsh.site",
-    "port": 6379,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "redis.internal",
-    "rel": "redis",
     "path": null,
     "query": [],
     "password": null,
+    "port": 6379,
+    "host_mapped": false,
+    "service": "redis6",
+    "hostname": "7mnenhdiz7ecraovljrba6pmiy.redis6.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "247.229.144.209"
+    ],
+    "rel": "redis",
+    "scheme": "redis",
     "type": "redis:6.0",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/solr
+++ b/sites/platform/static/files/fetch/examples/relationships/solr
@@ -1,18 +1,22 @@
 {
     "username": null,
-    "scheme": "solr",
-    "service": "solr86",
     "fragment": null,
     "ip": "169.254.68.119",
-    "hostname": "csjsvtdhmjrdre2uaoeim22xjy.solr86.service._.eu-3.platformsh.site",
-    "port": 8080,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "solr.internal",
-    "rel": "solr",
     "path": "solr\/maincore",
     "query": [],
     "password": null,
+    "port": 8080,
+    "host_mapped": false,
+    "service": "solr86",
+    "hostname": "csjsvtdhmjrdre2uaoeim22xjy.solr86.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "246.180.32.10"
+    ],
+    "rel": "solr",
+    "scheme": "solr",
     "type": "solr:8.6",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }

--- a/sites/platform/static/files/fetch/examples/relationships/vault-kms
+++ b/sites/platform/static/files/fetch/examples/relationships/vault-kms
@@ -1,20 +1,24 @@
 {
     "username": "",
-    "scheme": "http",
-    "service": "vault-kms",
     "fragment": "",
     "ip": "169.254.196.95",
-    "hostname": "ckmpv2fz7jtdmpkmrun7yfgut4.vault-kms.service._.eu-3.platformsh.site",
-    "port": 8200,
     "cluster": "rjify4yjcwxaa-master-7rqtwti",
     "host": "vault-kms.internal",
-    "rel": "sign",
     "path": "\/",
     "query": {
         "is_master": true
     },
-    "password": "b.AAAAAQKY7LuvSZLHlkVOunFGip34HDGbXdOwcSzUK3Mkmdpp5TbGkw2KRaBGyuQRfvaI8h3jXG5iBYP3HcZMpk01uz72C3YTqdszglYXZlOtC0e3QU__T58dVEreodrVWGATYA4IxvIpSGaXvArC1hmA-c0CORPf-dsQQeswfO4sZayuC2WpLmUNXC7G9TKsOKuNxlS3l1byI5CQzuO7OEpD-rCjHvnewmFNDfmWGQ",
+    "password": "b.AAAAAQIm98Ptsj51HNBsgo4QUSJPFPdhAHCIML0ayQZOZsfRKLsXgh1gw4Tc5RbLjpJPKHdMtOObh-G1eNQwrgCei_wHPLciC7S-fxHRzv3t1ZqrxbnKIueuQPwE3-ur-wSrEmz3u08RfqKGAi0deP-LDwEt06j1qqJVwmHyMXTZYp5zOOB8B2nF129bbvX_Aom3Tqt_wI0x1uXW1yU4rdDdFc4SAuIcPfb_6rG08g",
+    "port": 8200,
+    "host_mapped": false,
+    "service": "vault-kms",
+    "hostname": "ckmpv2fz7jtdmpkmrun7yfgut4.vault-kms.service._.eu-3.platformsh.site",
+    "epoch": 0,
+    "instance_ips": [
+        "246.180.32.8"
+    ],
+    "rel": "sign",
+    "scheme": "http",
     "type": "vault-kms:1.6",
-    "public": false,
-    "host_mapped": false
+    "public": false
 }


### PR DESCRIPTION
Templates.yaml for all frameworks have been fixed (not by me!) so routes yaml snippets should be working now. I didn't realise that the templates.yaml had been fixed already so I went in and hard coded the Django routes.yaml section. I only realised that the others were working when I ran it all locally. 

So right now, just Django is hard coded. I thought it'd be better to leave it hard coded so we can go ahead and hard code the rest in future if we need to.

## Why

Closes #4342 

## What's changed

All framework templates and the define routes section (bottom of page) on the Django page. 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
