### PR TITLE
corrects workflow name that comment workflow is dependent on

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -5,7 +5,7 @@
 name: Comment on PR
 on:
   workflow_run:
-    workflows: ["Get PR URL, dependent jobs"]
+    workflows: ["Get PR URL, start dependent jobs"]
     types:
       - completed
 


### PR DESCRIPTION
## Why

PR comment workflow was broken

## What's changed

The name of the workflow the comments workflow depends on changed.

## Where are changes

