### PR TITLE
4395 adjust markdown button location

### DIFF
--- a/sites/upsun/src/get-started/stacks/_index.md
+++ b/sites/upsun/src/get-started/stacks/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Frameworks
+title: How to deploy
 weight: -80
 layout: single
 # aliases:

--- a/themes/psh-docs/layouts/partials/editpagebutton.html
+++ b/themes/psh-docs/layouts/partials/editpagebutton.html
@@ -1,7 +1,7 @@
 <!-- Edit page button link -->
 <div class="hidden md:block mb-6 mr-2 text-right">
   {{ $editLocation := printf "%sedit/main/%s/src/%s" site.Params.repo site.Params.folder .File.Path }}
-  <a href="{{ $editLocation }}" rel="noopener" class="print:hidden font-semibold bg-gray-400 text-white hover:bg-ebony focus:bg-ebony pl-4 pr-3 py-2 font-['Space_Grotesk'] text-xs rounded-full inline-flex items-center gap-2">
+  <a href="{{ $editLocation }}" rel="noopener" target="_blank" class="print:hidden font-semibold bg-gray-400 text-white hover:bg-ebony focus:bg-ebony pl-4 pr-3 py-2 font-['Space_Grotesk'] text-xs rounded-full inline-flex items-center gap-2">
     
     Edit page<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline">
       <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/>

--- a/themes/psh-docs/layouts/partials/page-content.html
+++ b/themes/psh-docs/layouts/partials/page-content.html
@@ -18,9 +18,24 @@
 <!-- If the feature is in beta -->
 {{ partial "beta-flag/banner.html" .context }}
 
-{{ if ne .context.Params.editPage false }}
-  {{ partial "editpagebutton.html" .context }}
-{{ end }}
+<div class="flex justify-end mr-4">
+  <!-- Add a Button to open the Markdown version of this page (Upsun only) -->
+  {{ if ( eq .context.Site.Params.vendor.config.version 2 ) }}
+  <div class="hidden md:block mb-6 mr-2 text-right">
+    <a href="{{ if eq .context.Page.RelPermalink "/" }}/index.md{{ else }}{{ .context.Page.RelPermalink | replaceRE ".html" ".md" }}{{ end }}"
+        class="print:hidden font-semibold bg-skye text-white hover:bg-skye-dark focus:bg-skye-dark px-4 py-2 font-['Space_Grotesk'] text-xs rounded-full inline-flex items-center gap-2"
+        title="Open this page in a markdown format. This format is easier for AI and other tools to read."
+        target="_blank">
+      View in markdown
+    </a>
+  </div>
+  {{ end }}
+
+  <!-- Edit page button link -->
+  {{ if ne .context.Params.editPage false }}
+    {{ partial "editpagebutton.html" .context }}
+  {{ end }}
+</div>
 
 <!-- Page title -->
 {{ if ne .context.Params.showTitle false }}
@@ -102,17 +117,6 @@
     </div>
     {{ end }}
 
-    <!-- Add a Button to open the Markdown version of this page (Upsun only) -->
-    {{ if ( eq .context.Site.Params.vendor.config.version 2 ) }}
-      <div class="justify-start border border-stone border-t-0 px-4 pt-10 pb-4 mb-12 md:mb-0 bottom-0 text-sm [&_a]:text- hover:[&_a]:underline focus:[&_a]:underline [&_ul_ul]:pl-4">
-        <a href="{{ if eq .context.Page.RelPermalink "/" }}/index.md{{ else }}{{ .context.Page.RelPermalink | replaceRE ".html" ".md" }}{{ end }}"
-           class="px-6 py-2 bg-[#6046FF] hover:!bg-[#4D38CC] rounded-3xl text-white text-center text-sm font-semibold"
-           title="View this page in a Markdown format"
-           target="_blank">
-          View Markdown version
-        </a>
-      </div>
-    {{ end }}
   </div>
 
   <div class="prose xl:prose-lg max-w-[96vw] md:max-w-full w-full prose-code:!mb-0 prose-h2:text-xl prose-h3:text-xl prose-h4:text-lg">

--- a/themes/psh-docs/layouts/partials/page-content.html
+++ b/themes/psh-docs/layouts/partials/page-content.html
@@ -20,7 +20,7 @@
 
 <div class="flex justify-end mr-4">
   <!-- Add a Button to open the Markdown version of this page (Upsun only) -->
-  {{ if ( eq .context.Site.Params.vendor.config.version 2 ) }}
+  {{ if and ( eq .context.Site.Params.vendor.config.version 2 ) ( ne .context.Page.RelPermalink "/" ) }}
   <div class="hidden md:block mb-6 mr-2 text-right">
     <a href="{{ if eq .context.Page.RelPermalink "/" }}/index.md{{ else }}{{ .context.Page.RelPermalink | replaceRE ".html" ".md" }}{{ end }}"
         class="print:hidden font-semibold bg-skye text-white hover:bg-skye-dark focus:bg-skye-dark px-4 py-2 font-['Space_Grotesk'] text-xs rounded-full inline-flex items-center gap-2"

--- a/themes/psh-docs/layouts/partials/sidebar/nav.html
+++ b/themes/psh-docs/layouts/partials/sidebar/nav.html
@@ -29,7 +29,7 @@
   {{ if $isHome }}
     {{ $inCurrentSection = false }}
   {{ end }}
-  <div x-data="{ expanded: {{ $inCurrentSection }} }">
+  <div x-data="{ expanded: {{ or $inCurrentSection (eq .section "home") }} }">
     <h3 class="font-semibold">
       <button class="bg-no-repeat bg-right-2 w-[95%] py-4 pl-2 pr-6 my-2 text-left bg-grey" :style="expanded ? 'background-image: url(/images/icons/minus.svg);' : 'background-image: url(/images/icons/add.svg);'" @click="expanded = ! expanded" aria-controls="section-{{ .section }}" aria-expanded="{{ $inCurrentSection }}">
         {{ .title }}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #4395

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

- moved markdown button to declutter
- expanded navbar for more visibility and quicker navigation
- rename Frameworks in Getting Started to "How to deploy" to reduce confusion and better direct users

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
