### PR TITLE
feat: added support nix channels section

### DIFF
--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -103,6 +103,11 @@ and visit the documentation page dedicated to your runtime.
 If you use PHP, note that PHP-FPM is only started automatically if PHP is defined as the primary runtime.
 {{% /note %}}
 
+### Supported Nix channels
+
+- `24.05`
+- `25.05`
+
 ### Supported Nix packages
 
 {{% note %}}

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -123,6 +123,11 @@ and visit the documentation page dedicated to your runtime.
 If you use PHP, note that PHP-FPM is only started automatically if PHP is defined as the primary runtime.
 {{% /note %}}
 
+### Supported Nix channels
+
+- `24.05`
+- `25.05`
+
 ### Supported Nix packages
 
 {{% note %}}


### PR DESCRIPTION
Added supported nix channels section

## Why

Closes #4622 

## What's changed

Added supported nix channels section - still need to add note about type and stack

## Where are changes

composable image page

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
