### PR TITLE
Accessibility: Fix aria labels on section buttons

### DIFF
--- a/themes/psh-docs/layouts/partials/sidebar/expand-button.html
+++ b/themes/psh-docs/layouts/partials/sidebar/expand-button.html
@@ -1,3 +1,3 @@
-<button class="py-2" id="nav-expand-{{ .itemID }}" aria-controls="{{ .itemID }}" aria-expanded="{{ .isCurrentSection }}" aria-label="Toggle section">
+<button class="py-2" id="nav-expand-{{ .itemID }}" aria-controls="{{ .itemID }}" aria-expanded="{{ .isCurrentSection }}" aria-label="{{ .itemTitle }}">
   <svg :class="{{ .expandLevel }} ? '' : '-rotate-90'" @click="{{ .expandLevel }} = ! {{ .expandLevel }}" width="24" height="24" viewBox="0 0 24 24" fill="current" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">{{ readFile "layouts/shortcodes/icon-paths/expand.html" | safeHTML }}</svg>
 </button>

--- a/themes/psh-docs/layouts/partials/sidebar/list.html
+++ b/themes/psh-docs/layouts/partials/sidebar/list.html
@@ -28,7 +28,7 @@
     {{ range .Context.Pages }}
       <div class="pl-8 py-2 pr-2 flex items-center justify-between min-h-[2.5rem]">
         <h4 class="pr-2 font-semibold text-sm">
-          <a href="{{ .RelPermalink }}" class="hover:text-skye-dark focus:text-skye-dark{{ if $isCurrentSection }} text-skye-dark{{ end }}">
+          <a href="{{ .RelPermalink }}" class="hover:text-skye-dark focus:text-skye-dark{{ if $isCurrentSection }} text-skye-dark{{ end }}" {{ if $isCurrentSection }} aria-current="true" {{ end }}>
             {{ .Title }}
           </a>
         </h4>
@@ -60,7 +60,7 @@
 
     <!-- Add button for expanding if has children-->
     {{ if and ( eq .Context.Kind "section" ) ( gt ( len .Context.Pages ) 0  ) }}
-      {{ partial "sidebar/expand-button" (dict "itemID" $sectionId "isCurrentSection" $isCurrentSection "expandLevel" "topExpanded" )}}
+      {{ partial "sidebar/expand-button" (dict "itemID" $sectionId "itemTitle" $itemTitle "isCurrentSection" $isCurrentSection "expandLevel" "topExpanded" )}}
     {{ end }}
   </div>
   <ul x-show="topExpanded" class="pl-12" aria-labelledby="nav-expand-{{ $sectionId }}" id="{{ $sectionId }}">
@@ -101,7 +101,7 @@
           {{ if eq .Kind "section"}}
 
             <!-- Add button for expanding -->
-            {{ partial "sidebar/expand-button" (dict "itemID" $itemId "isCurrentSection" $isCurrentSection "expandLevel" "secondExpanded")}}
+            {{ partial "sidebar/expand-button" (dict "itemID" $itemId "itemTitle" $itemTitle "isCurrentSection" $isCurrentSection "expandLevel" "secondExpanded")}}
         </div>
             <ul x-show="secondExpanded" class="pl-4 py-2" aria-labelledby="nav-expand-{{ $itemId }}" id="{{ $itemId }}">
 

--- a/themes/psh-docs/layouts/partials/sidebar/nav.html
+++ b/themes/psh-docs/layouts/partials/sidebar/nav.html
@@ -31,7 +31,7 @@
   {{ end }}
   <div x-data="{ expanded: {{ $inCurrentSection }} }">
     <h3 class="font-semibold">
-      <button class="bg-no-repeat bg-right-2 w-[95%] py-4 pl-2 pr-6 my-2 text-left bg-grey" :style="expanded ? 'background-image: url(/images/icons/minus.svg);' : 'background-image: url(/images/icons/add.svg);'" @click="expanded = ! expanded" aria-controls="section-{{ .section }}" aria-expanded="{{ $inCurrentSection }}" aria-label="Toggle section">
+      <button class="bg-no-repeat bg-right-2 w-[95%] py-4 pl-2 pr-6 my-2 text-left bg-grey" :style="expanded ? 'background-image: url(/images/icons/minus.svg);' : 'background-image: url(/images/icons/add.svg);'" @click="expanded = ! expanded" aria-controls="section-{{ .section }}" aria-expanded="{{ $inCurrentSection }}">
         {{ .title }}
       </button>
     </h3>
@@ -47,7 +47,7 @@
 
       <div x-data="{ expanded: false }">
         <h3 class="font-semibold">
-          <button class="bg-no-repeat bg-right-2 w-[95%] py-4 pl-2 pr-6 my-2 text-left bg-grey" :style="expanded ? 'background-image: url(/images/icons/minus.svg);' : 'background-image: url(/images/icons/external_link.svg);'" @click="location.href = '{{ .link }}'" aria-expanded="false" aria-label="Toggle section">
+          <button class="bg-no-repeat bg-right-2 w-[95%] py-4 pl-2 pr-6 my-2 text-left bg-grey" :style="expanded ? 'background-image: url(/images/icons/minus.svg);' : 'background-image: url(/images/icons/external_link.svg);'" @click="location.href = '{{ .link }}'" aria-expanded="false">
             {{ .title }}
           </button>
         </h3>


### PR DESCRIPTION
## Why

In current platform.sh docs, there are quite a number of accessibility errors. Most of them are just annoying, but there was one thing that prevented really from using the docs with a screen reader correctly.
Each section has a button to expand it, and this button has an `aria-label` of "Toggle section". So imagine if each button had the same text: "Toggle section". that's how I see it on the currently released pages.

## What's changed

If a button contains an SVG image (correctly hidden with `aria-hidden="true"` btw), then the `aria-label` is changed to have the title of the section in question. If however the section title was the text of the button itself (simplified code: `<button>{{ .Title }}</button>`), then the `aria-label` was removed as it is not needed anymore: the text between the `button` tags is read by all screen readers.

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
