### PR TITLE
adds example config files in statically since the dynamic retrieval was disabled in previous PR

### DIFF
--- a/sites/platform/static/files/fetch/.gitignore
+++ b/sites/platform/static/files/fetch/.gitignore
@@ -2,6 +2,6 @@ config-examples
 config-examples-platform
 gatsby/*
 lando
-multiappyaml
-routesyaml
-servicesyaml
+# multiappyaml
+# routesyaml
+# servicesyaml

--- a/sites/platform/static/files/fetch/.gitignore
+++ b/sites/platform/static/files/fetch/.gitignore
@@ -1,4 +1,3 @@
-appyaml
 config-examples
 config-examples-platform
 gatsby

--- a/sites/platform/static/files/fetch/.gitignore
+++ b/sites/platform/static/files/fetch/.gitignore
@@ -1,6 +1,6 @@
 config-examples
 config-examples-platform
-gatsby
+gatsby/*
 lando
 multiappyaml
 routesyaml

--- a/sites/platform/static/files/fetch/appyaml/akeneo
+++ b/sites/platform/static/files/fetch/appyaml/akeneo
@@ -1,0 +1,186 @@
+# This file describes an application.
+
+# The name of this app. Must be unique within a project.
+name: akeneo
+
+# The language and version to use to run the application.
+type: php:8.0
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+# Enable non-default extensions required by Akeneo
+runtime:
+    extensions:
+        - apcu
+        - imagick
+        - memcached
+        - intl
+        # - amqp
+        - redis
+        - sodium
+
+variables:
+    env:
+        APP_ENV: 'prod'
+        APP_DEBUG: 0
+        APP_DEFAULT_LOCALE: 'en_US'
+        APP_PRODUCT_AND_PRODUCT_MODEL_INDEX_NAME: 'akeneo_pim_product_and_product_model'
+        AKENEO_STARTER: minimal
+        # AKENEO_STARTER: icecat_demo_dev
+        # Update these for your desired Node version.
+        NODE_VERSION: v14.19.0
+    php:
+        apc.enable_cli: 1
+
+build:
+    flavor: none
+
+hooks:
+    # We run the build hook before your application has been packaged.
+    build: |
+        set -e
+
+        # Install composer dependencies.
+        composer install
+
+        # Install n to use newer version of node.
+        export N_PREFIX=$HOME/.n
+        export PATH=$N_PREFIX/bin:$PATH
+        curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install_node.sh | { bash /dev/fd/3 -v $NODE_VERSION -y; } 3<&0
+
+        echo "Installing Node dependencies."
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 corepack yarn install
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 corepack yarn packages:build
+
+        echo "Installing assets."
+        php bin/console pim:installer:assets --symlink --clean -vvv
+        corepack yarn run less
+        corepack yarn update-extensions
+
+        echo "Running webpack."
+        corepack yarn run webpack
+
+    # We run the deploy hook after your application has been deployed and started.
+    deploy: |
+        set -e
+
+        echo "Warming cache"
+        rm -rf var/cache/*
+        php bin/console cache:warmup
+
+        STARTER_TRACKING=installer/$AKENEO_STARTER.installed
+        CATALOG_PATH=vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures
+
+        # run installer if no lockfile exists
+        if [ ! -f $STARTER_TRACKING ]; then
+
+            # Clear previous tracking files in case trying multiple.
+            rm -rf installer/*
+
+            # minimal catalog + fixtures.
+            if [ "$AKENEO_STARTER" = minimal ]; then
+                echo "Running the installer: $AKENEO_STARTER catalog + fixtures."
+                php bin/console pim:installer:db --env=$APP_ENV --catalog=$CATALOG_PATH/$AKENEO_STARTER
+                # Create the admin user (admin/admin). Change immediately.
+                php bin/console pim:user:create -n --admin admin admin admin@example.com Admin Istrator $APP_DEFAULT_LOCALE
+                php bin/console cache:clear
+                touch $STARTER_TRACKING
+
+            # icecat_demo_dev catalog + fixtures.
+            elif [ "$AKENEO_STARTER" = icecat_demo_dev ]; then
+                echo "Running the installer: $AKENEO_STARTER catalog + fixtures."
+                php bin/console pim:installer:db --env=$APP_ENV --catalog=$CATALOG_PATH/$AKENEO_STARTER
+                # Note: no admin user is created, since `icecat_demo_dev` creates on automatically (admin/admin). Change immediately.
+                php bin/console cache:clear
+                touch $STARTER_TRACKING
+
+            else
+                echo "No profile given. Skipping installation."
+            fi
+        else
+            echo "Akeneo already installed. Skipping."
+        fi
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the environment variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mysql"
+    essearch: "search:elasticsearch"
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            root: 'public'
+            passthru: '/index.php'
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    "var":
+        source: local
+        source_path: "var"
+    # Used to control the Platform.sh install process. Do not delete the file inside it.
+    "installer":
+        source: local
+        source_path: "installer"
+    "web":
+        source: local
+        source_path: "web"
+    "config/secrets":
+        source: local
+        source_path: "config/secrets"
+    # For media files
+    "public/media":
+        source: local
+        source_path: "public/media"
+    # For local generated files
+    "var/file_storage":
+        source: local
+        source_path: "var/file_storage"
+    # Sharing job files
+    "var/file_storage/jobs":
+        source: service
+        service: jobs
+        source_path: "var/file_storage/jobs"
+
+crons:
+    refresh:
+        spec: '30 1 * * *'
+        commands:
+            start: 'php bin/console pim:versioning:refresh'
+    purge_versioning:
+        spec: '30 2 * * *'
+        commands:
+            start: 'php bin/console pim:versioning:purge –more-than-days 90'
+    update_data:
+        spec: '1 * * * *'
+        commands:
+            start: 'php bin/console akeneo:connectivity-audit:update-data'
+    purge_jobs:
+        spec: '20 0 1 * *'
+        commands:
+            start: 'php bin/console akeneo:batch:purge-job-execution'
+    aggregate:
+        spec: '30 4 * * *'
+        commands:
+            start: 'php bin/console pim:volume:aggregate'
+
+workers:
+    queue:
+        disk: 512
+        commands:
+            start: |
+                php /app/bin/console akeneo:batch:job-queue-consumer-daemon
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/drupal10
+++ b/sites/platform/static/files/fetch/appyaml/drupal10
@@ -1,0 +1,159 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:8.1'
+
+dependencies:
+    php:
+        composer/composer: '^2.1'
+
+runtime:
+    # Enable the redis extension so Drupal can communicate with the Redis cache.
+    extensions:
+        - redis
+        - sodium
+        - apcu
+        - blackfire
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: 'db:mysql'
+    redis: 'cache:redis'
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    # The default Drupal files directory.
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    # Drupal gets its own dedicated tmp directory. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    # Private file uploads are stored outside the web root. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/private':
+        source: local
+        source_path: 'private'
+    # Drush needs a scratch space for its own caches.
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    # Drush will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    # Drupal Console will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/.console':
+        source: local
+        source_path: 'console'
+
+# Configuration of the build of this application.
+build:
+    flavor: composer
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        set -e
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+        set -e
+        php ./drush/platformsh_generate_drush_yml.php
+        # if drupal is installed, will call the following drush commands:
+        #   - `cache-rebuild`
+        #   - `updatedb`
+        #   - and if config files are present, `config-import`
+        cd web
+        bash $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        # All requests not otherwise specified follow these rules.
+        '/':
+            # The folder from which to serve static assets, for this location.
+            #
+            # This is a filesystem path, relative to the application root.
+            root: 'web'
+
+            # How long to allow static assets from this location to be cached.
+            #
+            # Can be a time in seconds, or -1 for no caching. Times can be
+            # suffixed with "s" (seconds), "m" (minutes), "h" (hours), "d"
+            # (days), "w" (weeks), "M" (months, as 30 days) or "y" (years, as
+            # 365 days).
+            expires: 5m
+
+            # Redirect any incoming request to Drupal's front controller.
+            passthru: '/index.php'
+
+            # Deny access to all static files, except those specifically allowed below.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(avif|webp|jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+                # Deny direct access to configuration files.
+                '^/sites/sites\.php$':
+                    scripts: false
+                '^/sites/[^/]+/settings.*?\.php$':
+                    scripts: false
+
+        # The files directory has its own special configuration rules.
+        '/sites/default/files':
+            # Allow access to all files in the public files directory.
+            allow: true
+            expires: 5m
+            passthru: '/index.php'
+            root: 'web/sites/default/files'
+
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+
+            rules:
+                # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
+                '^/sites/default/files/(css|js)':
+                    expires: 2w
+
+crons:
+    # Run Drupal's cron tasks every 19 minutes.
+    drupal:
+        spec: '*/19 * * * *'
+        commands: 
+            start: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+

--- a/sites/platform/static/files/fetch/appyaml/drupal7
+++ b/sites/platform/static/files/fetch/appyaml/drupal7
@@ -1,0 +1,111 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: 'app'
+
+# The runtime the application uses.
+type: 'php:7.2'
+
+# Configuration of the build of this application.
+build:
+  flavor: drupal
+
+# The build-time dependencies of the app.
+dependencies:
+  php:
+    "drush/drush": "^8.0"
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: 'db:mysql'
+
+# The configuration of app when it is exposed to the web.
+web:
+    # Specific parameters for different URL prefixes.
+    locations:
+        '/':
+            # The folder from which to serve static assets, for this location.
+            #
+            # This is a filesystem path, relative to the application root.
+            root: 'public'
+
+            # How long to allow static assets from this location to be cached.
+            #
+            # Can be a time in seconds, or -1 for no caching. Times can be
+            # suffixed with "s" (seconds), "m" (minutes), "h" (hours), "d"
+            # (days), "w" (weeks), "M" (months, as 30 days) or "y" (years, as
+            # 365 days).
+            expires: 5m
+
+            # Whether to forward disallowed and missing resources from this
+            # location to the application.
+            #
+            # Can be true, false or a URI path string.
+            passthru: '/index.php'
+
+            # Deny access to static files in this location.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+        '/sites/default/files':
+            # Allow access to all files in the public files directory.
+            allow: true
+            expires: 5m
+            passthru: '/index.php'
+            root: 'public/sites/default/files'
+
+            # Do not execute PHP scripts.
+            scripts: false
+
+            rules:
+                # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
+                '^/sites/default/files/(css|js)':
+                    expires: 2w
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    '/public/sites/default/files':
+        source: local
+        source_path: 'files'
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    '/private':
+        source: local
+        source_path: 'private'
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # We run deploy hook after your application has been deployed and started.
+    deploy: |
+        set -e
+        cd public
+        drush -y updatedb
+
+    # The configuration of scheduled execution.
+crons:
+    drupal:
+        spec: '*/20 * * * *'
+        cmd: 'cd public ; drush core-cron'

--- a/sites/platform/static/files/fetch/appyaml/drupal8
+++ b/sites/platform/static/files/fetch/appyaml/drupal8
@@ -1,0 +1,158 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:7.4'
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+runtime:
+    # Enable the redis extension so Drupal can communicate with the Redis cache.
+    extensions:
+        - redis
+        - blackfire
+        - sodium
+        - apcu
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: 'db:mysql'
+    redis: 'cache:redis'
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    # The default Drupal files directory.
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    # Drupal gets its own dedicated tmp directory. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    # Private file uploads are stored outside the web root. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/private':
+        source: local
+        source_path: 'private'
+    # Drush needs a scratch space for its own caches.
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    # Drush will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    # Drupal Console will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/.console':
+        source: local
+        source_path: 'console'
+
+# Configuration of the build of this application.
+build:
+    # Automatically run `composer install` on every build.
+    flavor: composer
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        set -e
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+        set -e
+        php ./drush/platformsh_generate_drush_yml.php
+        cd web
+        drush -y cache-rebuild
+        drush -y updatedb
+        drush -y config-import
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        # All requests not otherwise specified follow these rules.
+        '/':
+            # The folder from which to serve static assets, for this location.
+            #
+            # This is a filesystem path, relative to the application root.
+            root: 'web'
+
+            # How long to allow static assets from this location to be cached.
+            #
+            # Can be a time in seconds, or -1 for no caching. Times can be
+            # suffixed with "s" (seconds), "m" (minutes), "h" (hours), "d"
+            # (days), "w" (weeks), "M" (months, as 30 days) or "y" (years, as
+            # 365 days).
+            expires: 5m
+
+            # Redirect any incoming request to Drupal's front controller.
+            passthru: '/index.php'
+
+            # Deny access to all static files, except those specifically allowed below.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+                # Deny direct access to configuration files.
+                '^/sites/sites\.php$':
+                    scripts: false
+                '^/sites/[^/]+/settings.*?\.php$':
+                    scripts: false
+
+        # The files directory has its own special configuration rules.
+        '/sites/default/files':
+            # Allow access to all files in the public files directory.
+            allow: true
+            expires: 5m
+            passthru: '/index.php'
+            root: 'web/sites/default/files'
+
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+
+            rules:
+                # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
+                '^/sites/default/files/(css|js)':
+                    expires: 2w
+
+crons:
+    # Run Drupal's cron tasks every 19 minutes.
+    drupal:
+        spec: '*/19 * * * *'
+        commands:
+            start: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+

--- a/sites/platform/static/files/fetch/appyaml/drupal8-multisite
+++ b/sites/platform/static/files/fetch/appyaml/drupal8-multisite
@@ -1,0 +1,160 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:7.4'
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+runtime:
+    # Enable the redis extension so Drupal can communicate with the Redis cache.
+    extensions:
+        - redis
+        - sodium
+        - blackfire
+        - apcu
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    rediscache: 'cache:redis'
+    first: 'db:first'
+    second: 'db:second'
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    # For multisite, use a common shared files directory and subdirectories inside it
+    # to avoid needing a separate mount definition for each site.
+    '/web/files':
+        source: local
+        source_path: 'files'
+    # Drupal gets its own dedicated tmp directory. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    # Private file uploads are stored outside the web root. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/private':
+        source: local
+        source_path: 'private'
+    # Drush needs a scratch space for its own caches.
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    # Drush will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    # Drupal Console will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/.console':
+        source: local
+        source_path: 'console'
+
+# Configuration of the build of this application.
+build:
+    # Automatically run `composer install` on every build.
+    flavor: composer
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        set -e
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+        set -e
+        php ./drush/platformsh_generate_drush_yml.php
+        cd web
+        drush -y cache-rebuild
+        drush -y updatedb
+        drush -y config-import
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        # All requests not otherwise specified follow these rules.
+        '/':
+            # The folder from which to serve static assets, for this location.
+            #
+            # This is a filesystem path, relative to the application root.
+            root: 'web'
+
+            # How long to allow static assets from this location to be cached.
+            #
+            # Can be a time in seconds, or -1 for no caching. Times can be
+            # suffixed with "s" (seconds), "m" (minutes), "h" (hours), "d"
+            # (days), "w" (weeks), "M" (months, as 30 days) or "y" (years, as
+            # 365 days).
+            expires: 5m
+
+            # Redirect any incoming request to Drupal's front controller.
+            passthru: '/index.php'
+
+            # Deny access to all static files, except those specifically allowed below.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+                # Deny direct access to configuration files.
+                '^/sites/sites\.php$':
+                    scripts: false
+                '^/sites/[^/]+/settings.*?\.php$':
+                    scripts: false
+
+        # The files directory has its own special configuration rules.
+        '/files':
+            # Allow access to all files in the public files directory.
+            allow: true
+            expires: 5m
+            passthru: '/index.php'
+            root: 'web/files'
+
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+
+            rules:
+                # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
+                '^/files/(css|js)':
+                    expires: 2w
+
+crons:
+    # Run Drupal's cron tasks every 19 minutes.
+    drupal:
+        spec: '*/19 * * * *'
+        commands:
+            start: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+

--- a/sites/platform/static/files/fetch/appyaml/drupal9
+++ b/sites/platform/static/files/fetch/appyaml/drupal9
@@ -1,0 +1,159 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: 'drupal'
+
+# The runtime the application uses.
+type: 'php:8.1'
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+runtime:
+    # Enable the redis extension so Drupal can communicate with the Redis cache.
+    extensions:
+        - redis
+        - sodium
+        - apcu
+        - blackfire
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: 'db:mysql'
+    redis: 'cache:redis'
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    # The default Drupal files directory.
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    # Drupal gets its own dedicated tmp directory. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    # Private file uploads are stored outside the web root. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/private':
+        source: local
+        source_path: 'private'
+    # Drush needs a scratch space for its own caches.
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    # Drush will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    # Drupal Console will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/.console':
+        source: local
+        source_path: 'console'
+
+# Configuration of the build of this application.
+build:
+    flavor: composer
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        set -e
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+        set -e
+        php ./drush/platformsh_generate_drush_yml.php
+        # if drupal is installed, will call the following drush commands:
+        #   - `cache-rebuild`
+        #   - `updatedb`
+        #   - and if config files are present, `config-import`
+        cd web
+        bash $PLATFORM_APP_DIR/drush/platformsh_deploy_drupal.sh
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        # All requests not otherwise specified follow these rules.
+        '/':
+            # The folder from which to serve static assets, for this location.
+            #
+            # This is a filesystem path, relative to the application root.
+            root: 'web'
+
+            # How long to allow static assets from this location to be cached.
+            #
+            # Can be a time in seconds, or -1 for no caching. Times can be
+            # suffixed with "s" (seconds), "m" (minutes), "h" (hours), "d"
+            # (days), "w" (weeks), "M" (months, as 30 days) or "y" (years, as
+            # 365 days).
+            expires: 5m
+
+            # Redirect any incoming request to Drupal's front controller.
+            passthru: '/index.php'
+
+            # Deny access to all static files, except those specifically allowed below.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+                # Deny direct access to configuration files.
+                '^/sites/sites\.php$':
+                    scripts: false
+                '^/sites/[^/]+/settings.*?\.php$':
+                    scripts: false
+
+        # The files directory has its own special configuration rules.
+        '/sites/default/files':
+            # Allow access to all files in the public files directory.
+            allow: true
+            expires: 5m
+            passthru: '/index.php'
+            root: 'web/sites/default/files'
+
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+
+            rules:
+                # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
+                '^/sites/default/files/(css|js)':
+                    expires: 2w
+
+crons:
+    # Run Drupal's cron tasks every 19 minutes.
+    drupal:
+        spec: '*/19 * * * *'
+        commands: 
+            start: 'cd web ; drush core-cron'
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+

--- a/sites/platform/static/files/fetch/appyaml/gatsby
+++ b/sites/platform/static/files/fetch/appyaml/gatsby
@@ -1,0 +1,66 @@
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: 'app'
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: 'nodejs:18'
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 5120
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Each key in locations is a path on your site with a leading /.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#locations
+  locations:
+    '/':
+      # The directory to serve static assets for this location relative to the app’s root directory. Must be an
+      # actual directory inside the root directory.
+      root: 'public'
+      # Files to consider when serving a request for a directory.
+      index: [ 'index.html' ]
+      # Whether to allow serving files which don’t match a rule.
+      allow: true
+
+# Specifies a default set of build tasks to run. Flavors are language-specific.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#build
+build:
+  flavor: none
+
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
+dependencies:
+  nodejs:
+    yarn: "1.22.5"
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    yarn
+    yarn build
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/golang
+++ b/sites/platform/static/files/fetch/appyaml/golang
@@ -1,0 +1,52 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: golang:1.16
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    build: |
+        # Modify this line if you want to build differently or use an alternate name for your executable.
+        go build -o bin/app
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mysql"
+
+# The configuration of app when it is exposed to the web.
+web:
+    upstream:
+        socket_family: tcp
+        protocol: http
+
+    commands:
+        # If you change the build output in the build hook above, update this line as well.
+        start: ./bin/app
+
+    locations:
+        /:
+            # Route all requests to the Go app, unconditionally.
+            # If you want some files served directly by the web server without hitting Go, see
+            # https://docs.platform.sh/configuration/app/web.html
+            allow: false
+            passthru: true
+
+# The size of the persistent disk of the application (in MB).
+disk: 1024
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+    

--- a/sites/platform/static/files/fetch/appyaml/laravel
+++ b/sites/platform/static/files/fetch/appyaml/laravel
@@ -1,0 +1,120 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: php:8.0
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+runtime:
+    extensions:
+        - redis
+      # - blackfire # https://docs.platform.sh/integrations/observability/blackfire.
+
+build:
+    flavor: composer
+
+variables:
+    env:
+        N_PREFIX: /app/.global
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    build: |
+        set -e
+
+        # install a specific NodeJS version https://github.com/platformsh/snippets/
+        #   -v requested version
+        #   -y install Yarn
+        # curl -fsS https://raw.githubusercontent.com/platformsh/snippets/main/src/install_node.sh | { bash /dev/fd/3 -v 17.5 -y; } 3<&0
+
+        # uncomment next line to build assets deploying
+        # npm install && npm run production
+
+
+    deploy: |
+        set -e
+        php artisan optimize:clear
+        php artisan optimize
+        php artisan view:cache
+        php artisan migrate --force
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mysql"
+    rediscache: "cache:redis"
+    redissession: "cache:redis"
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+  "storage/app/public":
+      source: local
+      source_path: "public"
+  "storage/framework/views":
+      source: local
+      source_path: "views"
+  "storage/framework/sessions":
+      source: local
+      source_path: "sessions"
+  "storage/framework/cache":
+      source: local
+      source_path: "cache"
+  "storage/logs":
+      source: local
+      source_path: "logs"
+  "bootstrap/cache":
+      source: local
+      source_path: "cache"
+  "/.config":
+      source: local
+      source_path: "config"
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            root: "public"
+            index:
+                - index.php
+            allow: true
+            passthru: "/index.php"
+        "/storage":
+            root: "storage/app/public"
+            scripts: false
+
+# Note that use of workers require a Medium plan or larger.
+workers:
+  queue:
+    size: S
+    commands:
+      # To minimize leakage, the queue worker will stop every hour
+      # and get restarted automatically.
+      start: |
+        php artisan queue:work --max-time=3600
+    # set the worker's disk to the minimum amount
+    disk: 256
+  scheduler:
+    size: S
+    commands:
+      start: php artisan schedule:work
+    # set the worker's disk to the minimum amount
+    disk: 256
+
+
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/magento2ce
+++ b/sites/platform/static/files/fetch/appyaml/magento2ce
@@ -1,0 +1,161 @@
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: magento
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: php:7.4
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+  database: magento_database:mysql
+  redis: magento_redis:redis
+  search: magento_search:opensearch
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 2048
+
+# Mounts define directories that are writable after the build is complete. If set as a local source, disk property is required.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#mounts
+mounts:
+  "var": "shared:files/var"
+  "generated": "shared:files/generated"
+  "app/etc": "shared:files/etc"
+  "pub/media": "shared:files/media"
+  "pub/static": "shared:files/static"
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Each key in locations is a path on your site with a leading /.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#locations
+  locations:
+    '/':
+      # The directory to serve static assets for this location relative to the app’s root directory. Must be an
+      # actual directory inside the root directory.
+      root: "pub"
+      # Whether to forward disallowed and missing resources from this location to the app. A string is a path
+      # with a leading / to the controller, such as /index.php.
+      passthru: "/index.php"
+      # Files to consider when serving a request for a directory.
+      index:
+        - index.php
+      # Whether to allow scripts to run. Doesn’t apply to paths specified in passthru. Meaningful only on PHP containers.
+      scripts: true
+      # Whether to allow serving files which don’t match a rule.
+      allow: false
+      # The key of each item in rules is a regular expression to match paths exactly. If an incoming request
+      # matches the rule, it’s handled by the properties under the rule, overriding any conflicting rules from the
+      # rest of the locations properties.
+      # More information: https://docs.platform.sh/create-apps/app-reference.html#rules
+      rules:
+        \.(css|js|map|hbs|gif|jpe?g|png|tiff|wbmp|ico|jng|bmp|svgz|midi?|mp?ga|mp2|mp3|m4a|ra|weba|3gpp?|mp4|mpe?g|mpe|ogv|mov|webm|flv|mng|asx|asf|wmv|avi|ogx|swf|jar|ttf|eot|woff|otf|html?)$:
+          allow: true
+        ^/sitemap(.*)\.xml$:
+          passthru: "/media/sitemap$1.xml"
+    '/media':
+      root: "pub/media"
+      allow: true
+      scripts: false
+      passthru: "/get.php"
+      expires: 1y
+    '/static':
+      root: "pub/static"
+      allow: true
+      scripts: false
+      passthru: "/static.php"
+      expires: 1y
+      rules:
+        ^/static/version\d+/(?<resource>.*)$:
+          passthru: "/static/$resource"
+
+# Alternate copies of the application to run as background processes.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#workers
+workers:
+  queue:
+    size: S
+    disk: 128
+    commands:
+      start: |
+        bin/magento queue:consumers:start async.operations.all --single-thread --max-messages=10000
+
+# Variables to control the environment. More information: https://docs.platform.sh/create-apps/app-reference.html#variables
+variables:
+  # Customize your PHP.ini.
+  # See: https://docs.platform.sh/languages/php/ini.html
+  php:
+    # Include Magento's out-of-the-box settings
+    include: /app/.user.ini
+
+# Specifies a default set of build tasks to run. Flavors are language-specific.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#build
+build:
+  flavor: composer
+
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
+dependencies:
+  php:
+    composer/composer: "^1"
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    set -e
+    mkdir -p .versioned_backup/etc && cp app/etc/* .versioned_backup/etc/
+
+  # The deploy hook is run after the app container has been started, but before it has started accepting requests.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook
+  deploy: |
+    set -e
+    cp .versioned_backup/etc/* app/etc/
+    php deploy.php
+
+# Scheduled tasks for the app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#crons
+crons:
+  magento:
+    spec: "*/5 * * * *"
+    commands:
+      start: "php bin/magento cron:run"
+
+###
+# Customizations to your PHP or Lisp runtime. More information: https://docs.platform.sh/create-apps/app-reference.html#runtime
+# Specify additional PHP extensions that should be loaded.
+# To determine what you need to enable
+#   1. run locally: composer check-platform-reqs | grep "ext-\|php"
+#   2. Compare to https://docs.platform.sh/languages/php/extensions.html
+#      - "Def" = Already Enabled
+#      - "Avail" = Available, but you need to enable below.
+runtime:
+  extensions:
+    - xsl
+    - sodium
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/micronaut
+++ b/sites/platform/static/files/fetch/appyaml/micronaut
@@ -1,0 +1,29 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: "java:11"
+
+disk: 1024
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    build: mvn clean package
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+#relationships:
+#    database: "db:mysql"
+
+# The configuration of app when it is exposed to the web.
+web:
+    commands:
+        start: java -Xmx$(jq .info.limits.memory /run/config.json)m -XX:+ExitOnOutOfMemoryError -jar target/micronaut-1.0-SNAPSHOT.jar

--- a/sites/platform/static/files/fetch/appyaml/nodejs
+++ b/sites/platform/static/files/fetch/appyaml/nodejs
@@ -1,0 +1,38 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: nodejs:14
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+  database: "db:mysql"
+
+# The configuration of app when it is exposed to the web.
+web:
+  commands:
+   start: "node index.js"
+
+# The size of the persistent disk of the application (in MB).
+disk: 512
+
+mounts:
+    'run':
+        source: local
+        source_path: run
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+    

--- a/sites/platform/static/files/fetch/appyaml/php
+++ b/sites/platform/static/files/fetch/appyaml/php
@@ -1,0 +1,59 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The type of the application to build.
+type: 'php:8.0'
+
+# Indicate that we want to use composer2, (leave out if you want composer1)
+dependencies:
+    php: 
+        composer/composer: '^2'
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    build: |
+        set -e
+
+    deploy: |
+        set -e
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+#relationships:
+#    database: "db:mysql"
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    # Because this directory is in the webroot, files here will be web-accessible.
+    'web/uploads':
+        source: local
+        source_path: uploads
+    # Files in this directory will not be web-accessible.
+    'private':
+        source: local
+        source_path: private
+
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "web"
+            # The front-controller script to send non-static requests to.
+            passthru: "/index.php"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+    

--- a/sites/platform/static/files/fetch/appyaml/pip/django4
+++ b/sites/platform/static/files/fetch/appyaml/pip/django4
@@ -1,0 +1,119 @@
+#########################
+# Django 4 using pip
+##########################
+# Container configuration.
+
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: 'app'
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: 'python:3.10'
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+  database: "db:postgresql"
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 512
+
+# Mounts define directories that are writable after the build is complete. If set as a local source, disk property is required.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#mounts
+mounts:
+  'logs':
+    source: local
+    source_path: logs
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Commands are run once after deployment to start the application process.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#web-commands
+  commands:
+    # The command to launch your app. If it terminates, it’s restarted immediately.
+    start: "gunicorn -w 4 -b unix:$SOCKET myapp.wsgi:application"
+
+  # More information: https://docs.platform.sh/configuration/app-containers.html#upstream
+  upstream:
+    # Whether your app should speak to the webserver via TCP or Unix socket. Defaults to tcp
+    # More information: https://docs.platform.sh/create-apps/app-reference.html#where-to-listen
+    socket_family: unix
+
+  # Each key in locations is a path on your site with a leading /.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#locations
+  locations:
+    "/":
+      # Whether to forward disallowed and missing resources from this location to the app. A string is a path
+      # with a leading / to the controller, such as /index.php.
+      passthru: true
+    "/static":
+      # The directory to serve static assets for this location relative to the app’s root directory. Must be an
+      # actual directory inside the root directory.
+      root: "static"
+      # The number of seconds whitelisted (static) content should be cached.
+      expires: 1h
+      # Whether to allow serving files which don’t match a rule.
+      allow: true
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    set -eu
+
+    # Download the latest version of pip
+    python3.10 -m pip install --upgrade pip
+
+    # Install dependencies
+    pip install -r requirements.txt
+
+    # Collect static assets
+    python manage.py collectstatic
+
+  # The deploy hook is run after the app container has been started, but before it has started accepting requests.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook
+  deploy: python manage.py migrate
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        # Upgrade pip
+        python3.10 -m pip install --upgrade pip
+
+        # Upgrade Poetry.
+        ./install-poetry.sh
+        export PATH="/app/.local/bin:$PATH"
+        poetry update --lock
+
+        # Upgrade pip
+        poetry export -f requirements.txt > requirements.txt
+
+        # Upgrade Pipenv.
+        pip install pipenv
+        pipenv update
+
+        git add Pipfile.lock poetry.lock requirements.txt
+        git commit --allow-empty -m "Dependency updates."
+#      command: |
+#        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/pipenv/django4
+++ b/sites/platform/static/files/fetch/appyaml/pipenv/django4
@@ -1,0 +1,112 @@
+#########################
+# Django4 using pipenv
+##########################
+# Container configuration.
+
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: 'app'
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: 'python:3.10'
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+  database: "db:postgresql"
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 512
+
+# Mounts define directories that are writable after the build is complete. If set as a local source, disk property is required.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#mounts
+mounts:
+  'logs':
+    source: local
+    source_path: logs
+  '.cache':
+    source: local
+    source_path: cache
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Commands are run once after deployment to start the application process.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#web-commands
+  commands:
+    # The command to launch your app. If it terminates, it’s restarted immediately.
+    start: "pipenv run gunicorn -w 4 -b unix:$SOCKET myapp.wsgi:application"
+
+  # More information: https://docs.platform.sh/configuration/app-containers.html#upstream
+  upstream:
+    # Whether your app should speak to the webserver via TCP or Unix socket. Defaults to tcp
+    # More information: https://docs.platform.sh/create-apps/app-reference.html#where-to-listen
+    socket_family: unix
+
+  # Each key in locations is a path on your site with a leading /.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#locations
+  locations:
+    "/":
+      # Whether to forward disallowed and missing resources from this location to the app. A string is a path
+      # with a leading / to the controller, such as /index.php.
+      passthru: true
+    "/static":
+      # The directory to serve static assets for this location relative to the app’s root directory. Must be an
+      # actual directory inside the root directory.
+      root: "static"
+      # The number of seconds whitelisted (static) content should be cached.
+      expires: 1h
+      # Whether to allow serving files which don’t match a rule.
+      allow: true
+
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
+dependencies:
+  python3:
+    pipenv: '2022.9.4'
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    set -eu
+
+    # Download the latest version of pip
+    python3.10 -m pip install --upgrade pip
+
+    # Install dependencies
+    pipenv install --deploy
+
+    # Collect static assets
+    pipenv run python manage.py collectstatic
+
+  # The deploy hook is run after the app container has been started, but before it has started accepting requests.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook
+  deploy: pipenv run python manage.py migrate
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/poetry/django4
+++ b/sites/platform/static/files/fetch/appyaml/poetry/django4
@@ -1,0 +1,119 @@
+#########################
+# Django4 using Poetry
+##########################
+# Container configuration.
+
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: 'app'
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: 'python:3.10'
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+  database: "db:postgresql"
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 512
+
+# Mounts define directories that are writable after the build is complete. If set as a local source, disk property is required.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#mounts
+mounts:
+  'logs':
+    source: local
+    source_path: logs
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Commands are run once after deployment to start the application process.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#web-commands
+  commands:
+    # The command to launch your app. If it terminates, it’s restarted immediately.
+    start: "poetry run gunicorn -w 4 -b unix:$SOCKET myapp.wsgi:application"
+
+  # More information: https://docs.platform.sh/configuration/app-containers.html#upstream
+  upstream:
+    # Whether your app should speak to the webserver via TCP or Unix socket. Defaults to tcp
+    # More information: https://docs.platform.sh/create-apps/app-reference.html#where-to-listen
+    socket_family: unix
+
+      # Each key in locations is a path on your site with a leading /.
+    # More information: https://docs.platform.sh/create-apps/app-reference.html#locations
+  locations:
+    "/":
+      # Whether to forward disallowed and missing resources from this location to the app. A string is a path
+      # with a leading / to the controller, such as /index.php.
+      passthru: true
+    "/static":
+      # The directory to serve static assets for this location relative to the app’s root directory. Must be an
+      # actual directory inside the root directory.
+      root: "static"
+      # The number of seconds whitelisted (static) content should be cached.
+      expires: 1h
+      # Whether to allow serving files which don’t match a rule.
+      allow: true
+
+# Variables to control the environment. More information: https://docs.platform.sh/create-apps/app-reference.html#variables
+variables:
+  env:
+    POETRY_VIRTUALENVS_IN_PROJECT: true
+    POETRY_VIRTUALENVS_CREATE: false
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    set -eu
+
+    # Download the latest version of pip
+    python3.10 -m pip install --upgrade pip
+
+    # Install and configure Poetry
+    #   NOTE: There is a matching export PATH=... in `.environment`, which allows the use of Poetry
+    #     in the deploy hook, start command, and during SSH sessions. Make sure to include in your
+    #     own projects.
+    export PIP_USER=false
+    curl -sSL https://install.python-poetry.org | python3 - --version $POETRY_VERSION
+    export PATH="/app/.local/bin:$PATH"
+    export PIP_USER=true
+
+    # Install dependencies
+    poetry install
+
+    # Collect static assets
+    poetry run python manage.py collectstatic
+
+  # The deploy hook is run after the app container has been started, but before it has started accepting requests.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook
+  deploy: poetry run python manage.py migrate
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  # The path where the app code lives. Defaults to the directory of the .platform.app.yaml file. Useful for multi-app setups.
+  root:
+
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/pyramid
+++ b/sites/platform/static/files/fetch/appyaml/pyramid
@@ -1,0 +1,64 @@
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: app
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: "python:3.9"
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+  database: "db:mysql"
+  redis: "cache:redis"
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 1024
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Commands are run once after deployment to start the application process.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#web-commands
+  commands:
+    # The command to launch your app. If it terminates, it’s restarted immediately.
+    start: python app.py
+
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
+dependencies:
+  python:
+    pipenv: "2018.10.13"
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    pipenv install --system --deploy
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+

--- a/sites/platform/static/files/fetch/appyaml/python3
+++ b/sites/platform/static/files/fetch/appyaml/python3
@@ -1,0 +1,43 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: "python:3.8"
+
+# The build-time dependencies of the app.
+dependencies:
+    python3:
+       pipenv: "2018.10.13"
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    build: |
+      pipenv install --system --deploy
+
+# The size of the persistent disk of the application (in MB).
+disk: 1024
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mysql"
+    rediscache: "cache:redis"
+
+# The configuration of app when it is exposed to the web.
+web:
+    commands:
+        start: python server.py
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0
+    

--- a/sites/platform/static/files/fetch/appyaml/quarkus
+++ b/sites/platform/static/files/fetch/appyaml/quarkus
@@ -1,0 +1,28 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: "java:11"
+disk: 1024
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    build: ./mvnw package -DskipTests
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+#relationships:
+#    database: "db:mysql"
+
+# The configuration of app when it is exposed to the web.
+web:
+    commands:
+        start: java -jar -Xmx$(jq .info.limits.memory /run/config.json)m -XX:+ExitOnOutOfMemoryError -Dquarkus.http.port=$PORT target/quarkus-1.0.0-SNAPSHOT-runner.jar

--- a/sites/platform/static/files/fetch/appyaml/spring-boot-maven-mysql
+++ b/sites/platform/static/files/fetch/appyaml/spring-boot-maven-mysql
@@ -1,0 +1,30 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: "java:11"
+
+disk: 1024
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    build: mvn clean package -Dmaven.test.skip=true
+
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mysql"
+
+# The configuration of app when it is exposed to the web.
+web:
+    commands:
+        start: java -jar $JAVA_OPTS target/spring-boot-maven-mysql.jar --server.port=$PORT

--- a/sites/platform/static/files/fetch/appyaml/spring-mvc-maven-mongodb
+++ b/sites/platform/static/files/fetch/appyaml/spring-mvc-maven-mongodb
@@ -1,0 +1,29 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/user_guide/reference/platform-app-yaml.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: "java:11"
+
+disk: 1024
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    build: mvn clean package
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mongodb"
+
+# The configuration of app when it is exposed to the web.
+web:
+    commands:
+        start: java -jar $JAVA_OPTS target/spring-mvc-maven-mongodb.jar --server.port=$PORT

--- a/sites/platform/static/files/fetch/appyaml/strapi4
+++ b/sites/platform/static/files/fetch/appyaml/strapi4
@@ -1,0 +1,104 @@
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: app
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: nodejs:18
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+  postgresdatabase: "dbpostgres:postgresql"
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 1024
+
+# Mounts define directories that are writable after the build is complete. If set as a local source, disk property is required.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#mounts
+mounts:
+  # Strapi's cache directory.
+  "/.cache":
+    source: local
+    source_path: cache
+
+  # Mount .tmp file in the app folder for strapi
+  ".tmp":
+    source: local
+    source_path: app
+
+  # Mount database folder for strapi
+  "database":
+    source: local
+    source_path: database
+
+  # Give write access for extension configuration JSONs.
+  "extensions":
+    source: local
+    source_path: extensions
+
+  # Allow for media uploads at runtime.
+  "public/uploads":
+    source: local
+    source_path: uploads
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+  # Commands are run once after deployment to start the application process.
+  # More information: https://docs.platform.sh/create-apps/app-reference.html#web-commands
+  commands:
+    # The command to launch your app. If it terminates, it’s restarted immediately.
+    start: |
+      yarn start
+
+# Variables to control the environment. More information: https://docs.platform.sh/create-apps/app-reference.html#variables
+variables:
+  env:
+    NODE_ENV: 'production'
+
+# Specifies a default set of build tasks to run. Flavors are language-specific.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#build
+build:
+  # Use Yarn instead of npm.
+  flavor: none
+
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
+dependencies:
+  nodejs:
+    yarn: "1.22.5"
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
+hooks:
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+  build: |
+    # Download dependencies and build Strapi.
+    yarn --frozen-lockfile
+    yarn build
+
+# Information on the app's source code and operations that can be run on it.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#source
+source:
+  ######################################################################################################################
+  ##                                                                                                                  ##
+  ## This source operation is part of the Platform.sh process of updating and maintaining our collection of           ##
+  ## templates. For more information see https://docs.platform.sh/create-apps/source-operations.html and              ##
+  ## https://github.com/platformsh/source-operations                                                                  ##
+  ##                                                                                                                  ##
+  ##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                     ##
+  ##                                                                                                                  ##
+  ######################################################################################################################
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/symfony-base/platformsh-symfony-template
+++ b/sites/platform/static/files/fetch/appyaml/symfony-base/platformsh-symfony-template
@@ -1,0 +1,67 @@
+name: app
+
+type: php:8.2
+
+dependencies:
+    php:
+        composer/composer: "^2"
+
+runtime:
+    extensions:
+        - apcu
+        - blackfire
+        - ctype
+        - iconv
+        - mbstring
+        - pdo_pgsql
+        - sodium
+        - xsl
+        
+
+variables:
+    php:
+        opcache.preload: config/preload.php
+build:
+    flavor: none
+
+disk: 1024
+
+web:
+    locations:
+        "/":
+            root: "public"
+            expires: 1h
+            passthru: "/index.php"
+
+mounts:
+    "/var": { source: local, source_path: var }
+    
+
+relationships:
+    database: "database:postgresql"
+    
+hooks:
+    build: |
+        set -x -e
+
+        curl -fs https://get.symfony.com/cloud/configurator | bash
+        
+        NODE_VERSION=18 symfony-build
+
+    deploy: |
+        set -x -e
+
+        symfony-deploy
+
+crons:
+    security-check:
+        # Check that no security issues have been found for PHP packages deployed in production
+        # See https://github.com/fabpot/local-php-security-checker
+        spec: '50 23 * * *'
+        cmd: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape php-security-checker; fi
+
+workers:
+    messenger:
+        commands:
+            # Consume "async" messages (as configured in the routing section of config/packages/messenger.yaml)
+            start: symfony console --time-limit=3600 --memory-limit=64M messenger:consume async

--- a/sites/platform/static/files/fetch/appyaml/symfony-demo/platformsh-symfony-template
+++ b/sites/platform/static/files/fetch/appyaml/symfony-demo/platformsh-symfony-template
@@ -1,0 +1,59 @@
+name: app
+
+type: php:8.2
+
+dependencies:
+    php:
+        composer/composer: "^2"
+
+runtime:
+    extensions:
+        - apcu
+        - blackfire
+        - mbstring
+        - pdo_sqlite
+        - sodium
+        - xsl
+        
+
+variables:
+    php:
+        opcache.preload: config/preload.php
+build:
+    flavor: none
+
+disk: 1024
+
+web:
+    locations:
+        "/":
+            root: "public"
+            expires: 1h
+            passthru: "/index.php"
+
+mounts:
+    "/var": { source: local, source_path: var }
+    "/data": { source: local, source_path: "data" }
+
+
+hooks:
+    build: |
+        set -x -e
+
+        curl -fs https://get.symfony.com/cloud/configurator | bash
+        
+        NODE_VERSION=18 symfony-build
+
+    deploy: |
+        set -x -e
+
+        symfony-deploy
+
+crons:
+    security-check:
+        # Check that no security issues have been found for PHP packages deployed in production
+        # See https://github.com/fabpot/local-php-security-checker
+        spec: '50 23 * * *'
+        cmd: if [ "$PLATFORM_ENVIRONMENT_TYPE" = "production" ]; then croncape php-security-checker; fi
+
+

--- a/sites/platform/static/files/fetch/appyaml/symfony-docker-compose/platformsh-symfony-template
+++ b/sites/platform/static/files/fetch/appyaml/symfony-docker-compose/platformsh-symfony-template
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+###> doctrine/doctrine-bundle ###
+  database:
+    image: postgres:${POSTGRES_VERSION:-15}-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+      # You should definitely change the password in production
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+    volumes:
+      - database_data:/var/lib/postgresql/data:rw
+      # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
+      # - ./docker/db/data:/var/lib/postgresql/data:rw
+###< doctrine/doctrine-bundle ###
+
+volumes:
+###> doctrine/doctrine-bundle ###
+  database_data:
+###< doctrine/doctrine-bundle ###

--- a/sites/platform/static/files/fetch/appyaml/typo3
+++ b/sites/platform/static/files/fetch/appyaml/typo3
@@ -1,0 +1,221 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+#
+# See https://docs.platform.sh/configuration/app.html
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: php:7.4
+
+dependencies:
+    php:
+        composer/composer: '^2'
+
+runtime:
+    # Enable the redis extension so TYPO3 can communicate with the Redis cache.
+    extensions:
+        - redis
+
+# Composer build tasks run prior to build hook, which runs
+# composer --no-ansi --no-interaction install --no-progress --prefer-dist --optimize-autoloader
+# if composer.json is detected.
+build:
+    flavor: composer
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+#
+# NOTE: Be sure to update database and Redis configuration in `public/typo3conf/PlatformshConfiguration.php`
+# if you rename the relationships here.
+relationships:
+    # MariaDB/MySQL will then be accessible to the app from 'database' relationship.
+    # The service name `db` must match the top-level attribute in `.platform/services.yaml`.
+    database: 'db:mysql'
+
+    # Redis will then be accessible to the app from 'rediscache' relationship.
+    # The service name `cache` must match the top-level attribute in `.platform/services.yaml`.
+    rediscache: 'cache:redis'
+
+# The configuration of app when it is exposed to the web.
+web:
+    # How the application container responds to incoming requests.
+    locations:
+        # All requests not otherwise specified follow these rules.
+        '/':
+            # The folder from which to serve static assets, for this location.
+            # This is a filesystem path, relative to the application root.
+            root: 'public'
+
+            # Redirect any incoming request to TYPO3's front controller.
+            passthru: '/index.php'
+
+            # File to consider first when serving requests for a directory.
+            index:
+                - 'index.php'
+
+            # Deny access to all static files, except those specifically allowed below.
+            allow: false
+
+            # Rules for specific URI patterns.
+            rules:
+                # Allow access to common static files.
+                '\.(jpe?g|png|gif|svgz?|css|js|map|ico|bmp|eot|woff2?|otf|ttf)$':
+                    allow: true
+                '^/robots\.txt$':
+                    allow: true
+                '^/sitemap\.xml$':
+                    allow: true
+
+        # Default Storage location where TYPO3 expects media resources to be located.
+        # Writable at runtime with the mount `public/fileadmin`.
+        '/fileadmin':
+            root: 'public/fileadmin'
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+            allow: true
+            passthru: '/index.php'
+
+        # Directory for temporary files that should be publicly available (e.g. generated images).
+        # Writable at runtime with the mount `publi/typo3temp`.
+        '/typo3temp/assets':
+            root: 'public/typo3temp/assets'
+            # Do not execute PHP scripts from the writeable mount.
+            scripts: false
+            allow: true
+            passthru: '/index.php'
+
+        # Local TYPO3 installation settings.
+        '/typo3conf/LocalConfiguration.php':
+            allow: false
+
+        # Additional TYPO3 installation settings.
+        '/typo3conf/AdditionalConfiguration.php':
+            allow: false
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The 'mounts' describe writable, persistent filesystem mounts in the application.
+mounts:
+    # Directory for temporary files. It contains subdirectories (see below) for
+    # temporary files of extensions and TYPO3 components.
+    "public/typo3temp":
+        source: local
+        source_path: "typo3temp"
+    # Default Storage location where TYPO3 expects media resources to be located.
+    "public/fileadmin":
+        source: local
+        source_path: "fileadmin"
+    # Contains system files, like caches, logs, sessions
+    "var":
+        source: local
+        source_path: "var"
+
+# The hooks that will be performed when the package is deployed.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+        # Start the installation with no interaction or extension setup, using `SetupConfiguration.yaml`.
+        if [ ! -f var/platformsh.installed ]; then
+            php vendor/bin/typo3cms install:setup --install-steps-config=src/SetupConfiguration.yaml --no-interaction --skip-extension-setup
+        fi;
+
+        # Generates the `PackageStates.php` file from the `composer.json` configuration
+        php vendor/bin/typo3cms install:generatepackagestates
+
+        # Enable the install tool for 60mins after deployment.
+        touch public/typo3conf/ENABLE_INSTALL_TOOL
+
+        # Keep the checked-in LocalConfiguration available, but make the actual file writable later-on
+        # by creating a symlink which will be accesible below.
+        if [ -f public/typo3conf/LocalConfiguration.php ]; then
+            mv public/typo3conf/LocalConfiguration.php public/typo3conf/LocalConfiguration.FromSource.php
+            ln -sf ../../var/LocalConfiguration.php public/typo3conf/LocalConfiguration.php
+        fi;
+
+        # Clean up the FIRST_INSTALL file, that was created.
+        if [ -f public/FIRST_INSTALL ]; then
+            rm public/FIRST_INSTALL
+        fi;
+
+        # initial activation of Introduction package will fail if it is unable to write to this images directory.
+        # if it exists, we'll move its contents out to a temp space, remove the original, and symlink to a writable mount
+        if [ -d public/typo3conf/ext/introduction/Initialisation/Files/images/ ]; then
+            if [ ! -d imagestemp ]; then
+                # create our temp images directory
+                mkdir -p imagestemp
+                # copy the image files out of the real location into our temp space
+                cp -r public/typo3conf/ext/introduction/Initialisation/Files/images/. imagestemp/
+            fi
+
+            #now create the symlink for the images
+            #remove the original directory
+            rm -rf public/typo3conf/ext/introduction/Initialisation/Files/images/
+            # now create a symlink
+            ln -sf "$PLATFORM_APP_DIR/var/images" public/typo3conf/ext/introduction/Initialisation/Files/images
+        fi
+
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+        # Exit hook immediately if a command exits with a non-zero status.
+        set -e
+
+        # if the images location existed in the build hook, it was converted to a symlink. we now to need to make sure
+        # the target of the symlink exists, and then rsync any new files to the writable location
+        if [ -L public/typo3conf/ext/introduction/Initialisation/Files/images ]; then
+            #make sure our images directory exists in var mount
+            if [ ! -d var/images ]; then
+                mkdir -p var/images
+                echo "This directory is symlinked to public/typo3conf/ext/introduction/Initialisation/Files/images/. Do not delete." >> var/images/readme.txt
+            fi
+
+            #rsync any new files from imagestemp into var/images
+            rsync -a --ignore-existing imagestemp/ var/images
+        fi
+
+        # Set TYPO3 site defaults on first deploy.
+        if [ ! -f var/platformsh.installed ]; then
+            # Copy the created LocalConfiguration into the writable location.
+            cp public/typo3conf/LocalConfiguration.FromSource.php var/LocalConfiguration.php
+
+            # On first install, create an inital admin user with a default password.
+            # *CHANGE THIS VALUE IMMEDIATELY AFTER INSTALLATION*
+            php vendor/bin/typo3cms install:setup \
+                --install-steps-config=src/SetupDatabase.yaml \
+                --site-setup-type=no \
+                --site-name="TYPO3 on Platform.sh" \
+                --admin-user-name=admin \
+                --admin-password=password \
+                --skip-extension-setup \
+                --no-interaction
+
+            # Sets up all extensions that are marked as active in the system.
+            php vendor/bin/typo3cms extension:setupactive || true
+
+            # Create file that indicates first deploy and installation has been completed.
+            touch var/platformsh.installed
+        fi;
+
+crons:
+     # Run TYPO3's Scheduler tasks every 5 minutes.
+    typo3:
+        spec: "*/5 * * * *"
+        commands:
+            start: "vendor/bin/typo3 scheduler:run"
+
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/wordpress-composer
+++ b/sites/platform/static/files/fetch/appyaml/wordpress-composer
@@ -1,0 +1,128 @@
+# Complete list of all available properties: https://docs.platform.sh/create-apps/app-reference.html
+
+# A unique name for the app. Must be lowercase alphanumeric characters. Changing the name destroys data associated
+# with the app.
+name: app
+
+# The runtime the application uses.
+# Complete list of available runtimes: https://docs.platform.sh/create-apps/app-reference.html#types
+type: 'php:8.1'
+
+# Specifies a default set of build tasks to run. Flavors are language-specific.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#build
+build:
+    flavor: composer
+
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
+dependencies:
+    php:
+        composer/composer: '^2'
+        wp-cli/wp-cli-bundle: "^2.4.0"
+
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages
+# More info:
+hooks:
+    # The build hook is run after any build flavor.
+    # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
+    build: |
+        set -e
+        # Copy manually-provided plugins into the plugins directory.
+        # This allows manually-provided and composer-provided plugins to coexist.
+        rsync -a plugins/* wordpress/wp-content/plugins/
+
+    # The deploy hook is run after the app container has been started, but before it has started accepting requests.
+    # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook
+    deploy: |
+        # Flushes the object cache which might have changed between current production and newly deployed changes
+        wp cache flush
+        # Runs the WordPress database update procedure in case core is being updated with the newly deployed changes
+        wp core update-db
+        # Runs all cron events that are due now and may have come due during the build+deploy procedure
+        wp cron event run --due-now
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#relationships
+relationships:
+    database: "db:mysql"
+
+# The web key configures the web server running in front of your app.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#web
+web:
+    # Each key in locations is a path on your site with a leading /.
+    # More information: https://docs.platform.sh/create-apps/app-reference.html#locations
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "wordpress"
+            # The front-controller script to send non-static requests to.
+            passthru: "/index.php"
+            # Wordpress has multiple roots (wp-admin) so the following is required
+            index:
+                - "index.php"
+            # The number of seconds whitelisted (static) content should be cached.
+            expires: 600
+            scripts: true
+            allow: true
+            # The key of each item in rules is a regular expression to match paths exactly. If an incoming request
+            # matches the rule, it’s handled by the properties under the rule, overriding any conflicting rules from the
+            # rest of the locations properties.
+            # More information: https://docs.platform.sh/create-apps/app-reference.html#rules
+            rules:
+                ^/composer\.json:
+                    allow: false
+                ^/license\.txt$:
+                    allow: false
+                ^/readme\.html$:
+                    allow: false
+        "/wp-content/cache":
+            root: "wordpress/wp-content/cache"
+            scripts: false
+            allow: false
+        "/wp-content/uploads":
+            root: "wordpress/wp-content/uploads"
+            scripts: false
+            allow: false
+            rules:
+                # Allow access to common static files.
+                '(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$':
+                    allow: true
+                    expires: 1w
+
+# The size of the persistent disk of the application (in MB). Minimum value is 128.
+disk: 2048
+
+# Mounts define directories that are writable after the build is complete. If set as a local source, disk property is required.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#mounts
+mounts:
+    "wordpress/wp-content/cache":
+        source: local
+        source_path: "cache"
+    "wordpress/wp-content/uploads":
+        source: local
+        source_path: "uploads"
+
+# More information: https://docs.platform.sh/create-apps/app-reference.html#extensions 
+runtime:
+    extensions:
+        - blackfire
+
+########################################################################################################################
+##                                                                                                                    ##
+## This source operation is part of the Platform.sh process of updating and maintaining our collection of templates.  ##
+## For more information see https://docs.platform.sh/create-apps/source-operations.html and                           ##
+## https://github.com/platformsh/source-operations                                                                    ##
+##                                                                                                                    ##
+##                  YOU CAN SAFELY DELETE THIS COMMENT AND THE LINES BENEATH IT                                       ##
+##                                                                                                                    ##
+########################################################################################################################
+source:
+  operations:
+    auto-update:
+      command: |
+        curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 sop-autoupdate; } 3<&0

--- a/sites/platform/static/files/fetch/appyaml/wordpress-vanilla
+++ b/sites/platform/static/files/fetch/appyaml/wordpress-vanilla
@@ -1,0 +1,105 @@
+# This file describes an application. You can have multiple applications
+# in the same project.
+
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses.
+type: "php:8.1"
+
+dependencies:
+    php:
+        wp-cli/wp-cli-bundle: "^2.4"
+        psy/psysh: "^0.10.4"
+
+# The relationships of the application with services or other applications.
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form `<service name>:<endpoint name>`.
+relationships:
+    database: "db:mysql"
+
+variables:
+    php:
+        session.gc_maxlifetime: '200000'
+        session.cookie_lifetime: '2000000'
+        pcre.backtrack_limit: '200000'
+        pcre.recursion_limit: '200000'
+
+# The configuration of app when it is exposed to the web.
+web:
+    locations:
+        "/":
+            # The public directory of the app, relative to its root.
+            root: "wordpress"
+            # The front-controller script to send non-static requests to.
+            passthru: "/index.php"
+            # Wordpress has multiple roots (wp-admin) so the following is required
+            index:
+                - "index.php"
+            # The number of seconds whitelisted (static) content should be cached.
+            expires: 600
+            scripts: true
+            allow: true
+            rules:
+                ^/composer\.json:
+                    allow: false
+                ^/license\.txt$:
+                    allow: false
+                ^/readme\.html$:
+                    allow: false
+        "/wp-content/cache":
+            root: "wordpress/wp-content/cache"
+            scripts: false
+            allow: false
+        "/wp-content/uploads":
+            root: "wordpress/wp-content/uploads"
+            scripts: false
+            allow: false
+            rules:
+                # Allow access to common static files.
+                '(?<!\-lock)\.(?i:jpe?g|gif|png|svg|bmp|ico|css|js(?:on)?|eot|ttf|woff|woff2|pdf|docx?|xlsx?|pp[st]x?|psd|odt|key|mp[2-5g]|m4[av]|og[gv]|wav|mov|wm[av]|avi|3g[p2])$':
+                    allow: true
+                    expires: 1w
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    "wordpress/wp-content/cache":
+        source: local
+        source_path: "cache"
+    "wordpress/wp-content/uploads":
+        source: local
+        source_path: "uploads"
+
+hooks:
+    deploy: |
+        wp cache flush
+        wp core update-db
+        wp cron event run --due-now
+
+source:
+    operations:
+        auto-update:
+            command: |
+                # get our pub directory as defined in the application
+                pubDir=$(echo $PLATFORM_APPLICATION | base64 --decode | jq -r '.web.locations."/".root')
+                # grab the latest version of WordPress, save locally based on pubDir name
+                curl https://wordpress.org/latest -o "${PLATFORM_CACHE_DIR}/${pubDir}.tar.gz"
+                cd "${PLATFORM_CACHE_DIR}"
+                tar -xvf "${pubDir}.tar.gz" && rm "${pubDir}.tar.gz"
+                # the archive always expands into a "wordpress" directory
+                rsync -av wordpress/ "${PLATFORM_SOURCE_DIR}/${pubDir}"
+                cd "${PLATFORM_SOURCE_DIR}"
+                git add --all
+                confirm=$(git status --porcelain=1);
+                if [ -z "${confirm}" ]; then
+                    echo "No changes to commit."
+                else
+                    git commit -m "Auto updated via source operations" 
+                fi
+                
+                
+

--- a/sites/platform/static/files/fetch/multiappyaml/gatsby-drupal
+++ b/sites/platform/static/files/fetch/multiappyaml/gatsby-drupal
@@ -1,0 +1,85 @@
+# The name of this app. Must be unique within a project.
+name: gatsby
+
+type: 'nodejs:14'
+
+variables:
+    env:
+        NODE_OPTIONS: --max-old-space-size=1536
+        GENERATED_VARS: 'deploy/platformsh.environment'
+
+size: L
+
+resources:
+    base_memory: 1024
+    memory_ratio: 1024
+
+dependencies:
+    nodejs:
+        # yarn: "1.22.17"
+        pm2: "5.2.0"
+
+hooks:
+    post_deploy: |
+        # Verify the connection to the backend can be made with those variables.
+        if [ -f "$GENERATED_VARS" ]; then
+            # Source environment variables, build the frontend, and start the server.
+            . $GENERATED_VARS
+        else 
+              printf "In %s, %s is not available, therefore I could not source" "web:commands:start" "${GENERATED_VARS}"
+        fi
+        # Gatsby clean on a RO-filesystem
+        rm -rf .cache/* && rm -rf public/*
+        npm run build -- --no-color
+
+web:
+    commands:
+        start: |
+            # npm run serve -- -p $PORT --no-color
+
+            if [ -f "$GENERATED_VARS" ]; then
+                # Source environment variables, build the frontend, and start the server.
+                . $GENERATED_VARS            
+            else 
+              printf "In %s, %s is not available, therefore I could not source" "web:commands:start" "${GENERATED_VARS}"
+            fi
+            APP=$(cat package.json | jq -r '.name')
+            pm2 start npm --no-daemon --watch --name $APP -- run serve -- -p $PORT --no-color
+            #pm2 start npm --no-daemon --watch --name $APP -- run develop -- -p $PORT --no-color
+
+
+
+            # Maybe since we're foregoing the first deploy, yarn start is good enough.
+            # if [ -f "$GENERATED_VARS" ]; then
+            #     # Source environment variables, build the frontend, and start the server.
+            #     # . $GENERATED_VARS
+            #     npm run clean
+            #     npm run build
+            #     npm run serve
+            #     # APP=$(cat package.json | jq -r '.name')
+            #     # pm2 start npm --no-daemon --watch --name $APP -- preview -- -p $PORT
+            # else
+            #     # On the first deploy, display next steps page.
+            #     node first_deploy.js
+            # fi
+
+
+disk: 512
+
+mounts:
+    /.cache:
+        source: local
+        source_path: 'cache'
+    /.config:
+        source: local
+        source_path: 'config'
+    /.pm2:
+        source: local
+        source_path: 'pm2'
+    public:
+        source: local
+        source_path: 'public'
+    deploy:
+        source: service
+        service: files
+        source_path: deploy

--- a/sites/platform/static/files/fetch/multiappyaml/gatsby-strapi
+++ b/sites/platform/static/files/fetch/multiappyaml/gatsby-strapi
@@ -1,0 +1,39 @@
+# .platform.app.yaml
+
+# The name of this application, which must be unique within a project.
+name: gatsby
+
+# The type key specifies the language and version for your application.
+type: 'nodejs:14'
+
+# The hooks that will be triggered when the package is deployed.
+hooks:
+    # Build hooks can modify the application files on disk but not access any services like databases.
+    post_deploy: |
+      npm run build
+# The size of the persistent disk of the application (in MB).
+disk: 1024
+
+relationships:
+   strapi: "strapi:http"
+
+# The configuration of the application when it is exposed to the web.
+web:
+    locations:
+        '/':
+            # The public directory of the application relative to its root.
+            root: 'public'
+            index: ['index.html']
+            scripts: false
+            allow: true
+
+mounts:
+  '/.cache':
+      source: local
+      source_path: cache
+  '/.config':
+      source: local
+      source_path: config
+  'public':
+      source: local
+      source_path: public

--- a/sites/platform/static/files/fetch/multiappyaml/gatsby-wordpress
+++ b/sites/platform/static/files/fetch/multiappyaml/gatsby-wordpress
@@ -1,0 +1,45 @@
+# .platform.app.yaml
+
+# The name of this application, which must be unique within a project.
+name: 'gatsby'
+
+# The type key specifies the language and version for your application.
+type: 'nodejs:14'
+
+# Restrict Yarn memory use when running during post deploy hook.
+variables:
+    env:
+        NODE_OPTIONS: --max_old_space_size=1536
+
+# The hooks that will be triggered when the package is deployed.
+hooks:
+    # Post deploy hook builds Gatsby frontend now that backend content is available.
+    post_deploy: |
+        npm run build
+
+relationships:
+    wordpress: "wordpress:http"
+
+# The size of the persistent disk of the application (in MB).
+disk: 1280
+
+# The configuration of the application when it is exposed to the web.
+web:
+    locations:
+        '/':
+            # The public directory of the application relative to its root.
+            root: 'public'
+            index: ['index.html']
+            scripts: false
+            allow: true
+
+mounts:
+  '/.cache':
+      source: local
+      source_path: cache
+  '/.config':
+      source: local
+      source_path: config
+  'public':
+      source: local
+      source_path: public

--- a/sites/platform/static/files/fetch/routesyaml/django4
+++ b/sites/platform/static/files/fetch/routesyaml/django4
@@ -1,0 +1,14 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+# More information: https://docs.platform.sh/define-routes.html
+"https://{default}/":
+  type: upstream
+  upstream: "app:http"
+
+# A basic redirect definition
+# More information: https://docs.platform.sh/define-routes.html#basic-redirect-definition
+"https://www.{default}/":
+  type: redirect
+  to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/drupal10
+++ b/sites/platform/static/files/fetch/routesyaml/drupal10
@@ -1,0 +1,17 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+    type: upstream
+    upstream: "drupal:http"
+    cache:
+      enabled: true
+
+      # Base the cache on the session cookie and custom Drupal cookies. Ignore all other cookies.
+      cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/drupal9
+++ b/sites/platform/static/files/fetch/routesyaml/drupal9
@@ -1,0 +1,17 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+    type: upstream
+    upstream: "drupal:http"
+    cache:
+      enabled: true
+
+      # Base the cache on the session cookie and custom Drupal cookies. Ignore all other cookies.
+      cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/gatsby
+++ b/sites/platform/static/files/fetch/routesyaml/gatsby
@@ -1,0 +1,8 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+# More information: https://docs.platform.sh/define-routes.html
+"https://{default}/":
+  type: upstream
+  upstream: "app:http"

--- a/sites/platform/static/files/fetch/routesyaml/gatsby-drupal
+++ b/sites/platform/static/files/fetch/routesyaml/gatsby-drupal
@@ -1,0 +1,19 @@
+https://api.{default}/:
+  type: upstream
+  upstream: "drupal:http"
+  id: "api"
+  cache:
+    enabled: true
+    cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
+https://www.api.{default}/:
+  type: redirect
+  to: "https://api.{default}/"
+
+"https://www.{default}/":
+    type: upstream
+    upstream: "gatsby:http"
+    primary: true
+
+"https://{default}/":
+    type: redirect
+    to: "https://www.{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/gatsby-strapi
+++ b/sites/platform/static/files/fetch/routesyaml/gatsby-strapi
@@ -1,0 +1,21 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://www.{default}/":
+    type: upstream
+    upstream: "gatsby:http"
+
+"https://{default}/":
+    type: redirect
+    to: "https://www.{default}/"
+
+"https://www.backend.{default}/":
+    type: upstream
+    upstream: "strapi:http"
+
+"https://backend.{default}/":
+    type: redirect
+    id: 'strapi'
+    to: "https://www.backend.{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/gatsby-wordpress
+++ b/sites/platform/static/files/fetch/routesyaml/gatsby-wordpress
@@ -1,0 +1,21 @@
+"https://www.{default}/":
+  type: upstream
+  upstream: "gatsby:http"
+
+"https://{default}/":
+    type: redirect
+    to: "https://www.{default}/"
+
+"https://backend.{default}/":
+    type: upstream
+    upstream: "wordpress:http"
+    cache:
+        enabled: true
+        # Base the cache on the session cookies. Ignore all other cookies.
+        cookies:
+            - '/^wordpress_logged_in_/'
+            - '/^wordpress_sec_/'
+            - 'wordpress_test_cookie'
+            - '/^wp-settings-/'
+            - '/^wp-postpass/'
+            - '/^wp-resetpass-/'

--- a/sites/platform/static/files/fetch/routesyaml/laravel
+++ b/sites/platform/static/files/fetch/routesyaml/laravel
@@ -1,0 +1,11 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://www.{default}/":
+    type: upstream
+    upstream: "app:http"
+"https://{default}/":
+    type: redirect
+    to: "https://www.{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/micronaut
+++ b/sites/platform/static/files/fetch/routesyaml/micronaut
@@ -1,0 +1,12 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+  type: upstream
+  upstream: "app:http"
+
+"https://www.{default}/":
+  type: redirect
+  to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/php
+++ b/sites/platform/static/files/fetch/routesyaml/php
@@ -1,0 +1,12 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/platformsh-symfony-template
+++ b/sites/platform/static/files/fetch/routesyaml/platformsh-symfony-template
@@ -1,0 +1,2 @@
+"https://{all}/": { type: upstream, upstream: "app:http" }
+"http://{all}/": { type: redirect, to: "https://{all}/" }

--- a/sites/platform/static/files/fetch/routesyaml/quarkus
+++ b/sites/platform/static/files/fetch/routesyaml/quarkus
@@ -1,0 +1,12 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+  type: upstream
+  upstream: "app:http"
+
+"https://www.{default}/":
+  type: redirect
+  to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/spring-mvc-maven-mongodb
+++ b/sites/platform/static/files/fetch/routesyaml/spring-mvc-maven-mongodb
@@ -1,0 +1,12 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+  type: upstream
+  upstream: "app:http"
+
+"https://www.{default}/":
+  type: redirect
+  to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/strapi4
+++ b/sites/platform/static/files/fetch/routesyaml/strapi4
@@ -1,0 +1,14 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+# More information: https://docs.platform.sh/define-routes.html
+"https://www.{default}/":
+  type: upstream
+  upstream: "app:http"
+
+# A basic redirect definition
+# More information: https://docs.platform.sh/define-routes.html#basic-redirect-definition
+"https://{default}/":
+  type: redirect
+  to: "https://www.{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/typo3
+++ b/sites/platform/static/files/fetch/routesyaml/typo3
@@ -1,0 +1,37 @@
+# This file describes an application's routes. You can define as many routes as your
+# application requires.
+#
+# See https://docs.platform.sh/configuration/routes.html
+
+# URL template for the main route, where `{default}` is replaced by
+# the Platform.sh generated environment URL or the configured domain.
+"https://{default}/":
+    # This route serves an application (upstream).
+    type: upstream
+
+    # Defines the upstream according to the form `<application-name>:http`,
+    # where the `name` attribute from `.platform.app.yaml` is used.
+    upstream: "app:http"
+
+    # Optional route identifier; constant across all environments. 
+    # 
+    # For TYPO3, the id "main" is used within `public/typo3conf/PlatformshConfig.php` 
+    # to set the `base` attribute for the site (in `config/sites/main/config.yaml`) from the 
+    # Platform.sh environment variable `PLATFORM_ROUTES`.
+    id: "main"
+
+    # HTTP cache configuration.
+    cache:
+        # Enabled (default `true`, but only if `cache` attribute is unspecified).
+        enabled: true
+
+        # List of allowed cookie names, all others are ignored. 
+        cookies:
+          # Used to identify a backend session when Backend User logged in.
+          - 'be_typo_user'
+          # Used to identify session ID when logged into TYPO3 Frontend.
+          - 'fe_typo_user'
+          # Default PHP session cookie.
+          - 'PHPSESSID'
+          # Validates sessions for System Maintenance Area.
+          - 'Typo3InstallTool'

--- a/sites/platform/static/files/fetch/routesyaml/wordpress-composer
+++ b/sites/platform/static/files/fetch/routesyaml/wordpress-composer
@@ -1,0 +1,28 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+# More information: https://docs.platform.sh/define-routes.html
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+    # Platform.sh supports HTTP caching at the server level. Caching is enabled by default, but is only applied to
+    # GET and HEAD requests.
+    # More information: https://docs.platform.sh/define-routes/cache.html
+    cache:
+        # All possible cache configuration options: https://docs.platform.sh/define-routes/cache.html#cache-configuration-properties
+        enabled: true
+        # Base the cache on the session cookies. Ignore all other cookies.
+        cookies:
+            - '/^wordpress_logged_in_/'
+            - '/^wordpress_sec_/'
+            - 'wordpress_test_cookie'
+            - '/^wp-settings-/'
+            - '/^wp-postpass/'
+            - '/^wp-resetpass-/'
+
+# A basic redirect definition
+# More information: https://docs.platform.sh/define-routes.html#basic-redirect-definition
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/sites/platform/static/files/fetch/routesyaml/wordpress-vanilla
+++ b/sites/platform/static/files/fetch/routesyaml/wordpress-vanilla
@@ -1,0 +1,22 @@
+# The routes of the project.
+#
+# Each route describes how an incoming URL is going
+# to be processed by Platform.sh.
+
+"https://{default}/":
+    type: upstream
+    upstream: "app:http"
+    cache:
+        enabled: true
+        # Base the cache on the session cookies. Ignore all other cookies.
+        cookies:
+            - '/^wordpress_logged_in_/'
+            - '/^wordpress_sec_/'
+            - 'wordpress_test_cookie'
+            - '/^wp-settings-/'
+            - '/^wp-postpass/'
+            - '/^wp-resetpass-/'
+
+"https://www.{default}/":
+    type: redirect
+    to: "https://{default}/"

--- a/sites/platform/static/files/fetch/servicesyaml/django4
+++ b/sites/platform/static/files/fetch/servicesyaml/django4
@@ -1,0 +1,9 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+# More information: https://docs.platform.sh/add-services.html
+# Full list of available services: https://docs.platform.sh/add-services.html#available-services
+db:
+  type: postgresql:12
+  disk: 1024

--- a/sites/platform/static/files/fetch/servicesyaml/drupal10
+++ b/sites/platform/static/files/fetch/servicesyaml/drupal10
@@ -1,0 +1,11 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+
+db:
+    type: mariadb:10.4
+    disk: 2048
+
+cache:
+    type: redis:6.0

--- a/sites/platform/static/files/fetch/servicesyaml/gatsby-drupal
+++ b/sites/platform/static/files/fetch/servicesyaml/gatsby-drupal
@@ -1,0 +1,15 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+
+db:
+    type: mariadb:10.4
+    disk: 2048
+
+cache:
+    type: redis:5.0
+
+files:
+  type: network-storage:1.0
+  disk: 256

--- a/sites/platform/static/files/fetch/servicesyaml/gatsby-strapi
+++ b/sites/platform/static/files/fetch/servicesyaml/gatsby-strapi
@@ -1,0 +1,8 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+
+dbpostgres:
+    type: postgresql:12
+    disk: 256

--- a/sites/platform/static/files/fetch/servicesyaml/gatsby-wordpress
+++ b/sites/platform/static/files/fetch/servicesyaml/gatsby-wordpress
@@ -1,0 +1,3 @@
+db:
+    type: mariadb:10.4
+    disk: 512

--- a/sites/platform/static/files/fetch/servicesyaml/platformsh-symfony-template
+++ b/sites/platform/static/files/fetch/servicesyaml/platformsh-symfony-template
@@ -1,0 +1,4 @@
+
+database:
+    type: postgresql:15
+    disk: 1024

--- a/sites/platform/static/files/fetch/servicesyaml/typo3
+++ b/sites/platform/static/files/fetch/servicesyaml/typo3
@@ -1,0 +1,21 @@
+# This file describes an application's services. You can define as many services as your
+# application requires, subject to your plan's resource restrictions.
+#
+# See https://docs.platform.sh/configuration/services.html.
+
+# MariaDB/MySQL 10.4 service with 2048MB of allocated disk.
+# The service name `db` is used in defining the `database` relationship in the
+# `.platform.app.yaml` file.
+# 
+# See https://docs.platform.sh/configuration/services/mysql.html.
+db:
+    type: mysql:10.4
+    disk: 2048
+
+# Redis 5.0 service definition. 
+# The service name `cache` is used in defining the `rediscache` relationship in the
+# `.platform.app.yaml` file.
+# 
+# See https://docs.platform.sh/configuration/services/redis.html.
+cache:
+    type: redis:5.0

--- a/sites/platform/static/files/fetch/servicesyaml/wordpress-composer
+++ b/sites/platform/static/files/fetch/servicesyaml/wordpress-composer
@@ -1,0 +1,9 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+# More information: https://docs.platform.sh/add-services.html
+# Full list of available services: https://docs.platform.sh/add-services.html#available-services
+db:
+    type: mariadb:10.4
+    disk: 2048

--- a/sites/platform/static/files/fetch/servicesyaml/wordpress-vanilla
+++ b/sites/platform/static/files/fetch/servicesyaml/wordpress-vanilla
@@ -1,0 +1,8 @@
+# The services of the project.
+#
+# Each service listed will be deployed
+# to power your Platform.sh project.
+
+db:
+    type: mariadb:10.4
+    disk: 2048


### PR DESCRIPTION
## Why
PR 4207 disabled the dynamic retrieval of example config files. As such, those are now showing as blank in the docs. This adds these example config files as static files. 

Closes #4362 


