### PR TITLE
updates link to drupal template from v10 to v11

### DIFF
--- a/sites/platform/src/guides/drupal/deploy/_index.md
+++ b/sites/platform/src/guides/drupal/deploy/_index.md
@@ -11,7 +11,7 @@ Drupal is a flexible and extensible PHP-based CMS framework. To deploy Drupal on
 
 This guide assumes you are using the well-supported Composer flavor of Drupal.
 
-{{% guides/starting-point name="Drupal" templateRepo="drupal10" composerLink="https://github.com/drupal/recommended-project/" initExample=true %}}
+{{% guides/starting-point name="Drupal" templateRepo="drupal11" composerLink="https://github.com/drupal/recommended-project/" initExample=true %}}
 
 {{% guides/requirements %}}
 


### PR DESCRIPTION
## Why
In the drupal guides updates the link to the template from v10 to v11