### PR TITLE
adding a cron and post_deploy example and new method to handle trailing slashes

### DIFF
--- a/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
@@ -147,8 +147,9 @@ applications:
         wp cache flush
         # Runs the WordPress database update procedure
         wp core update-db
-        # Runs all due cron events
+      post_deploy: |
         wp cron event run --due-now
+
 ```
 
 ## 5. Update App container depdencies
@@ -194,7 +195,22 @@ routes:
 Matching the application name `myapp` with the `upstream` definition `myapp:http` is the most important setting to ensure at this stage.
 If these strings aren't the same, the WordPress deployment will not succeed.
 
-## 7. Update `.environment`
+## 6. Add your crons
+
+Under your application configuration you can now add a cron.
+
+```
+    crons:
+      wp-cron:
+        spec: '*/10 * * * *'
+        commands:
+          start: wp cron event run --due-now
+        shutdown_timeout: 600
+
+
+```
+
+## 8. Update `.environment`
 
 The CLI generated a `.environment` file during the Getting started guide. Notice it has already created some environment
 variables for you to connect to your database service.
@@ -230,7 +246,7 @@ To configure the remaining environment variables that WordPress needs to run smo
     export NONCE_SALT="${PLATFORM_PROJECT_ENTROPY}NONCE_SALT"
    ```
 
-## 8. Commit, Push, and Deploy!
+## 9. Commit, Push, and Deploy!
 You can now commit all the changes made to `.upsun/config.yaml` and `.environment` and push to {{% vendor/name %}}.
 
    ```bash {location="Terminal"}

--- a/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
@@ -131,7 +131,7 @@ application can receive requests. Such tasks include:
 - Running any due cron jobs
 
 To perform these tasks, we'll utilize  the [deploy hook](/learn/overview/build-deploy.md#deploy-steps). Locate the
-`deploy:` section (below the `build:` section). Update the `deploy:` section as follows:
+`deploy:` section (below the `build:` section). Update the `deploy:` and `post_deploy:` section as follows:
 
 ```yaml {configFile="app"}
 applications:

--- a/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
@@ -195,7 +195,7 @@ routes:
 Matching the application name `myapp` with the `upstream` definition `myapp:http` is the most important setting to ensure at this stage.
 If these strings aren't the same, the WordPress deployment will not succeed.
 
-## 6. Add your crons
+## 7. Add your crons
 
 Under your application configuration you can now add a cron.
 
@@ -231,7 +231,7 @@ To configure the remaining environment variables that WordPress needs to run smo
 2. Add the following at the end of the file:
 
    ```bash {location=".environment"}
-    export WP_HOME=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key')
+    export WP_HOME=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | if (.key[-1:] == "/") then (.key[0:-1]) else .key end')
     export WP_SITEURL="${WP_HOME}/wp"
     export WP_DEBUG_LOG=/var/log/app.log
     # Uncomment this line if you would like development versions of WordPress on non-production environments.

--- a/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/bedrock.md
@@ -199,15 +199,19 @@ If these strings aren't the same, the WordPress deployment will not succeed.
 
 Under your application configuration you can now add a cron.
 
-```
+```yaml {configFile="app"}
+applications:
+  myapp:
+    source:
+      root: "/"
+    type: 'php:8.3'
+    ...
     crons:
       wp-cron:
         spec: '*/10 * * * *'
         commands:
           start: wp cron event run --due-now
         shutdown_timeout: 600
-
-
 ```
 
 ## 8. Update `.environment`

--- a/sites/upsun/src/get-started/stacks/wordpress/composer.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/composer.md
@@ -240,7 +240,7 @@ If these strings aren't the same, the WordPress deployment will not succeed.
 
 Under your application configuration you can now add a cron.
 
-```
+```yaml {configFile="app"}
 applications:
   myapp:
     source:
@@ -253,8 +253,6 @@ applications:
         commands:
           start: wp cron event run --due-now
         shutdown_timeout: 600
-
-
 ```
 
 ## 8. Update your MariaDB service relationship

--- a/sites/upsun/src/get-started/stacks/wordpress/composer.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/composer.md
@@ -186,7 +186,7 @@ Such tasks include:
 
 To launch these tasks during the deploy hook,
 locate the `deploy:` section (below the `build:` section).</br>
-Update the `deploy:` section as follows:
+Update the `deploy:` and `post_deploy:` section as follows:
 
 ```yaml {configFile="app"}
 applications:
@@ -202,6 +202,7 @@ applications:
         wp cache flush
         # Runs the WordPress database update procedure
         wp core update-db
+      post_deploy: |
         # Runs all due cron events
         wp cron event run --due-now
 ```
@@ -235,7 +236,22 @@ routes:
 Matching the application name `myapp` with the `upstream` definition `myapp:http` is the most important setting to ensure at this stage.
 If these strings aren't the same, the WordPress deployment will not succeed.
 
-## 7. Update your MariaDB service relationship
+## 7. Add your crons
+
+Under your application configuration you can now add a cron.
+
+```
+    crons:
+      wp-cron:
+        spec: '*/10 * * * *'
+        commands:
+          start: wp cron event run --due-now
+        shutdown_timeout: 600
+
+
+```
+
+## 8. Update your MariaDB service relationship
 
 You need to update the name used to represent the [relationship](/create-apps/app-reference/single-runtime-image.md#relationships) between your app and your MariaDB service.
 To do so, locate the `relationships:` top-level property.

--- a/sites/upsun/src/get-started/stacks/wordpress/composer.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/composer.md
@@ -241,6 +241,12 @@ If these strings aren't the same, the WordPress deployment will not succeed.
 Under your application configuration you can now add a cron.
 
 ```
+applications:
+  myapp:
+    source:
+      root: "/"
+    type: 'php:8.3'
+    ...
     crons:
       wp-cron:
         spec: '*/10 * * * *'


### PR DESCRIPTION
## Why

The merge is to add a cron and post_deploy example and provide a new method to handle trailing slashes

## What's changed

Adjusted the 3 wordpress upsun docs pages with a cron and post deployment examples, and now check and remove any trailing slashes in the wordpress URL.

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ X] upsun (`sites/upsun` templates)
