### PR TITLE
corrects ONE tiny typo 

### DIFF
--- a/.github/workflows/pr-url-and-dependent.yaml
+++ b/.github/workflows/pr-url-and-dependent.yaml
@@ -321,7 +321,7 @@ jobs:
       - name: "Determine status and message"
         id: determine-status-message
         run: |
-          if [ 'success' = ${{ needs.run-redirection-tests.results }} ]; then
+          if [ 'success' = ${{ needs.run-redirection-tests.result }} ]; then
             state="success"
             message="Redirection verifications passed."
           else


### PR DESCRIPTION
`needs.run-redirection-tests.result` not `needs.run-redirection-tests.results`
