### PR TITLE
Removes links from front matter meta descriptions, Integrate Observability

### DIFF
--- a/sites/platform/src/increase-observability/integrate-observability/new-relic/_index.md
+++ b/sites/platform/src/increase-observability/integrate-observability/new-relic/_index.md
@@ -4,11 +4,11 @@ weight: 2
 toc: false
 sectionBefore: Third-party observability tools
 description: |
-  {{% vendor/name %}} supports [New Relic application performance monitoring](https://newrelic.com/products/application-monitoring).
+  {{% vendor/name %}} supports New Relic application performance monitoring.
 layout: single
 ---
 
-{{% description %}}
+{{% vendor/name %}} supports [New Relic application performance monitoring](https://newrelic.com/products/application-monitoring).
 
 {{% version/specific %}}
 ## On a {{% names/dedicated-gen-2 %}} cluster

--- a/sites/platform/src/increase-observability/integrate-observability/tideways.md
+++ b/sites/platform/src/increase-observability/integrate-observability/tideways.md
@@ -1,10 +1,10 @@
 ---
 title: "Tideways"
 description: |
-  {{% vendor/name %}} supports [Tideways APM](https://tideways.com/) for PHP. This functionality is only available on PHP 7.0 and later.
+  {{% vendor/name %}} supports Tideways APM for PHP. This functionality is only available on PHP 7.0 and later.
 ---
 
-{{% description %}}
+{{% vendor/name %}} supports [Tideways APM](https://tideways.com/) for PHP. This functionality is only available on PHP 7.0 and later.
 
 {{< note >}}
 The Tideways upstream is available as a plugin on {{% vendor/name %}}:


### PR DESCRIPTION

## Why

Closes #4464 

## What's changed

Removes links from front matter meta descriptions and into the content

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
