### PR TITLE
adds a job to report check status back to the PR for the previous jobs

### DIFF
--- a/.github/workflows/pr-url-and-dependent.yaml
+++ b/.github/workflows/pr-url-and-dependent.yaml
@@ -304,14 +304,46 @@ jobs:
   run_all_tests:
     name: Report all E2E tests status
     runs-on: ubuntu-latest
-    needs: run-e2e-test
+    needs:
+      - run-e2e-test
+      - run-redirection-tests
+      - get_info_on_pr
+    env:
+      HEADSHA: ${{ needs.get_info_on_pr.outputs.headsha }}
     if: ${{ always() }}
     steps:
       - name: Report matrix status
-        run: |
-          result="${{ needs.run-e2e-test.result }}"
-          if [[ $result == "success" || $result == "skipped" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.checks.create({
+              name: 'Report E2E tests status',
+              head_sha: '${{ env.HEADSHA }}',
+              status: 'completed',
+              conclusion: '${{ needs.run-e2e-test.result }}',
+              output: {
+                title: 'Report E2E tests status',
+                summary: 'Results: ${{ needs.run-e2e-test.result }}'
+              },
+              owner: github.repository_owner,
+              repo: github.repository
+            })
+
+      - name: Report Redirection checks
+        uses: actions/github-script@v7
+        with:
+         github-token: ${{ secrets.GITHUB_TOKEN }}
+         script: |
+           github.checks.create({
+             name: 'Verify contracted redirections',
+             head_sha: '${{ env.HEADSHA }}',
+             status: 'completed',
+             conclusion: '${{ needs.run-redirection-tests.result }}',
+             output: {
+               title: 'Verify contracted redirections',
+               summary: 'Results: ${{ needs.run-redirection-tests.result }}'
+             },
+             owner: github.repository_owner,
+             repo: github.repository
+           })


### PR DESCRIPTION
Because we moved the PR testing jobs into a workflow triggered by workflow_run we lost the ability for those jobs to report their status back to the PR. This adds an additional job to create the check status and report their status to the PR (🤞 ) 