### PR TITLE
delay PR related activities until after build from fork workflow completes

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -3,7 +3,7 @@ name: Build from fork
 on:
   pull_request_target:
     branches: [main]
-    types: [labeled,unlabeled,synchronize]
+    types: [labeled,opened,reopened,synchronize]
 
 env:
   PLATFORMSH_CLI_NO_INTERACTION: 1
@@ -27,12 +27,28 @@ jobs:
         with:
           cli_provider: 'platform'
 
+      - name: 'checks if branch already exists'
+        id: buildthebranch
+        env:
+          PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+        run: |
+          buildbranch='true'
+          branchExists=$(platform project:curl /environments | jq --arg branch "${{ env.BRANCH_TITLE }}" -r '.[] | select(.name | contains($branch))');
+          if [ -n "${branchExists}" ]; then
+            # branch already exists
+            buildBranch='false'
+          fi
+
+          echo "buildBranch=${buildbranch}" >> $GITHUB_OUTPUT
       # Create an environment and activate it
-      - env:
+      - name: 'Build a branch from the fork'
+        if: ${{ 'true'  == steps.buildthebranch.outputs.buildBranch }}
+        env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
           # @see activate_environment:Set environment title:env in manage-environment.yaml
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          echo "::notice::Building branch from forked PR"
           # Get most recent changes
           git checkout ${{ github.event.pull_request.head.sha }}
 
@@ -70,3 +86,5 @@ jobs:
             echo "::notice::Activating environment ${{ env.BRANCH_TITLE }}"
             platform environment:activate -e ${{ env.BRANCH_TITLE }}
           fi
+
+

--- a/.github/workflows/pr-url-and-dependent.yaml
+++ b/.github/workflows/pr-url-and-dependent.yaml
@@ -1,8 +1,13 @@
 name: Get PR URL, start dependent jobs
+#on:
+#  pull_request_target:
+#    branches: [main]
+#    types: [labeled,opened,reopened,synchronize]
 on:
-  pull_request_target:
-    branches: [main]
-    types: [labeled,opened,reopened,synchronize]
+  workflow_run:
+    workflows: ["Build from fork"]
+    types:
+      - completed
 
 env:
   PLATFORMSH_CLI_NO_INTERACTION: 1


### PR DESCRIPTION
## Why

`build-from-fork` (BFF) workflow and the `pr-url-and-dependent`(PUD) workflow.

Initially, the idea was that since the PUD workflow has to wait until the PR environment is deployed anyway, it shouldn’t matter if they both are triggered at the same time. BUT that also assumes that the necessary label is added to a PR from a fork in a timely manner. If the label isn’t added for a bit, the PUD workflow will error out since the environment doesn’t exist yet. 

moves the PUD workflow to a `workflow_call` event based on completion of BFF workflow. BFF has been updated to fire on all pr related events (`labeled`, `opened`, `reopened` ,`synchronize`) and only builds the branch if it doesn't already exist.


