### PR TITLE
4596 guide wonkiness

### DIFF
--- a/sites/platform/src/guides/django/_index.md
+++ b/sites/platform/src/guides/django/_index.md
@@ -3,10 +3,10 @@ title: "Django"
 weight: -200
 sectionBefore: Python
 description: |
-  Everything you need to get started with [Django](https://www.djangoproject.com/), a Python framework for web development, on {{% vendor/name %}}.
+  Everything you need to get started with Django, a Python framework for web development, on {{% vendor/name %}}.
 ---
 
-{{% description %}}
+Everything you need to get started with [Django](https://www.djangoproject.com/), a Python framework for web development, on {{% vendor/name %}}.
 
 Anything included in these guides applies to not only to Django, but also [Wagtail](https://wagtail.org/), the content management system built with Django.
 

--- a/sites/platform/src/guides/gatsby/_index.md
+++ b/sites/platform/src/guides/gatsby/_index.md
@@ -3,9 +3,9 @@ title: "Gatsby"
 weight: -90
 sectionBefore: Javascript/Node.js
 description: |
-    Everything you need to get started with [Gatsby](https://www.gatsbyjs.com/), the open source framework based on React, on {{% vendor/name %}}.
+    Everything you need to get started with Gatsby, the open source framework based on React, on {{% vendor/name %}}.
 ---
 
-{{% description %}}
+Everything you need to get started with [Gatsby](https://www.gatsbyjs.com/), the open source framework based on React, on {{% vendor/name %}}.
 
 {{% guides/link-philosophy %}}

--- a/sites/platform/src/guides/laravel/_index.md
+++ b/sites/platform/src/guides/laravel/_index.md
@@ -2,9 +2,9 @@
 title: "Laravel"
 weight: -140
 description: |
-  Everything you need to get started with [Laravel](https://laravel.com/) on {{% vendor/name %}}.
+  Everything you need to get started with Laravel on {{% vendor/name %}}.
 ---
 
-{{% description %}}
+Everything you need to get started with [Laravel](https://laravel.com/) on {{% vendor/name %}}.
 
 {{% guides/link-philosophy %}}

--- a/sites/platform/src/guides/nextjs/_index.md
+++ b/sites/platform/src/guides/nextjs/_index.md
@@ -2,9 +2,9 @@
 title: "Next.js"
 weight: -80
 description: |
-  Everything you need to get started with [Next.js](https://nextjs.org/), a React framework for building websites and web apps, on {{% vendor/name %}}.
+  Everything you need to get started with Next.js, a React framework for building websites and web apps, on {{% vendor/name %}}.
 ---
 
-{{% description %}}
+Everything you need to get started with [Next.js](https://nextjs.org/), a React framework for building websites and web apps, on {{% vendor/name %}}.
 
 {{% guides/link-philosophy %}}

--- a/sites/platform/src/guides/strapi/_index.md
+++ b/sites/platform/src/guides/strapi/_index.md
@@ -2,9 +2,9 @@
 title: "Strapi"
 weight: -70
 description: |
-  Everything you need to get started with [Strapi](https://www.strapi.io/), the open source headless CMS based on NodeJS, on {{% vendor/name %}}.
+  Everything you need to get started with Strapi, the open source headless CMS based on NodeJS, on {{% vendor/name %}}.
 ---
 
-{{% description %}}
+Everything you need to get started with [Strapi](https://www.strapi.io/), the open source headless CMS based on NodeJS, on {{% vendor/name %}}.
 
 {{% guides/link-philosophy %}}

--- a/sites/platform/src/guides/symfony/_index.md
+++ b/sites/platform/src/guides/symfony/_index.md
@@ -3,9 +3,9 @@ title: "Symfony"
 weight: -150
 partner: true
 description: |
-    Everything you need to get started with [Symfony](https://www.symfony.com/), a [PHP](/development/templates.md#php) framework for web development, on {{% vendor/name %}}.
+    Everything you need to get started with Symfony, a [PHP](/development/templates.md#php) framework for web development, on {{% vendor/name %}}.
 ---
-{{% description %}}
+Everything you need to get started with [Symfony](https://www.symfony.com/), a [PHP](/development/templates.md#php) framework for web development, on {{% vendor/name %}}.
 
 [comment]: <> (See an example Symfony project in the official [Symfony template repository]&#40;https://github.com/symfonycorp/platformsh-symfony-template&#41;, which you can use as a starting point for your own project.)
 


### PR DESCRIPTION
## Why

Closes #4596

## What's changed

Removes the anchor from the description meta data for several guides, and makes that description information static in the guide itself. This is required so that we don't end up with nested anchor elements.

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
