### PR TITLE
removes extraneous new lines from terminal commands

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/ddev/token.md
+++ b/themes/psh-docs/layouts/shortcodes/ddev/token.md
@@ -7,12 +7,12 @@ Then add the token to your DDEV configuration.
 You can do so globally (easiest for most people):
 
 ```bash
-ddev config global --web-environment-add={{ `{{< vendor/prefix_cli >}}` | .Page.RenderString }}_CLI_TOKEN={{ `{{< variable "API_TOKEN" >}}` | .Page.RenderString }}
+ddev config global --web-environment-add={{ `{{< vendor/prefix_cli >}}` | .Page.RenderString | chomp }}_CLI_TOKEN={{ `{{< variable "API_TOKEN" >}}` | .Page.RenderString }}
 ```
 
 You can also add the token only to the project:
 
 ```bash
-ddev config --web-environment-add={{ `{{< vendor/prefix_cli >}}` | .Page.RenderString }}_CLI_TOKEN={{ `{{< variable "API_TOKEN" >}}` | .Page.RenderString }}
+ddev config --web-environment-add={{ `{{< vendor/prefix_cli >}}` |  .Page.RenderString | chomp }}_CLI_TOKEN={{ `{{< variable "API_TOKEN" >}}` | .Page.RenderString }}
 ```
 <!-- shortcode end {{ .Name }} -->


### PR DESCRIPTION
## Why

Closes #4466 

## What's changed

adds a `chomp` after we render the shortcode and after that return is passed through `.RenderString`

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
