### PR TITLE
:memo: Update mTLS docs with request option

### DIFF
--- a/sites/platform/src/define-routes/https.md
+++ b/sites/platform/src/define-routes/https.md
@@ -158,3 +158,16 @@ tls:
       ### Several lines of different characters here ###
       -----END CERTIFICATE-----
 ```
+
+If you want to request a client certificate without _requiring_ the client to send one, you can set this by using `request` as a value for `client_authentication`:
+
+```yaml {configFile="routes"}
+routes:
+  "https://{default}/":
+    # ...
+    tls:
+      client_authentication: "request"
+    # ...
+```
+
+Requests on routes with mTLS configured that are passed through to your app will contain additional headers such as `X-Client-Verify` (with values like `Success` or `None` depending on whether a client certificate was presented and validated or not) and `X-Client-Cert` (with information about the client certificate that was used) that your application can use as required.

--- a/sites/upsun/src/define-routes/https.md
+++ b/sites/upsun/src/define-routes/https.md
@@ -174,3 +174,16 @@ routes:
           ### Several lines of different characters here ###
           -----END CERTIFICATE-----
 ```
+
+If you want to request a client certificate without _requiring_ the client to send one, you can set this by using `request` as a value for `client_authentication`:
+
+```yaml {configFile="routes"}
+routes:
+  "https://{default}/":
+    # ...
+    tls:
+      client_authentication: "request"
+    # ...
+```
+
+Requests on routes with mTLS configured that are passed through to your app will contain additional headers such as `X-Client-Verify` (with values like `Success` or `None` depending on whether a client certificate was presented and validated or not) and `X-Client-Cert` (with information about the client certificate that was used) that your application can use as required.


### PR DESCRIPTION

## Why
In addition to require, request can also be used as an option for mTLS. This wasn't documented so far. This change adds this information.

Additional headers are also added to a request where mTLS was used, which are now mentioned in a note.

## What's changed
Added information on the above to both the relevant Upsun and PSH doc pages.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
