### PR TITLE
HTTP Status code clarification for redirections

### DIFF
--- a/sites/platform/src/define-routes/redirects.md
+++ b/sites/platform/src/define-routes/redirects.md
@@ -17,6 +17,7 @@ https://{default}/:
   type: redirect
   to: https://www.{default}/
 ```
+The default HTTP status code for Whole-route redirects is `301`. See [Specify a HTTP status code](#specify-a-http-status-code) to change the status code that is used.
 
 ## Partial redirects
 
@@ -35,7 +36,7 @@ https://{default}/:
         regexp: true
 ```
 
-This format is richer and works with any type of route, including routes served directly by the application.
+This format is richer and works with any type of route, including routes served directly by the application. The default HTTP status code for partial redirects is `302`. See [Specify a HTTP status code](#specify-a-http-status-code) to change the status code that is used.
 
 Two keys are available under `redirects`:
 
@@ -56,7 +57,7 @@ The value object is defined with the following keys:
 | `regexp`           | No       | `false` | Specifies whether the path key should be interpreted as a PCRE regular expression. If you use a capturing group, the replace field (`$1`) has to come after a slash (`/`). [More information](#redirects-using-regular-expressions).|
 | `prefix`           | No       | `true`, but not supported if `regexp` is `true` | Specifies whether both the path and all its children or just the path itself should be redirected. [More information](#redirects-using-prefix-and-append_suffix).|
 | `append_suffix`    | No       | `true`, but not supported if `regexp` is `true` or if `prefix` is `false`  | Determines if the suffix is carried over with the redirect. [More information](#redirects-using-prefix-and-append_suffix).|
-| `code`             | No       | n/a     | HTTP status code. Valid status codes are `301`, `302`, `307`, and `308`. Defaults to `302`. [More information](#specify-a-http-status-code). |
+| `code`             | No       | n/a     | HTTP status code. Valid status codes are `301`, `302`, `307`, and `308`. Defaults to `302` for [Partial redirects](#partial-redirects), and `301` for [Whole-route redirects](#whole-route-redirects). [More information](#specify-a-http-status-code). |
 | `expires`          | No       | Defaults to the `expires` value defined directly under the `redirects` key, but can be fine-tuned. To [disable caching on a specific redirect](#disable-caching-on-your-redirects), set `expires` to `0`. | The duration the redirect is cached for. [More information](#manage-caching).
 
 To set up partial redirects, you can use regular expressions (`regexp`).</br>

--- a/sites/platform/src/define-routes/redirects.md
+++ b/sites/platform/src/define-routes/redirects.md
@@ -234,7 +234,7 @@ A request to `/from/some/path` (and any path after `/from`) redirects to just `/
 
 ### Specify a HTTP status code
 
-To set a specific HTTP status code for your redirect, use the `codes` key:
+To set a specific HTTP status code for your redirect, use the `code` key:
 
 ```yaml {configFile="routes"}
 https://{default}/:

--- a/sites/upsun/src/define-routes/redirects.md
+++ b/sites/upsun/src/define-routes/redirects.md
@@ -18,6 +18,7 @@ routes:
     type: redirect
     to: https://www.{default}/
 ```
+The default HTTP status code for Whole-route redirects is `301`. See [Specify a HTTP status code](#specify-a-http-status-code) to change the status code that is used.
 
 ## Partial redirects
 
@@ -37,7 +38,7 @@ routes:
           regexp: true
 ```
 
-This format is richer and works with any type of route, including routes served directly by the application.
+This format is richer and works with any type of route, including routes served directly by the application. The default HTTP status code for partial redirects is `302`. See [Specify a HTTP status code](#specify-a-http-status-code) to change the status code that is used.
 
 Two keys are available under `redirects`:
 
@@ -52,13 +53,13 @@ Each rule under `paths` is defined by a key describing:
 
 The value object is defined with the following keys:
 
-| Key                | Required | Default |Description |
-| ------------------ | -------- | ----------- | ------------- |
-| `to`               | Yes      | n/a     | A relative URL - `'/destination'`, or absolute URL - `'https://example.com/'`. |
-| `regexp`           | No       | `false` | Specifies whether the path key should be interpreted as a PCRE regular expression. If you use a capturing group, the replace field (`$1`) has to come after a slash (`/`). [More information](#redirects-using-regular-expressions).|
-| `prefix`           | No       | `true`, but not supported if `regexp` is `true` | Specifies whether both the path and all its children or just the path itself should be redirected. [More information](#redirects-using-prefix-and-append_suffix).|
-| `append_suffix`    | No       | `true`, but not supported if `regexp` is `true` or if `prefix` is `false`  | Determines if the suffix is carried over with the redirect. [More information](#redirects-using-prefix-and-append_suffix).|
-| `code`             | No       | n/a     | HTTP status code. Valid status codes are `301`, `302`, `307`, and `308`. Defaults to `302`. [More information](#specify-a-http-status-code). |
+| Key                | Required | Default | Description                                                                                                                                                                                                                                      |
+| ------------------ | -------- | ----------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `to`               | Yes      | n/a     | A relative URL - `'/destination'`, or absolute URL - `'https://example.com/'`.                                                                                                                                                                   |
+| `regexp`           | No       | `false` | Specifies whether the path key should be interpreted as a PCRE regular expression. If you use a capturing group, the replace field (`$1`) has to come after a slash (`/`). [More information](#redirects-using-regular-expressions).             |
+| `prefix`           | No       | `true`, but not supported if `regexp` is `true` | Specifies whether both the path and all its children or just the path itself should be redirected. [More information](#redirects-using-prefix-and-append_suffix).                                                                                |
+| `append_suffix`    | No       | `true`, but not supported if `regexp` is `true` or if `prefix` is `false`  | Determines if the suffix is carried over with the redirect. [More information](#redirects-using-prefix-and-append_suffix).                                                                                                                       |
+| `code`             | No       | n/a     | HTTP status code. Valid status codes are `301`, `302`, `307`, and `308`. Defaults to `302` for [Partial redirects](#partial-redirects), and `301` for [Whole-route redirects](#whole-route-redirects). [More information](#specify-a-http-status-code). |
 | `expires`          | No       | Defaults to the `expires` value defined directly under the `redirects` key, but can be fine-tuned. To [disable caching on a specific redirect](#disable-caching-on-your-redirects), set `expires` to `0`. | The duration the redirect is cached for. [More information](#manage-caching).
 
 To set up partial redirects, you can use regular expressions (`regexp`).</br>

--- a/sites/upsun/src/define-routes/redirects.md
+++ b/sites/upsun/src/define-routes/redirects.md
@@ -269,7 +269,7 @@ A request to `/from/some/path` (and any path after `/from`) redirects to just `/
 
 ### Specify a HTTP status code
 
-To set a specific HTTP status code for your redirect, use the `codes` key:
+To set a specific HTTP status code for your redirect, use the `code` key:
 
 ```yaml
 routes:


### PR DESCRIPTION
## Why

Closes #4416 & #4444 

## What's changed

Adds a sentence to the whole redirection and partial redirection sections clarifying which HTTP status code is returned by default. Adds this same information to the table. Also corrects `codes` to `code` when referencing the key in the yaml file to change the status code.

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
