### PR TITLE
missed redirection for changelog for upsun, should have been in #4360

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -261,7 +261,7 @@ https://{default}/:
 
       # Splitting 'other' section into proper top-level items within Reference.
       "/other/glossary.html" : { "to": "/glossary.html", "code": 301 }
-     
+
 
       # Change of URL for the custom domains on preview environments page
       "/domains/steps/custom-non-production-domains.html" : { "to": "/domains/steps/custom-domains-preview-environments.html", "code": 301 }
@@ -378,6 +378,10 @@ https://docs.upsun.com/:
       "/get-started/laravel/": { "to": "/get-started/stacks/laravel.html", "code": 301, "prefix": true, "append_suffix": false }
       "/get-started/nextjs/": { "to": "/get-started/stacks/nextjs.html", "code": 301, "prefix": true, "append_suffix": false }
       "/get-started/strapi/": { "to": "/get-started/stacks/strapi.html", "code": 301, "prefix": true, "append_suffix": false }
+
+      #Changelog to Feature requests page
+      "/changelog.html": { "to": "/request-features.html", "code": 301 }
+
 
 # "https://docs.deployfriday.net/":
 #     type: redirect


### PR DESCRIPTION
## Why

a redirection should have been added to the routes for docs.upsun.com in #4360 

## What's changed

docs.upsun.com/changelog.html --> docs.upsun.com/request-features.html

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
