### PR TITLE
feat: corrected permissions section

### DIFF
--- a/sites/platform/src/administration/users.md
+++ b/sites/platform/src/administration/users.md
@@ -221,9 +221,10 @@ For more information on project access control, see how to [manage project users
 
 ### Organization permissions
 
-As an organization owner or an organization user with the **Manage users** permission,
-you can invite other users to your organization and grant them the following permissions:
+As an organization owner or an organization user with the **Manage users** permission, you can invite other users to your organization and grant them the following permissions:
 
+- **Admin** (`owner`):
+  Manage the organization and access all organization permissions, including all listed below.
 - **Manage billing** (`billing`):
   Add, remove, and edit billing information.
   Access invoices and vouchers.

--- a/sites/upsun/src/administration/users.md
+++ b/sites/upsun/src/administration/users.md
@@ -234,12 +234,12 @@ For more information on project access control, see how to [manage project users
 As an organization owner or an organization user with the **Manage users** permission,
 you can invite other users to your organization and grant them the following permissions:
 
+- **Admin** (`owner`):
+  Manage the organization and access all organization permissions, including all listed below.
 - **Manage billing** (`billing`):
   Add, remove, and edit billing information.
   Access invoices and vouchers.
   Users with this permission receive monthly invoices by email.
-- **Manage plans** (`plans`):
-  Access to update settings of existing projects in an organization.
 - **Manage users** (`members`):
   Add, remove, and edit organization-level users and permissions, except their own.
   Users with this permission can't grant other users permissions that they themselves don't have.


### PR DESCRIPTION
### Removed 'manage plans' from Upsun section, added Admin permission to both Upsun and Platform docs

## Why
Closes #4491 

## What's changed
Removed 'manage plans' from Upsun section, added Admin permission to both Upsun and Platform docs

## Where are changes
Admin -> Users -> Organization Permissions

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
