### PR TITLE
enables robots.txt for both sites

### DIFF
--- a/sites/platform/config/_default/config.yaml
+++ b/sites/platform/config/_default/config.yaml
@@ -119,3 +119,5 @@ security:
   http:
     methods:
     - GET
+
+enableRobotsTXT: true

--- a/sites/upsun/config/_default/config.yaml
+++ b/sites/upsun/config/_default/config.yaml
@@ -126,3 +126,5 @@ security:
   http:
     methods:
     - GET
+
+enableRobotsTXT: true


### PR DESCRIPTION
Enables robots.txt in Hugo config for both sites. 
## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
