### PR TITLE
moves us to the official upsun cli action now that it's public

### DIFF
--- a/.github/actions/get-pr-info/action.yaml
+++ b/.github/actions/get-pr-info/action.yaml
@@ -29,10 +29,9 @@ runs:
   steps:
     - name: Set up Platform.sh CLI
       # temporary usage until the official is public
-      uses: platformsh/gha-retrieve-production-url@main
+      uses: upsun/action-cli@v1
       with:
-        platformsh_token: ${{ inputs.platformsh_token }}
-        project_id: ${{ inputs.project }}
+          cli_provider: 'platform'
     - name: Get environment URL
       shell: bash
       env:

--- a/.github/actions/set-up-cli/action.yaml
+++ b/.github/actions/set-up-cli/action.yaml
@@ -1,9 +1,0 @@
-name: Set up Platform.sh CLI
-description: Installs the Platform.sh CLI.
-
-runs:
-  using: "composite"
-  steps:
-    - name: Install CLI
-      run: curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
-      shell: bash

--- a/.github/actions/set-up-upsun-cli/action.yaml
+++ b/.github/actions/set-up-upsun-cli/action.yaml
@@ -1,9 +1,0 @@
-name: Set up Upsun CLI
-description: Installs the Upsun CLI.
-
-runs:
-  using: "composite"
-  steps:
-    - name: Install Upsun CLI
-      run: curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
-      shell: bash

--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -23,11 +23,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
-      - uses: platformsh/gha-retrieve-production-url@main
+      - uses: upsun/action-cli@v1
         with:
-          # temporary usage until the official is public
-          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-          project_id: ${{ vars.PROJECT_ID }}
+          cli_provider: 'platform'
 
       # Create an environment and activate it
       - env:

--- a/.github/workflows/generate-cli-commands-page.yaml
+++ b/.github/workflows/generate-cli-commands-page.yaml
@@ -32,11 +32,15 @@ jobs:
 
       # Set up workflow environment to use the Platform.sh CLI
       - name: Set up Platform.sh CLI
-        uses: ./.github/actions/set-up-cli
+        uses: upsun/action-cli@v1
+        with:
+          cli_provider: 'platform'
 
       # Set up workflow environment to use the Upsun CLI
       - name: Set up Upsun CLI
-        uses: ./.github/actions/set-up-upsun-cli
+        uses: upsun/action-cli@v1
+        with:
+          cli_provider: 'platform'
 
       - name: Make changes to pull request
         run: |

--- a/.github/workflows/manage-environment.yaml
+++ b/.github/workflows/manage-environment.yaml
@@ -23,12 +23,9 @@ jobs:
       github.event.pull_request.head.repo.id == 21975579
     steps:
       # Set up workflow environment to use the Platform.sh CLI
-      - uses: platformsh/gha-retrieve-production-url@main
+      - uses: upsun/action-cli@v1
         with:
-          # temporary usage until the official is public
-          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-          project_id: ${{ vars.PROJECT_ID }}
-
+          cli_provider: 'platform'
       - name: Set environment title
         env:
           # Github does not escape PR titles before swapping the token with the value. This means that in a shell context
@@ -66,11 +63,9 @@ jobs:
 
       # Set up workflow environment to use the Platform.sh CLI
       - name: Set up Platform.sh CLI
-        uses: platformsh/gha-retrieve-production-url@main
+        uses: upsun/action-cli@v1
         with:
-          # temporary usage until the official is public
-          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-          project_id: ${{ vars.PROJECT_ID }}
+          cli_provider: 'platform'
 
       - name: Close environment
         env:
@@ -112,11 +107,9 @@ jobs:
       - name: Set up Platform.sh CLI
         # If the Git branch was deleted, skip checks for the environment
         if: steps.branch_exists.outputs.branch_exists != 'true'
-        uses: platformsh/gha-retrieve-production-url@main
+        uses: upsun/action-cli@v1
         with:
-          # temporary usage until the official is public
-          platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-          project_id: ${{ vars.PROJECT_ID }}
+          cli_provider: 'platform'
 
       - name: Check if environment exists
         id: environment_exists


### PR DESCRIPTION
- swaps out all calls to the gha-retrieve-production-url action with the official Upsun GitHub action [action-cli](https://github.com/upsun/action-cli). Also, 
- updates the generate-cli-commands-page workflow to use this action
- removes the now deprecated set-up-cli actions