### PR TITLE
fix note: on manage plans will also grant projects:list

### DIFF
--- a/sites/platform/src/administration/users.md
+++ b/sites/platform/src/administration/users.md
@@ -244,7 +244,7 @@ As an organization owner or an organization user with the **Manage users** permi
 
 Users with the **Manage users** (`members`) permission can add, edit, or remove _any_ user's permissions except their own.
 
-Users with the **Manage billing** (`billing`) permission automatically are granted **List projects** (`projects:list`) permission.
+Users with the **Manage billing** (`billing`) or **Manage Plans** (`plans`) permission automatically are granted **List projects** (`projects:list`) permission.
 That is, they are able to see all organization projects once given billing rights.
 
 {{< /note >}}

--- a/sites/platform/src/administration/users.md
+++ b/sites/platform/src/administration/users.md
@@ -245,7 +245,7 @@ As an organization owner or an organization user with the **Manage users** permi
 Users with the **Manage users** (`members`) permission can add, edit, or remove _any_ user's permissions except their own.
 
 Users with the **Manage billing** (`billing`) or **Manage Plans** (`plans`) permission automatically are granted **List projects** (`projects:list`) permission.
-That is, they are able to see all organization projects once given billing rights.
+That is, they are able to see all organization projects once given billing or plans rights.
 
 {{< /note >}}
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #4599 

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

In platformsh, manage plans permission would also grant list projects

## Where are changes
https://docs.platform.sh/administration/users.html#organization-permissions

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
