### PR TITLE
Remove Advanced tier

### DIFF
--- a/sites/platform/src/security/web-application-firewall/fastly-waf.md
+++ b/sites/platform/src/security/web-application-firewall/fastly-waf.md
@@ -12,11 +12,10 @@ you can subscribe to the Fastly Next-Gen WAF to further protect your app from se
 ## Available offers
 
 If you want to subscribe to the Fastly Next-Gen WAF through {{% vendor/name %}},
-you can choose from three offers:
+you can choose from two offers:
 
-- If you subscribe to the **Basic** or **Basic configurable** offer, your WAF is fully managed by {{% vendor/name %}}.
-- If you subscribe to the **Advanced** offer, after your WAF is installed by {{% vendor/name %}},
-  you have access to more features that you manage yourself.
+- If you subscribe to the **Basic** offer, your WAF is fully managed by {{% vendor/name %}}
+- If you subscribe to the **Basic configurable** offer, your WAF is fully managed by {{% vendor/name %}} too, but with additional flexibility and visibility provided
 
 To view a list of all the features included in each offer, see the following table.
 
@@ -28,16 +27,16 @@ Included features may present limitations compared to those advertised by Fastly
 
 {{< /note >}}
 
-| Capability                                                                                                                                               | Basic offer     | Basic configurable offer          | Advanced offer                 |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------------------|--------------------------------|
-| Available modes                                                                                                                                          | Block mode only | Block, not blocking, off modes    | Block, not blocking, off modes |
-| [Default attack signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/using-system-signals/#attacks)                             | Yes             | Yes                               | Yes                            |
-| [Default anomaly signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/using-system-signals/#anomalies)                          | Yes             | Yes                               | Yes                            |
-| [Virtual patching](https://docs.fastly.com/signalsciences/using-signal-sciences/rules/working-with-templated-rules/#working-with-virtual-patching-rules) | No              | Yes, in block mode only           | Yes, via custom signals        |
-| [Default dashboards](https://docs.fastly.com/signalsciences/using-signal-sciences/web-interface/about-the-site-overview-page/)                           | No              | During quarterly business reviews | Yes                            |
-| [Custom response codes](https://docs.fastly.com/signalsciences/using-signal-sciences/custom-response-codes/)                                             | No              | No                                | Yes                            |
-| [Custom signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/working-with-custom-signals/)                                      | No              | No                                | Yes                            |
-| [Standard API & ATO signals](https://docs.fastly.com/signalsciences/using-signal-sciences/rules/working-with-templated-rules/)                           | No              | No                                | Yes                            |
+| Capability                                                                                                                                               | Basic offer     | Basic configurable offer          |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------------------|
+| Available modes                                                                                                                                          | Block mode only | Block, not blocking, off modes    |
+| [Default attack signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/using-system-signals/#attacks)                             | Yes             | Yes                               |
+| [Default anomaly signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/using-system-signals/#anomalies)                          | Yes             | Yes                               |
+| [Virtual patching](https://docs.fastly.com/signalsciences/using-signal-sciences/rules/working-with-templated-rules/#working-with-virtual-patching-rules) | No              | Yes, in block mode only           |
+| [Default dashboards](https://docs.fastly.com/signalsciences/using-signal-sciences/web-interface/about-the-site-overview-page/)                           | No              | During quarterly business reviews |
+| [Custom response codes](https://docs.fastly.com/signalsciences/using-signal-sciences/custom-response-codes/)                                             | No              | No                                |
+| [Custom signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/working-with-custom-signals/)                                      | No              | No                                |
+| [Standard API & ATO signals](https://docs.fastly.com/signalsciences/using-signal-sciences/rules/working-with-templated-rules/)                           | No              | No                                |
 
 To subscribe to a Fastly Next-Gen WAF offer through {{% vendor/name %}},
 [contact Sales](https://platform.sh/contact/).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

See latest Async post about NGWAF.

## What's changed

Advanced tier is removed from the public docs.

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
