### PR TITLE
Fixes broken links to opensearch.org

### DIFF
--- a/sites/platform/src/add-services/opensearch.md
+++ b/sites/platform/src/add-services/opensearch.md
@@ -40,7 +40,7 @@ To update the versions in this table, use docs/data/registry.json
 On Grid and {{% names/dedicated-gen-3 %}}, from version 2, you only specify the major version.
 The latest compatible minor version and patches are applied automatically. On Grid, version 1 represents a rolling release - the latest minor version available from the upstream (starting with opensearch 1.3).
 
-You can see the latest minor and patch versions of OpenSearch available from the [`2.x`](https://opensearch.org/lines/2x.html) and [`1.x`](https://opensearch.org/lines/1x.html) release lines.
+You can see the latest minor and patch versions of OpenSearch available from the [`2.x`](https://docs.opensearch.org/lines/2x.html) and [`1.x`](https://docs.opensearch.org/lines/1x.html) release lines.
 
 ## Deprecated versions
 

--- a/sites/upsun/src/add-services/opensearch.md
+++ b/sites/upsun/src/add-services/opensearch.md
@@ -20,7 +20,7 @@ The latest compatible minor version and patches are applied automatically.
 
 {{< image-versions image="opensearch" status="supported" environment="grid" >}}
 
-You can see the latest minor and patch versions of OpenSearch available from the [`2.x`](https://opensearch.org/lines/2x.html) and [`1.x`](https://opensearch.org/lines/1x.html) (1.3) release lines.
+You can see the latest minor and patch versions of OpenSearch available from the [`2.x`](https://docs.opensearch.org/lines/2x.html) and [`1.x`](https://docs.opensearch.org/lines/1x.html) (1.3) release lines.
 
 ## Deprecated versions
 


### PR DESCRIPTION
## Why

Closes #4544 
Closes #4543 

## What's changed

links have changed from opensearch.org/lines/2x.html to docs.opensearch.org/lines/2x.html

and then the same for 1x.

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
