### PR TITLE
Enhance HTTP metrics documentation with sanitization measures

### DIFF
--- a/sites/platform/src/increase-observability/metrics/http-metrics.md
+++ b/sites/platform/src/increase-observability/metrics/http-metrics.md
@@ -5,7 +5,7 @@ description: Understand HTTP metrics
 
 The HTTP metrics dashboard provides {{< vendor/name >}} users with network-related metrics.
 Those insights are designed to help them better understand the state of their
-applications. 
+applications.
 
 {{< note theme="info" title="No CDN data">}}
 
@@ -56,10 +56,17 @@ time of the top-10 most impactful URLs during a given time frame.
 This graph helps identify potential trouble spots, understand user behavior, and
 prioritize areas for optimization.
 
+{{< note >}}
+For security and privacy reasons, all URLs undergo the following sanitization measures:
+- All query parameters (`?param=value`) are sanitized to prevent leakage of sensitive information.
+- URLs exceeding 2048 characters are truncated to adhere to security best practices.
+- Specific sensitive URL paths are proactively scrubbed and anonymized.
+{{< /note >}}
+
 ## Limits
 Note that the following data retention limits apply when using the HTTP metrics dashboard:
 
 - **8-hour retention** for standard customers (without Observability Suite).
 - **24-hour retention** for Observability Suite customers (Enterprise and Elite tiers).
 
-For more information about the different tiers for standard and Observability Suite customers, visit the [Pricing page](https://platform.sh/pricing/). 
+For more information about the different tiers for standard and Observability Suite customers, visit the [Pricing page](https://platform.sh/pricing/).

--- a/sites/upsun/src/increase-observability/metrics/http-metrics.md
+++ b/sites/upsun/src/increase-observability/metrics/http-metrics.md
@@ -45,3 +45,8 @@ time of the top-10 most impactful URLs during a given time frame.
 
 This graph helps identify potential trouble spots, understand user behavior, and
 prioritize areas for optimization.
+
+Note: For security and privacy reasons, all URLs undergo the following sanitization measures:
+- Query Parameters: All query parameters (?param=value) are sanitized to prevent leakage of sensitive information.
+- URL Length: URLs exceeding 2048 characters are truncated to adhere to security best practices.
+- Path Scrubbing: Specific sensitive URL paths are proactively scrubbed and anonymized.

--- a/sites/upsun/src/increase-observability/metrics/http-metrics.md
+++ b/sites/upsun/src/increase-observability/metrics/http-metrics.md
@@ -46,7 +46,9 @@ time of the top-10 most impactful URLs during a given time frame.
 This graph helps identify potential trouble spots, understand user behavior, and
 prioritize areas for optimization.
 
-Note: For security and privacy reasons, all URLs undergo the following sanitization measures:
-- Query Parameters: All query parameters (?param=value) are sanitized to prevent leakage of sensitive information.
-- URL Length: URLs exceeding 2048 characters are truncated to adhere to security best practices.
-- Path Scrubbing: Specific sensitive URL paths are proactively scrubbed and anonymized.
+{{< note >}}
+For security and privacy reasons, all URLs undergo the following sanitization measures:
+- All query parameters (`?param=value`) are sanitized to prevent leakage of sensitive information.
+- URLs exceeding 2048 characters are truncated to adhere to security best practices.
+- Specific sensitive URL paths are proactively scrubbed and anonymized.
+{{< /note >}}


### PR DESCRIPTION
Enhance HTTP metrics documentation with sanitization measures

## Why

Closes #4579 

## What's changed

Added a note detailing the sanitization measures for URLs in the HTTP metrics dashboard, including query parameter sanitization, URL length truncation, and path scrubbing for security and privacy compliance.

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
