### PR TITLE
adds missing gotenberg service to container profiles reference

### DIFF
--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -336,37 +336,38 @@ There are three container profiles available: ``HIGH_CPU``, ``BALANCED``, and ``
 
 The following table shows which container profiles {{% vendor/name %}} applies when deploying your project.
 
-| Container               | Profile          |
-|-------------------------|------------------|
-| Chrome Headless         | HIGH_CPU         |
-| .NET                    | HIGH_CPU         |
-| Elasticsearch           | HIGH_MEMORY      |
-| Elasticsearch Premium   | HIGH_MEMORY      |
-| Elixir                  | HIGH_CPU         |
-| Go                      | HIGH_CPU         |
-| InfluxDB                | HIGH_MEMORY      |
-| Java                    | HIGH_MEMORY      |
-| Kafka                   | HIGH_MEMORY      |
-| Lisp                    | HIGH_CPU         |
-| MariaDB                 | HIGH_MEMORY      |
-| Memcached               | BALANCED         |
-| MongoDB                 | HIGH_MEMORY      |
-| MongoDB Premium         | HIGH_MEMORY      |
-| Network Storage         | HIGH_MEMORY      |
-| Node.js                 | HIGH_CPU         |
-| OpenSearch              | HIGH_MEMORY      |
-| Oracle MySQL            | HIGH_MEMORY      |
-| PHP                     | HIGH_CPU         |
-| PostgreSQL              | HIGH_MEMORY      |
-| Python                  | HIGH_CPU         |
-| RabbitMQ                | HIGH_MEMORY      |
-| Redis ephemeral         | BALANCED         |
-| Redis persistent        | BALANCED         |
-| Ruby                    | HIGH_CPU         |
-| Rust                    | HIGH_CPU         |
-| Solr                    | HIGH_MEMORY      |
-| Varnish                 | HIGH_MEMORY      |
-| Vault KMS               | HIGH_MEMORY      |
+| Container               | Profile       |
+|-------------------------|---------------|
+| Chrome Headless         | HIGH_CPU      |
+| .NET                    | HIGH_CPU      |
+| Elasticsearch           | HIGH_MEMORY   |
+| Elasticsearch Premium   | HIGH_MEMORY   |
+| Elixir                  | HIGH_CPU      |
+| Go                      | HIGH_CPU      |
+| Gotenberg               | HIGH_MEMORY   |
+| InfluxDB                | HIGH_MEMORY   |
+| Java                    | HIGH_MEMORY   |
+| Kafka                   | HIGH_MEMORY   |
+| Lisp                    | HIGH_CPU      |
+| MariaDB                 | HIGH_MEMORY   |
+| Memcached               | BALANCED      |
+| MongoDB                 | HIGH_MEMORY   |
+| MongoDB Premium         | HIGH_MEMORY   |
+| Network Storage         | HIGH_MEMORY   |
+| Node.js                 | HIGH_CPU      |
+| OpenSearch              | HIGH_MEMORY   |
+| Oracle MySQL            | HIGH_MEMORY   |
+| PHP                     | HIGH_CPU      |
+| PostgreSQL              | HIGH_MEMORY   |
+| Python                  | HIGH_CPU      |
+| RabbitMQ                | HIGH_MEMORY   |
+| Redis ephemeral         | BALANCED      |
+| Redis persistent        | BALANCED      |
+| Ruby                    | HIGH_CPU      |
+| Rust                    | HIGH_CPU      |
+| Solr                    | HIGH_MEMORY   |
+| Varnish                 | HIGH_MEMORY   |
+| Vault KMS               | HIGH_MEMORY   |
 
 ### Sizes in preview environments
 

--- a/sites/platform/src/create-apps/app-reference/single-runtime-image.md
+++ b/sites/platform/src/create-apps/app-reference/single-runtime-image.md
@@ -155,37 +155,38 @@ There are three container profiles available: ``HIGH_CPU``, ``BALANCED``, and ``
 
 The following table shows which container profiles {{% vendor/name %}} applies when deploying your project.
 
-| Container               | Profile          |
-|-------------------------|------------------|
-| Chrome Headless         | HIGH_CPU         |
-| .NET                    | HIGH_CPU         |
-| Elasticsearch           | HIGH_MEMORY      |
-| Elasticsearch Premium   | HIGH_MEMORY      |
-| Elixir                  | HIGH_CPU         |
-| Go                      | HIGH_CPU         |
-| InfluxDB                | HIGH_MEMORY      |
-| Java                    | HIGH_MEMORY      |
-| Kafka                   | HIGH_MEMORY      |
-| Lisp                    | HIGH_CPU         |
-| MariaDB                 | HIGH_MEMORY      |
-| Memcached               | BALANCED         |
-| MongoDB                 | HIGH_MEMORY      |
-| MongoDB Premium         | HIGH_MEMORY      |
-| Network Storage         | HIGH_MEMORY      |
-| Node.js                 | HIGH_CPU         |
-| OpenSearch              | HIGH_MEMORY      |
-| Oracle MySQL            | HIGH_MEMORY      |
-| PHP                     | HIGH_CPU         |
-| PostgreSQL              | HIGH_MEMORY      |
-| Python                  | HIGH_CPU         |
-| RabbitMQ                | HIGH_MEMORY      |
-| Redis ephemeral         | BALANCED         |
-| Redis persistent        | BALANCED         |
-| Ruby                    | HIGH_CPU         |
-| Rust                    | HIGH_CPU         |
-| Solr                    | HIGH_MEMORY      |
-| Varnish                 | HIGH_MEMORY      |
-| Vault KMS               | HIGH_MEMORY      |
+| Container             | Profile     |
+|-----------------------|-------------|
+| Chrome Headless       | HIGH_CPU    |
+| .NET                  | HIGH_CPU    |
+| Elasticsearch         | HIGH_MEMORY |
+| Elasticsearch Premium | HIGH_MEMORY |
+| Elixir                | HIGH_CPU    |
+| Go                    | HIGH_CPU    |
+| Gotenberg             | HIGH_MEMORY |
+| InfluxDB              | HIGH_MEMORY |
+| Java                  | HIGH_MEMORY |
+| Kafka                 | HIGH_MEMORY |
+| Lisp                  | HIGH_CPU    |
+| MariaDB               | HIGH_MEMORY |
+| Memcached             | BALANCED    |
+| MongoDB               | HIGH_MEMORY |
+| MongoDB Premium       | HIGH_MEMORY |
+| Network Storage       | HIGH_MEMORY |
+| Node.js               | HIGH_CPU    |
+| OpenSearch            | HIGH_MEMORY |
+| Oracle MySQL          | HIGH_MEMORY |
+| PHP                   | HIGH_CPU    |
+| PostgreSQL            | HIGH_MEMORY |
+| Python                | HIGH_CPU    |
+| RabbitMQ              | HIGH_MEMORY |
+| Redis ephemeral       | BALANCED    |
+| Redis persistent      | BALANCED    |
+| Ruby                  | HIGH_CPU    |
+| Rust                  | HIGH_CPU    |
+| Solr                  | HIGH_MEMORY |
+| Varnish               | HIGH_MEMORY |
+| Vault KMS             | HIGH_MEMORY |
 
 ### Sizes in preview environments
 


### PR DESCRIPTION
## Why

Closes #4357 

## What's changed
Adds Goteberg and its container profile to the container profile tables in the app-reference sections. 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
