### PR TITLE
limits job to run only if PR workflow completed successfully

### DIFF
--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Why

Closes #4443 


## What's changed

sets the comment on PR workflow job to only run if the PR url workflow completes _successfully_. 

