### PR TITLE
feat: added note about large file limits

### DIFF
--- a/sites/platform/src/learn/bestpractices/clean-repository.md
+++ b/sites/platform/src/learn/bestpractices/clean-repository.md
@@ -89,9 +89,11 @@ Therefore, {{% vendor/name %}} recommends that you only commit your source code 
 To upload any other files to your app, [create mounts](https://docs.platform.sh/create-apps/app-reference.html#mounts)
 and [transfer your files directly to them](https://docs.platform.sh/development/file-transfer.html#transfer-a-file-to-a-mount).
 
-{{< note >}}
+{{< note theme="warning" >}}
 
-{{% vendor/name %}} does not currently support [Git Large File Storage](https://git-lfs.com/).
+{{% vendor/name %}} does not currently support [Git Large File Storage](https://git-lfs.com/). 
+
+There is a **100MB default file size limit** for direct Git pushes to {{% vendor/name %}}, so please do not upload files larger than this. If you'd like to request a custom limit, please [contact Support](/learn/overview/get-support).
 
 {{< /note >}}
 

--- a/sites/platform/src/learn/bestpractices/clean-repository.md
+++ b/sites/platform/src/learn/bestpractices/clean-repository.md
@@ -93,7 +93,7 @@ and [transfer your files directly to them](https://docs.platform.sh/development/
 
 {{% vendor/name %}} does not currently support [Git Large File Storage](https://git-lfs.com/). 
 
-There is a **100MB default file size limit** for direct Git pushes to {{% vendor/name %}}, so please do not upload files larger than this. If you'd like to request a custom limit, please [contact Support](/learn/overview/get-support).
+There is a **100MB default file size limit** for direct Git pushes to {{% vendor/name %}}. Pushing files larger than the limit will result in rejecting the push, so please keep this in mind. If you'd like to request a custom limit, please [contact Support](/learn/overview/get-support).
 
 {{< /note >}}
 

--- a/sites/upsun/src/learn/bestpractices/clean-repository.md
+++ b/sites/upsun/src/learn/bestpractices/clean-repository.md
@@ -89,9 +89,11 @@ Therefore, {{% vendor/name %}} recommends that you only commit your source code 
 To upload any other files to your app, [create mounts](https://docs.platform.sh/create-apps/app-reference.html#mounts)
 and [transfer your files directly to them](https://docs.platform.sh/development/file-transfer.html#transfer-a-file-to-a-mount).
 
-{{< note >}}
+{{< note theme="warning" >}}
 
-{{% vendor/name %}} does not currently support [Git Large File Storage](https://git-lfs.com/).
+{{% vendor/name %}} does not currently support [Git Large File Storage](https://git-lfs.com/). 
+
+There is a **100MB default file size limit** for direct Git pushes to {{% vendor/name %}}, so please do not upload files larger than this. If you'd like to request a custom limit, please [contact Support](/learn/overview/get-support).
 
 {{< /note >}}
 

--- a/sites/upsun/src/learn/bestpractices/clean-repository.md
+++ b/sites/upsun/src/learn/bestpractices/clean-repository.md
@@ -93,7 +93,7 @@ and [transfer your files directly to them](https://docs.platform.sh/development/
 
 {{% vendor/name %}} does not currently support [Git Large File Storage](https://git-lfs.com/). 
 
-There is a **100MB default file size limit** for direct Git pushes to {{% vendor/name %}}, so please do not upload files larger than this. If you'd like to request a custom limit, please [contact Support](/learn/overview/get-support).
+There is a **100MB default file size limit** for direct Git pushes to {{% vendor/name %}}. Pushing files larger than the limit will result in rejecting the push, so please keep this in mind. If you'd like to request a custom limit, please [contact Support](/learn/overview/get-support).
 
 {{< /note >}}
 


### PR DESCRIPTION
### Added note about large file limits with link to support

## Why
Closes #4512 

## What's changed
Added information about large file limits to bottom note (changed to warning note) in the /learn/bestpractices/clean-repository page on both Upsun and Platform.sh.

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
