### PR TITLE
chrome-headless service must not define disk

### DIFF
--- a/sites/platform/src/add-services/headless-chrome.md
+++ b/sites/platform/src/add-services/headless-chrome.md
@@ -74,7 +74,6 @@ To define the service, use the `chrome-headless` type:
 # The name of the service container. Must be unique within a project.
 <SERVICE_NAME>:
   type: chrome-headless:<VERSION>
-  disk: 256
 ```
 
 Note that changing the name of the service replaces it with a brand new service and all existing data is lost.


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->
Following the current doc, deployment with chrome-headless fails with

```
  E: Error parsing configuration files:
      - services.browser.disk: service is not persistent, it cannot have a disk
```

## What's changed

This removes the extra `disk` attribute from the code snippet
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)

The upsun snippet seems already fixed!
