### PR TITLE
The big one

### DIFF
--- a/sites/platform/src/add-services/memcached.md
+++ b/sites/platform/src/add-services/memcached.md
@@ -75,11 +75,7 @@ To define the service, use the `memcached` type:
 # The name of the service container. Must be unique within a project.
 <SERVICE_NAME>:
   type: memcached:<VERSION>
-  disk: 256
 ```
-
-Note that changing the name of the service replaces it with a brand new service and all existing data is lost.
-Back up your data before changing the service.
 
 ### 2. Define the relationship
 

--- a/sites/platform/src/create-apps/web/rewrite-requests.md
+++ b/sites/platform/src/create-apps/web/rewrite-requests.md
@@ -39,7 +39,7 @@ Now a request to `/img/image.png` returns the file found at `/png/image.png`.
 
 ## Query parameters
 
-Query parameters in the request are unaffected and are passed in the request to the app.
-So if you have the category and product rule from previously, a request to `/shoes/great-shoe/?product=terrible-shoe`
+Query parameters in the request are untouched by rules and will be passed to the app.
+For example, if you have the category and product rule from previously, a request to `/shoes/great-shoe/?product=terrible-shoe`
 is rewritten to `?category=shoes&product=great-shoe&product=terrible-shoe`.
-In that case, the `product` query parameter returns as `terrible-shoe`.
+In that case, the `product` query parameter sent to the app will contain the value `terrible-shoe`.

--- a/sites/platform/src/define-routes/_index.md
+++ b/sites/platform/src/define-routes/_index.md
@@ -152,7 +152,7 @@ URLs in [preview environments](/glossary/_index.md#preview-environment) (develop
 No matter how you have set your default domain (even if you don't have one),
 using either the absolute URL or the `{default}` placeholder results in the same URL.
 
-In any case, you get the same URL for a `feature` environment:
+In any case, you get the same URL for an environment named `feature`:
 
 ```txt
 https://feature-t6dnbai-abcdef1234567.us-2.{{< vendor/urlraw "hostname" >}}/blog
@@ -246,7 +246,7 @@ If you have configured `example.com` as your default domain,
 HTTP requests to `www.example.com`, `blog.example.com`, and `us.example.com` are all routed to the same endpoint.
 
 It also works on preview environments.
-If you have a `feature` branch, it's `{default}` domain looks something like:
+If you have a branch named `feature`, it's `{default}` domain looks something like:
 `feature-def123-vmwklxcpbi6zq.us.{{< vendor/urlraw "host" >}}` (depending on the project's region).
 So requests to `blog.feature-def123-vmwklxcpbi6zq.us.{{< vendor/urlraw "host" >}}` and `us.feature-def123-vmwklxcpbi6zq.eu.{{< vendor/urlraw "host" >}}`
 are both routed to the same endpoint.
@@ -295,10 +295,10 @@ You can define your routes like this:
   upstream: 'app2:http'
 ```
 
-To see the generated routes on your `feature` environment, run:
+To see the generated routes on your environment named `feature`, run:
 
 ```bash
-{{% vendor/cli %}} ssh -e feature 'echo $PLATFORM_ROUTES | base64 --decode | jq .'
+{{% vendor/cli %}} ssh --environment feature 'echo $PLATFORM_ROUTES | base64 --decode | jq .'
 ```
 
 The result is something like this:

--- a/sites/platform/src/development/submodules.md
+++ b/sites/platform/src/development/submodules.md
@@ -231,8 +231,9 @@ To fix this, follow these steps:
         branch = submodule/branch
     ```
 
-2. Add the [project's public key to your remote Git repository](/development/private-repository.md).
-   This allows your {{% vendor/name %}} project to pull the repository from the remote Git service.
+2. Add the [project's public key to your remote Git repository](/development/private-repository.md). If there are nested
+   submodules in your submodule, then add the public key to those repositories as well. This allows your
+   {{% vendor/name %}} project to pull the repository from the remote Git service.
 
 {{< note >}}
 

--- a/sites/platform/src/learn/tutorials/dependency-updates.md
+++ b/sites/platform/src/learn/tutorials/dependency-updates.md
@@ -228,6 +228,12 @@ Make sure you carefully check your [user access on this project](/administration
 The example above synchronizes the `development` environment with its parent
 and then runs the `update` source operation defined [previously](#1-define-a-source-operation-to-update-your-dependencies).
 
+{{< note theme="warning">}}
+If you have enabled a [source integration](integrations/source.html), and have enabled `--fetch-branches` on that
+integration, merging on {{% vendor/name %}} is not possible. Therefore, the `sync` command in the example above would
+fail.
+{{< /note >}}
+
 ## 3. Configure notifications about dependency updates
 
 To get notified every time a source operation is triggered and therefore every time a dependency is updated,

--- a/sites/platform/src/learn/tutorials/dependency-updates.md
+++ b/sites/platform/src/learn/tutorials/dependency-updates.md
@@ -229,7 +229,7 @@ The example above synchronizes the `development` environment with its parent
 and then runs the `update` source operation defined [previously](#1-define-a-source-operation-to-update-your-dependencies).
 
 {{< note theme="warning">}}
-If you have enabled a [source integration](integrations/source.html), and have enabled `--fetch-branches` on that
+If you have enabled a [source integration](/integrations/source.html), and have enabled `--fetch-branches` on that
 integration, merging on {{% vendor/name %}} is not possible. Therefore, the `sync` command in the example above would
 fail.
 {{< /note >}}

--- a/sites/platform/src/security/_index.md
+++ b/sites/platform/src/security/_index.md
@@ -5,9 +5,9 @@ description: |
   Learn how {{% vendor/name %}} ensures your data is handled with appropriate care and according to industry standards.
 banner:
    title: Note
-   body: Your main source of information about the security, privacy,
-         and compliance of the {{% vendor/name %}} products and services,
-         is now the Platform.sh [Trust Center](https://platform.sh/trust-center/).
+   body: For more details about the security, and privacy of our products and services, along with information about our
+     security certifications like PCI, SOC2, HIPAA, etc. please visit the
+     [Trust Center](https://platform.sh/trust-center/).
 keywords:
 - pen-test
 - penetration test

--- a/sites/upsun/src/create-apps/web/rewrite-requests.md
+++ b/sites/upsun/src/create-apps/web/rewrite-requests.md
@@ -47,7 +47,7 @@ Now a request to `/img/image.png` returns the file found at `/png/image.png`.
 
 ## Query parameters
 
-Query parameters in the request are unaffected and are passed in the request to the app.
-So if you have the category and product rule from previously, a request to `/shoes/great-shoe/?product=terrible-shoe`
+Query parameters in the request are untouched by rules and will be passed to the app.
+For example, if you have the category and product rule from previously, a request to `/shoes/great-shoe/?product=terrible-shoe`
 is rewritten to `?category=shoes&product=great-shoe&product=terrible-shoe`.
-In that case, the `product` query parameter returns as `terrible-shoe`.
+In that case, the `product` query parameter sent to the app will contain the value `terrible-shoe`.

--- a/sites/upsun/src/define-routes/_index.md
+++ b/sites/upsun/src/define-routes/_index.md
@@ -155,7 +155,7 @@ URLs in [preview environments](../glossary/_index.md#preview-environment) (devel
 No matter how you have set your default domain (even if you don't have one),
 using either the absolute URL or the `{default}` placeholder results in the same URL.
 
-In any case, you get the same URL for a `feature` environment:
+In any case, you get the same URL for an environment named `feature`:
 
 ```txt
 https://feature-t6dnbai-abcdef1234567.us-2.{{< vendor/urlraw "hostname" >}}/blog
@@ -217,7 +217,7 @@ If you have configured `example.com` as your default domain,
 HTTP requests to `www.example.com`, `blog.example.com`, and `us.example.com` are all routed to the same endpoint.
 
 It also works on preview environments.
-If you have a `feature` branch, it's `{default}` domain looks something like:
+If you have a branch named `feature`, it's `{default}` domain looks something like:
 `feature-def123-vmwklxcpbi6zq.us.{{< vendor/urlraw "host" >}}` (depending on the project's region).
 So requests to `blog.feature-def123-vmwklxcpbi6zq.us.{{< vendor/urlraw "host" >}}` and `us.feature-def123-vmwklxcpbi6zq.eu.{{< vendor/urlraw "host" >}}`
 are both routed to the same endpoint.
@@ -255,10 +255,10 @@ routes:
     upstream: 'app2:http'
 ```
 
-To see the generated routes on your `feature` environment, run:
+To see the generated routes on your environment named `feature`, run:
 
 ```bash
-{{% vendor/cli %}} ssh -e feature 'echo $PLATFORM_ROUTES | base64 --decode | jq .'
+{{% vendor/cli %}} ssh --environment feature 'echo $PLATFORM_ROUTES | base64 --decode | jq .'
 ```
 
 The result is something like this:

--- a/sites/upsun/src/development/submodules.md
+++ b/sites/upsun/src/development/submodules.md
@@ -243,8 +243,9 @@ To fix this, follow these steps:
         branch = submodule/branch
     ```
 
-2. Add the [project's public key to your remote Git repository](/development/private-repository.md).
-   This allows your {{% vendor/name %}} project to pull the repository from the remote Git service.
+2. Add the [project's public key to your remote Git repository](/development/private-repository.md). If there are nested
+   submodules in your submodule, then add the public key to those repositories as well. This allows your
+   {{% vendor/name %}} project to pull the repository from the remote Git service.
 
 {{< note >}}
 

--- a/sites/upsun/src/learn/tutorials/dependency-updates.md
+++ b/sites/upsun/src/learn/tutorials/dependency-updates.md
@@ -233,6 +233,12 @@ applications:
 The example above synchronizes the `development` environment with its parent
 and then runs the `update` source operation defined [previously](#1-define-a-source-operation-to-update-your-dependencies).
 
+{{< note theme="warning">}}
+If you have enabled a [source integration](integrations/source.html), and have enabled `--fetch-branches` on that
+integration, merging on {{% vendor/name %}} is not possible. Therefore, the `sync` command in the example above would
+fail.
+{{< /note >}}
+
 ## 3. Configure notifications about dependency updates
 
 To get notified every time a source operation is triggered and therefore every time a dependency is updated,

--- a/sites/upsun/src/learn/tutorials/dependency-updates.md
+++ b/sites/upsun/src/learn/tutorials/dependency-updates.md
@@ -234,7 +234,7 @@ The example above synchronizes the `development` environment with its parent
 and then runs the `update` source operation defined [previously](#1-define-a-source-operation-to-update-your-dependencies).
 
 {{< note theme="warning">}}
-If you have enabled a [source integration](integrations/source.html), and have enabled `--fetch-branches` on that
+If you have enabled a [source integration](/integrations/source.html), and have enabled `--fetch-branches` on that
 integration, merging on {{% vendor/name %}} is not possible. Therefore, the `sync` command in the example above would
 fail.
 {{< /note >}}

--- a/sites/upsun/src/manage-resources/resource-init.md
+++ b/sites/upsun/src/manage-resources/resource-init.md
@@ -165,13 +165,13 @@ Once a resource initialization strategy is specified for your source integration
 it applies to **all** the deployments you launch through that source integration.
 
 {{< /note >}}
-
+#### **When creating a new source integration**
 To specify a resource initialization strategy when [creating your source integration](/integrations/source/_index.md),
 include the `--resources-init` flag in your source integration options.</br>
 For example, if you [set up a GitHub integration](/integrations/source/github.md), use the following options:
 
 ```bash {location="Terminal"}
-platform integration:add \
+{{% vendor/cli %}} integration:add \
   --project {{< variable "PROJECT_ID" >}} \
   --type github \
   --repository {{< variable "OWNER/REPOSITORY" >}} \
@@ -179,7 +179,7 @@ platform integration:add \
   --base-url {{< variable "GITHUB_URL" >}}
   --resources-init {{< variable "INITIALIZATION_STRATEGY" >}}
 ```
-
+#### **Update an existing source integration**
 To specify a resource initialization strategy for an existing source integration,
 run the following command:
 

--- a/sites/upsun/src/security/_index.md
+++ b/sites/upsun/src/security/_index.md
@@ -5,9 +5,9 @@ description: |
   Learn how {{% vendor/name %}} ensures your data is handled with appropriate care and according to industry standards.
 banner:
    title: Note
-   body: Your main source of information about the security, privacy,
-         and compliance of the {{% vendor/name %}} products and services,
-         is now the Platform.sh [Trust Center](https://platform.sh/trust-center/).
+   body: For more details about the security, and privacy of our products and services, along with information about our
+         security certifications like PCI, SOC2, HIPAA, etc. please visit the
+         [Trust Center](https://platform.sh/trust-center/).
 keywords:
 - pen-test
 - penetration test

--- a/themes/psh-docs/layouts/shortcodes/source-integration/enable-integration.html
+++ b/themes/psh-docs/layouts/shortcodes/source-integration/enable-integration.html
@@ -54,8 +54,9 @@
 {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your ` $baseUrlServer ` server if you self-host.
   If you use the public <code>` $baseUrlSource `</code>, omit the <code>--base-url</code> flag when running the command.` }}
 {{ else if ( eq $source "Bitbucket server" )}}
-  {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the base URL for your Bitbucket server.` }}
-  {{ $baseUrlExample = "--base-url https://example.com " }}
+  {{ $baseUrlExpanation = print `- <code>` $base_url_variable `</code> is the URL for your Bitbucket server.` }}
+  {{ $baseUrlExample = "--bitbucket-url https://example.com " }}
+  {{ $baseUrlVariable = print `--bitbucket-url {{< variable ` $base_url_variable ` >}} `}}
 {{ else if ( eq $source "Bitbucket" ) }}
   {{ $baseUrlVariable = "" }}
   {{ $exampleUrl = "bitbucket.org" }}
@@ -74,7 +75,9 @@
 {{ $accessFlagsExample := "--token abc123" }}
 {{ if ( eq $source "Bitbucket server" ) }}
   {{ $accessFlagsVariable = print `--username {{< variable BITBUCKET_USERNAME >}} \` "\n  " $accessFlagsVariable }}
-  {{ $accessFlagsExample = print `--username user@example.com \` "\n  " $accessFlagsExample}}
+  {{ $accessFlagsExample = print `--username user@example.com \` "\n  " $accessFlagsExample }}
+  {{ $accessFlagsExample = print $accessFlagsExample "\n  " }}
+  {{ $accessFlagsExample = print $accessFlagsExample $baseUrlExample}}
 {{ end }}
 {{ if ( eq $source "Bitbucket" ) }}
   {{ $accessFlagsVariable = print `--key {{< variable CONSUMER_KEY >}} \` "\n  " "--secret {{< variable CONSUMER_SECRET >}}" }}


### PR DESCRIPTION
## Why

Closes #3597 
Closes #3807 
Closes #3943 
Closes #4130 
Closes #4219 
Closes #4253 
Closes #4323 
Closes #4325 

## What's changed
- clarifies how parameters are handled in regards to rewrite rules.
- corrects cli name, clarifies new integration vs editing existing
- adds warning about merging on psh/upsun is not possible with source integration
- adds note to indicate deploy keys need to be added to nested submodules
- changes command sample and example code for bitbucket server to add correct parameters.
- clarification on our certs, per @rinchen 
- removes disk property from memcached as it can't have disk, removes warning about losing data
- clarifies example name used is the name of the environment/branch.  

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
