### PR TITLE
switches from upsun cli to public action in platformsh org

### DIFF
--- a/.github/actions/get-pr-info/action.yaml
+++ b/.github/actions/get-pr-info/action.yaml
@@ -25,9 +25,11 @@ runs:
   using: composite
   steps:
     - name: Set up Platform.sh CLI
-      env:
-        PLATFORMSH_CLI_TOKEN: ${{ inputs.platformsh_token }}
-      uses: ./.github/actions/set-up-cli
+      # temporary usage until the official is public
+      uses: platformsh/gha-retrieve-production-url@main
+      with:
+        platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+        project_id: ${{ vars.PROJECT_ID }}
     - name: Get environment URL
       shell: bash
       env:

--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -18,11 +18,11 @@ jobs:
     if: github.event.label.name == 'build-fork' || contains(github.event.pull_request.labels.*.name, 'build-fork')
     runs-on: ubuntu-latest
     steps:
-      - uses: upsun/action-cli@v1
+      - uses: platformsh/gha-retrieve-production-url@main
         with:
-          # Name of CLI provider.
-          # Default: 'upsun'
-          cli_provider: 'platform'
+          # temporary usage until the official is public
+          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+          project_id: ${{ vars.PROJECT_ID }}
 
       # Create an environment and activate it
       - env:

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -23,11 +23,11 @@ jobs:
       github.event.pull_request.head.repo.id == 21975579
     steps:
       # Set up workflow environment to use the Platform.sh CLI
-      - uses: upsun/action-cli@v1
+      - uses: platformsh/gha-retrieve-production-url@main
         with:
-          # Name of CLI provider.
-          # Default: 'upsun'
-          cli_provider: 'platform'
+          # temporary usage until the official is public
+          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+          project_id: ${{ vars.PROJECT_ID }}
 
       - name: Set environment title
         env:
@@ -66,7 +66,11 @@ jobs:
 
       # Set up workflow environment to use the Platform.sh CLI
       - name: Set up Platform.sh CLI
-        uses: ./.github/actions/set-up-cli
+        uses: platformsh/gha-retrieve-production-url@main
+        with:
+          # temporary usage until the official is public
+          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+          project_id: ${{ vars.PROJECT_ID }}
 
       - name: Close environment
         env:
@@ -108,7 +112,11 @@ jobs:
       - name: Set up Platform.sh CLI
         # If the Git branch was deleted, skip checks for the environment
         if: steps.branch_exists.outputs.branch_exists != 'true'
-        uses: ./.github/actions/set-up-cli
+        uses: platformsh/gha-retrieve-production-url@main
+        with:
+          # temporary usage until the official is public
+          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+          project_id: ${{ vars.PROJECT_ID }}
 
       - name: Check if environment exists
         id: environment_exists


### PR DESCRIPTION
swaps out the upsun cli action (private) to alt public action in the platformsh github org. This is temporary until the upsun cli action is made public