### PR TITLE
argh, there was a second link in the description

### DIFF
--- a/sites/platform/src/guides/symfony/_index.md
+++ b/sites/platform/src/guides/symfony/_index.md
@@ -3,7 +3,7 @@ title: "Symfony"
 weight: -150
 partner: true
 description: |
-    Everything you need to get started with Symfony, a [PHP](/development/templates.md#php) framework for web development, on {{% vendor/name %}}.
+    Everything you need to get started with Symfony, a PHP framework for web development, on {{% vendor/name %}}.
 ---
 Everything you need to get started with [Symfony](https://www.symfony.com/), a [PHP](/development/templates.md#php) framework for web development, on {{% vendor/name %}}.
 


### PR DESCRIPTION
## Why

Because there was a _second_ link in the description that I overlooked


## What's changed

Removes the link

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
