### PR TITLE
update to html --> markdown replacement

### DIFF
--- a/themes/psh-docs/layouts/partials/llms/replace-html.md
+++ b/themes/psh-docs/layouts/partials/llms/replace-html.md
@@ -99,7 +99,7 @@
 {{- $content = $content
   | replaceRE ` ([a-zA-Z0-9\@:-]){2,}="([][a-zA-Z0-9\.\_\!\+:='\''\;,\/\{\}\(\)\&><↗\ -]{0,})"` ``
   | replaceRE `<([A-Z0-9_]+)>` "##PLACEHOLDER_START##${1}##PLACEHOLDER_END##"
-  | replaceRE `<[^>]+>` ""
+  | replaceRE `<[^>\n]+>` ""
   | replaceRE "##PLACEHOLDER_START##(.*?)##PLACEHOLDER_END##" "<${1}>"
   | replaceRE `\[Back\]\([^)]+\)[\n|\ ]*\[[^\]]+\]\([^)]+\)` "\n"
 


### PR DESCRIPTION
## Why

Closes #4608 

Please note: this is only a temporary fix until I can discuss with @flovntp if the intention of line 102 is to clean out comments (ie `<!-- -->`) or "any other remaining html elements". If it's the former, we should target those specifically. if it's the latter, then we need to brainstorm on some solutions as what is proposed in this PR is brittle (ie new lines before the ending `>` in an html element _is_ valid, just not common). 