### PR TITLE
refactoring of build from fork steps

### DIFF
--- a/.github/workflows/build-from-fork.yaml
+++ b/.github/workflows/build-from-fork.yaml
@@ -15,7 +15,13 @@ env:
 
 jobs:
   build:
-    if: github.event.label.name == 'build-fork' || contains(github.event.pull_request.labels.*.name, 'build-fork')
+    # we only want to run this job if the pull request is from a fork AND it has been given the proper label
+    if: >-
+      (
+        github.event.label.name == 'build-fork' ||
+        contains(github.event.pull_request.labels.*.name, 'build-fork'
+      ) &&
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,34 +33,21 @@ jobs:
         with:
           cli_provider: 'platform'
 
-      - name: 'checks if branch already exists'
-        id: buildthebranch
-        env:
-          PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
-        run: |
-          buildbranch='true'
-          branchExists=$(platform project:curl /environments | jq --arg branch "${{ env.BRANCH_TITLE }}" -r '.[] | select(.name | contains($branch))');
-          if [ -n "${branchExists}" ]; then
-            # branch already exists
-            buildBranch='false'
-          fi
-
-          echo "buildBranch=${buildbranch}" >> $GITHUB_OUTPUT
       # Create an environment and activate it
       - name: 'Build a branch from the fork'
-        if: ${{ 'true'  == steps.buildthebranch.outputs.buildBranch }}
         env:
           PLATFORMSH_CLI_TOKEN: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
           # @see activate_environment:Set environment title:env in manage-environment.yaml
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "::notice::Building branch from forked PR"
+          echo "Adding changes from forked PR to local branch"
           # Get most recent changes
           git checkout ${{ github.event.pull_request.head.sha }}
 
           # Put most recent changes on the branch
           echo "Switching to branch ${{ env.BRANCH_TITLE }}"
-          git switch -C ${{ env.BRANCH_TITLE }}
+          # try to switch to the branch, and if it doesn't exist, create a new branch
+          git switch ${{ env.BRANCH_TITLE }} 2>/dev/null || git switch -C ${{ env.BRANCH_TITLE }}
 
           echo "Pushing most recent changes"
           git push --force origin ${{ env.BRANCH_TITLE }}


### PR DESCRIPTION
## Why

We need to push changes from a pr-from-a-fork to our build environment

## What's changed
Refactors the build from fork step to run the sync process even if it isn't a new build (syncs)

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
- [X] general workflows