### PR TITLE
trying to figure out why the workflow_run event is not triggering 

### DIFF
--- a/.github/workflows/pr-url-and-dependent.yaml
+++ b/.github/workflows/pr-url-and-dependent.yaml
@@ -5,7 +5,7 @@ name: Get PR URL, start dependent jobs
 #    types: [labeled,opened,reopened,synchronize]
 on:
   workflow_run:
-    workflows: ["Record information on PR and (maybe) Build from fork"]
+    workflows: [Record information on PR and (maybe) Build from fork]
     types:
       - completed
 


### PR DESCRIPTION
works as expected in a direct PR (like this one) but is not firing when the parent workflow has a label added and runs. 
