### PR TITLE
Workflow refactoring

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -1,4 +1,4 @@
-name: Build from fork
+name: Record information on PR and (maybe) Build from fork
 
 on:
   pull_request_target:
@@ -98,7 +98,7 @@ jobs:
       - name: "Save PR info for downstream workflows"
         if: ${{ always }}
         run: |
-          touch pr_number.txt pr_head_sha.txt pr_base_sha.txt branch.txt continuetests.txt
+          touch pr_number.txt pr_head_sha.txt pr_base_sha.txt branch.txt continuetests.txt forkorsource.txt
           # set default
           echo "false" > continuetests.txt
           echo "${{ github.event.number }}" > pr_number.txt
@@ -124,14 +124,26 @@ jobs:
         run: |
           echo "true" > continuetests.txt
 
+      - name: "We are building from the source"
+        if: github.event.pull_request.head.repo.id == vars.REPO_ID
+        run:
+          echo "source" > forkorsource.txt
+
+      - name: "We are building from a fork"
+        if: github.event.pull_request.head.repo.id != vars.REPO_ID && contains(github.event.pull_request.labels.*.name, 'build-fork')
+        run: |
+          echo "fork" > forkorsource.txt
+
       - name: "Save PR info"
         uses: actions/upload-artifact@v4
         with:
           name: pr-info
+          # @todo is there a better way to do this?
           path: |
             pr_number.txt
             pr_head_sha.txt
             pr_base_sha.txt
             branch.txt
             continuetests.txt
+            forkorsource.txt
           retention-days: 1

--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -88,3 +88,50 @@ jobs:
           fi
 
 
+  # records all the info needed about the PR for the downstream workflows
+  record-pr-info:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    if: ${{ always() }}
+    steps:
+      - name: "Save PR info for downstream workflows"
+        if: ${{ always }}
+        run: |
+          touch pr_number.txt pr_head_sha.txt pr_base_sha.txt branch.txt continuetests.txt
+          # set default
+          echo "false" > continuetests.txt
+          echo "${{ github.event.number }}" > pr_number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > pr_head_sha.txt
+          echo "${{ github.event.pull_request.base.sha }}" > pr_base_sha.txt
+
+      - name: "Get branch name"
+        id: branch_name
+        run: |
+          # For PRs from non-forked repos
+          if [ ${{ github.event.pull_request.head.repo.id }} == ${{ vars.REPO_ID }} ]; then
+            branch_name="${{ github.event.pull_request.head.ref }}"
+
+          # For PRs from forks
+          else
+            branch_name="${{ env.BRANCH_TITLE }}"
+          fi
+          echo "::notice::Setting branch name to ${branch_name}."
+          echo "${branch_name}" > branch.txt
+
+      - name: "PR is from source repo or from fork but properly labeled"
+        if: github.event.pull_request.head.repo.id == vars.REPO_ID || contains(github.event.pull_request.labels.*.name, 'build-fork')
+        run: |
+          echo "true" > continuetests.txt
+
+      - name: "Save PR info"
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-info
+          path: |
+            pr_number.txt
+            pr_head_sha.txt
+            pr_base_sha.txt
+            branch.txt
+            continuetests.txt
+          retention-days: 1

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           workflow: pr-url-and-dependent.yaml
           workflow_conclusion: completed
-          name: pr-info
+          name: pr-comment-info
 
       - name: Get PR number
         id: pr_number

--- a/.github/workflows/pr-url-and-dependent.yaml
+++ b/.github/workflows/pr-url-and-dependent.yaml
@@ -16,11 +16,61 @@ env:
   BRANCH_TITLE: ${{ vars.BFF_PREFIX }}-${{ github.event.number }}
   UPSUN_DOCS_PREFIX: "https://docs.upsun.com"
 jobs:
-  get_pr_info:
+  get_info_on_pr:
     runs-on: ubuntu-latest
+    name: "Retrieves information on the PR"
+    outputs:
+      prnum: ${{ steps.set_pr_number.outputs.prnum }}
+      headsha: ${{ steps.set_pr_head_sha.outputs.headsha }}
+      basesha: ${{ steps.set_pr_base_sha.outputs.basesha }}
+      prbranch: ${{ steps.set_pr_branch.outputs.branch }}
+      continuetests: ${{ steps.set_contintue_tests.outputs.continue }}
+      reposource: ${{ steps.set_repo_source.outputs.reposource }}
+    steps:
+      - name: Download info on PR
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build-from-fork.yaml
+          workflow_conclusion: completed
+          name: pr-info
+      - id: set_pr_number
+        run: |
+          PR_NUM=$(cat pr_number.txt)
+          echo "prnum=${PR_NUM}" >> $GITHUB_OUTPUT
+      - id: set_pr_head_sha
+        run: |
+          HEAD_SHA=$(cat pr_head_sha.txt)
+          echo "headsha=${HEAD_SHA}" >> $GITHUB_OUTPUT
+      - id: set_pr_base_sha
+        run: |
+          BASE_SHA=$(cat pr_base_sha.txt)
+          echo "basesha=${BASE_SHA}" >> $GITHUB_OUTPUT
+      - id: set_pr_branch
+        run: |
+          BRANCH=$(cat branch.txt)
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+      - id: set_contintue_tests
+        run: |
+          CONTINUE=$(cat continuetests.txt)
+          echo "continue=${CONTINUE}" >> $GITHUB_OUTPUT
+      - id: set_repo_source
+        run: |
+          SOURCE=$(cat forkorsource.txt)
+          echo "reposource=${SOURCE}" >> $GITHUB_OUTPUT
+  get_pr_info:
+    needs:
+      - get_info_on_pr
+    runs-on: ubuntu-latest
+    env:
+      CONTINUE: ${{ needs.get_info_on_pr.outputs.continuetests }}
+      BRANCH: ${{ needs.get_info_on_pr.outputs.prbranch }}
+      BASESHA: ${{ needs.get_info_on_pr.outputs.basesha }}
+      HEADSHA: ${{ needs.get_info_on_pr.outputs.headsha }}
+      PRNUM: ${{ needs.get_info_on_pr.outputs.prnum }}
+      REPOSOURCE: ${{ needs.get_info_on_pr.outputs.reposource }}
     name: Get info on build from PR
     # Run only for PRs from default repo and approved PRs from forks
-    if: github.event.pull_request.head.repo.id == vars.REPO_ID || contains(github.event.pull_request.labels.*.name, 'build-fork')
+    if: env.CONTINUE == 'true'
     outputs:
       pr_url: ${{ steps.get_env_url.outputs.pr_url }}
       pr_url_upsun: ${{ steps.get_env_url.outputs.pr_url_upsun }}
@@ -29,26 +79,12 @@ jobs:
       # at this point we want to checkout the repository but at the latest commit of the default branch
       - uses: actions/checkout@v4
 
-      - name: Set branch name
-        id: branch_name
-        run: |
-          # For PRs from non-forked repos
-          if [ ${{ github.event.pull_request.head.repo.id }} == ${{ vars.REPO_ID }} ]; then
-            branch_name="${{ github.event.pull_request.head.ref }}"
-
-          # For PRs from forks
-          else
-            branch_name="${{ env.BRANCH_TITLE }}"
-          fi
-          echo "::notice::Setting branch name to ${branch_name}."
-          echo "branch_name=${branch_name}" >> $GITHUB_OUTPUT
-
       - name: retrieve PR url
         id: get_env_url
         uses: ./.github/actions/get-pr-info
         with:
           platformsh_token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-          branch: ${{ steps.branch_name.outputs.branch_name }}
+          branch: ${{ env.BRANCH }}
           project: ${{ vars.PROJECT_ID }}
 
       #      - uses: actions/checkout@v4
@@ -58,36 +94,23 @@ jobs:
 
       - name: Make artifact files
         run: |
-          touch environment_url.txt
-          touch pr_comment.txt
-
-      - name: Save PR number
-        if: ${{ always() }}
-        run: echo ${{ github.event.number }} > pr_number.txt
-
-      - name: Save PR SHA
-        if: ${{ always() }}
-        run: echo "${{ github.event.pull_request.head.sha }}" > pr_sha.txt
+          # these are used in comment-on-pr
+          touch pr_number.txt pr_comment.txt
+          echo "${{ env.PRNUM }}" > pr_number.txt
 
       # If no environment URL, create a report of that
       - name: Create failure report
         if: steps.get_env_url.outputs.env_status == 'failure'
         run: |
-          echo -e "The environment on Platform.sh failed to deploy. :slightly_frowning_face:\n\nCheck the logs: https://console.platform.sh/projects/${{ env.PLATFORM_PROJECT }}/${{ steps.branch_name.outputs.branch_name }}" > pr_comment.txt
-
-      # Create a list of relevant changed pages
-      - name: Report environment URL
-        if: steps.get_env_url.outputs.env_status == 'success'
-        run: |
-          echo ${{ steps.get_env_url.outputs.pr_url }} > environment_url.txt
+          echo -e "The environment on Platform.sh failed to deploy. :slightly_frowning_face:\n\nCheck the logs: https://console.platform.sh/projects/${{ env.PLATFORM_PROJECT }}/${{ env.BRANCH }}" > pr_comment.txt
 
       - name: Get changed files
         if: steps.get_env_url.outputs.env_status == 'success'
         id: changed-files
         uses: tj-actions/changed-files@v41
         with:
-          sha: ${{ github.event.pull_request.head.sha }}
-          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha: ${{ env.HEADSHA }}
+          base_sha: ${{ env.BASESHA }}
 
       # Create a list of relevant changed pages
       - name: Get list of changed files
@@ -173,12 +196,10 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pr-info
+          name: pr-comment-info
           path: |
-            environment_url.txt
             pr_comment.txt
             pr_number.txt
-            pr_sha.txt
           retention-days: 1
 
       # If environment failed to create, fail the workflow
@@ -187,20 +208,24 @@ jobs:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
         if: steps.get_env_url.outputs.env_status != 'success'
         run: |
-          echo "::error::The environment for pull request ${{ github.event.number }} failed to deploy. Please rerun this workflow."
+          echo "::error::The environment for pull request ${{ env.PRNUM }} failed to deploy. Please rerun this workflow."
           echo "The last status we received was ${{ steps.get_env_url.outputs.env_status }}"
           echo "List of activities that we ask for, but not limited to the last one:"
-          platform activities --type "environment.push environment.activate environment.redeploy environment.branch" --environment ${{ steps.branch_name.outputs.branch_name }}
-          echo "Now a list of the (up to) last 20 activities for branch ${{ steps.branch_name.outputs.branch_name }}:"
-          platform activities --environment ${{ steps.branch_name.outputs.branch_name }} --limit 20
+          platform activities --type "environment.push environment.activate environment.redeploy environment.branch" --environment ${{ env.BRANCH }}
+          echo "Now a list of the (up to) last 20 activities for branch ${{ env.BRANCH }}:"
+          platform activities --environment ${{ env.BRANCH }} --limit 20
           # Get the ID of failed activity and output its log:
-          failedID=$(platform activities --format plain --type "environment.push environment.activate environment.redeploy environment.branch" --no-header --columns "ID" --limit 1 --environment ${{ steps.branch_name.outputs.branch_name }} --result=failure)
+          failedID=$(platform activities --format plain --type "environment.push environment.activate environment.redeploy environment.branch" --no-header --columns "ID" --limit 1 --environment ${{ env.BRANCH }} --result=failure)
           echo "Log for the failed activity, ID ${failedID}"
-          platform activity:log ${failedID} --environment ${{ steps.branch_name.outputs.branch_name }}
+          platform activity:log ${failedID} --environment ${{ env.BRANCH }}
           exit 1
   dont_run_nonlabeled_forks:
+    needs:
+      - get_info_on_pr
     name: Warn about non-labeled PRs from forks
-    if: github.event.pull_request.head.repo.id != vars.REPO_ID && !contains(github.event.pull_request.labels.*.name, 'build-fork')
+    env:
+      CONTINUE: ${{ needs.get_info_on_pr.outputs.continuetests }}
+    if: ${{ 'false' == env.CONTINUE }}
     runs-on: ubuntu-latest
     steps:
       - name: Warn the environment will not be built
@@ -211,9 +236,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify contracted redirections
     needs:
+      - get_info_on_pr
       - get_pr_info
+    env:
+      CONTINUE: ${{ needs.get_info_on_pr.outputs.continuetests }}
+      HEADSHA: ${{ needs.get_info_on_pr.outputs.headsha }}
     # this isn't REALLY needed since we're depending on get_pr_info and it only completes successfully
-    if: github.event.pull_request.head.repo.id == vars.REPO_ID || contains(github.event.pull_request.labels.*.name, 'build-fork')
+    if: 'true' == env.CONTINUE
     steps:
       - uses: actions/checkout@v4
         with:
@@ -221,7 +250,7 @@ jobs:
           # retrieve the contracted redirections from .platform/routes.yaml. This may change in the future if we
           # switch to using a redirection service. Actions DO NOT have access to secrets.
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.HEADSHA }}
       - uses: ./.github/actions/redirection-verification
         with:
           environment-url: ${{ needs.get_pr_info.outputs.pr_url_upsun }}
@@ -230,9 +259,14 @@ jobs:
     runs-on: ubuntu-latest
     name: E2E tests
     needs:
+      - get_info_on_pr
       - get_pr_info
+    env:
+      CONTINUE: ${{ needs.get_info_on_pr.outputs.continuetests }}
+      REPOSOURCE: ${{ needs.get_info_on_pr.outputs.reposource }}
+      HEADSHA: ${{ needs.get_info_on_pr.outputs.headsha }}
     # this isn't REALLY needed since we're depending on get_pr_info and it only completes successfully
-    if: github.event.pull_request.head.repo.id == vars.REPO_ID || contains(github.event.pull_request.labels.*.name, 'build-fork')
+    if: 'true' == env.CONTINUE
     strategy:
       matrix:
         include:
@@ -242,15 +276,15 @@ jobs:
             url: ${{ needs.get_pr_info.outputs.pr_url_upsun }}
     steps:
       - uses: actions/checkout@v4
-        if: github.event.pull_request.head.repo.id == vars.REPO_ID
+        if: 'source' == env.REPOSOURCE
         with:
           # If this is the base repo, then we want to check out the PR branch so we can potentially run new tests/changes
           # that are included in the PR.
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.HEADSHA }}
       - uses: actions/checkout@v4
         # if it isn't the base repo and we're in a fork then we'll checkout the base repo
-        if: github.event.pull_request.head.repo.id != vars.REPO_ID && contains(github.event.pull_request.labels.*.name, 'build-fork')
+        if: 'fork' == env.REPOSOURCE
       - uses: cypress-io/github-action@v6
         with:
           wait-on: ${{ matrix.url }}


### PR DESCRIPTION
After refactoring the build from fork workflow for security, it required changes to the PR tests workflow. One of those changes was moving the PR testing workflow to be triggered by the workflow_run event. Workflows triggered by this event do not have access to contexts (eg `github.event.pull_request.*`) that it previously relied on. 

This pr refactors the build from fork workflow to include a job that gathers up the needed information on the PR and stores it as an artifact that the PR testing workflow can then retrieve in order to run its jobs successfully. 