### PR TITLE
have checkout fetch all

### DIFF
--- a/.github/workflows/pr-url-and-dependent.yaml
+++ b/.github/workflows/pr-url-and-dependent.yaml
@@ -80,6 +80,7 @@ jobs:
     steps:
       # at this point we want to checkout the repository but at the latest commit of the default branch
       - uses: actions/checkout@v4
+        fetch-depth: 0
 
       - name: retrieve PR url
         id: get_env_url


### PR DESCRIPTION
the checkout in the workflow was still set to shallow so it couldnt find the commit to use for comparison. Changes to a full checkout.