### PR TITLE
feat: added rabbit 4.0 to dedicated docs

### DIFF
--- a/sites/platform/src/dedicated-environments/dedicated-gen-3/overview.md
+++ b/sites/platform/src/dedicated-environments/dedicated-gen-3/overview.md
@@ -80,7 +80,7 @@ Your app can connect to each service by referencing the exact same [environment
 | **Network Storage** | 2 |
 | **OpenSearch** | 2 |
 | **PostgreSQL** | 16, 15, 14, 13, 12 |
-| **RabbitMQ** | 3.13, 3.12 |
+| **RabbitMQ** | 3.13, 3.12, 4.0 |
 | **Redis** | 7.2, 7.0, 6.2 |
 | **Solr** | 9.6, 9.4, 9.2, 9.1, 8.11 |
 | **Vault KMS** | 1.12 |


### PR DESCRIPTION
Added rabbit 4.0 to available services in DG3 overview page

## Why

Closes #4343

## What's changed

Just added rabbitmq 4.0 to the little array in the available services section in the dg3 overview page.

## Where are changes

DG3 overview page.

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
