### PR TITLE
4605 upsun no plans

### DIFF
--- a/sites/upsun/src/administration/organizations.md
+++ b/sites/upsun/src/administration/organizations.md
@@ -142,7 +142,7 @@ To delete the organization `acme`, run:
 ## Transfer project ownership
 
 You can transfer your project ownership to a different organization at anytime.
-You have to be an organization owner or have the [manage billing permission](/administration/users.md#organization-permissions).
+To do this, you must be an organization owner or have the [manage billing permission](/administration/users.md#organization-permissions).
 
 1. Make the new organization owner a [project admin](/administration/users.md#)
    for the project you want to transfer.

--- a/sites/upsun/src/administration/organizations.md
+++ b/sites/upsun/src/administration/organizations.md
@@ -141,8 +141,8 @@ To delete the organization `acme`, run:
 
 ## Transfer project ownership
 
-You can transfer your plan ownership to a different organization at anytime.
-You have to be an organization owner or have the [manage plan permission](/administration/users.md#organization-permissions).
+You can transfer your project ownership to a different organization at anytime.
+You have to be an organization owner or have the [manage billing permission](/administration/users.md#organization-permissions).
 
 1. Make the new organization owner a [project admin](/administration/users.md#)
    for the project you want to transfer.

--- a/sites/upsun/src/create-apps/multi-app/_index.md
+++ b/sites/upsun/src/create-apps/multi-app/_index.md
@@ -2,10 +2,6 @@
 title: Set up multiple apps in a single project
 sidebarTitle: Multiple apps
 description: Create multiple apps within a single project, such as a CMS backend connected to a frontend to display it.
-banner:
-   title: Feature availability
-   type: tiered-feature
-   body: This page applies to Grid and {{% names/dedicated-gen-3 %}} projects. To ensure you have enough resources to support multiple apps, you need at least a [{{< partial "plans/multiapp-plan-name" >}} plan](/administration/pricing/_index.md#multiple-apps-in-a-single-project). To set up multiple apps on {{% names/dedicated-gen-2 %}} environments, [contact Sales](https://platform.sh/contact/).
 ---
 
 {{% multi-app-intro %}}

--- a/sites/upsun/src/create-apps/multi-app/project-structure.md
+++ b/sites/upsun/src/create-apps/multi-app/project-structure.md
@@ -2,10 +2,6 @@
 title: Choose a project structure
 weight: 10
 description: Explore possible code structures you can apply to your multiple application projects.
-banner:
-   title: Feature availability
-   type: tiered-feature
-   body: This page applies to Grid and {{% names/dedicated-gen-3 %}} projects. To ensure you have enough resources to support multiple apps, you need at least a [{{< partial "plans/multiapp-plan-name" >}} plan](/administration/pricing/_index.md#multiple-apps-in-a-single-project). To set up multiple apps on {{% names/dedicated-gen-2 %}} environments, [contact Sales](https://platform.sh/contact/).
 ---
 
 How you structure a project with multiple apps depends on how your code is organized

--- a/sites/upsun/src/create-apps/multi-app/relationships.md
+++ b/sites/upsun/src/create-apps/multi-app/relationships.md
@@ -3,10 +3,6 @@ title: Define relationships between your multiple apps
 sidebarTitle: Define relationships
 weight: 30
 description: Find out how relationships are managed between your apps.
-banner:
-   title: Feature availability
-   type: tiered-feature
-   body: This page applies to Grid and {{% names/dedicated-gen-3 %}} projects. To ensure you have enough resources to support multiple apps, you need at least a [{{< partial "plans/multiapp-plan-name" >}} plan](/administration/pricing/_index.md#multiple-apps-in-a-single-project). To set up multiple apps on {{% names/dedicated-gen-2 %}} environments, [contact Sales](https://platform.sh/contact/).
 ---
 
 When you set up a project containing multiple applications,

--- a/sites/upsun/src/create-apps/multi-app/routes.md
+++ b/sites/upsun/src/create-apps/multi-app/routes.md
@@ -3,10 +3,6 @@ title: Define routes for your multiple apps
 sidebarTitle: Define routes
 weight: 20
 description: Learn about the many ways you can define routes between your apps.
-banner:
-   title: Feature availability
-   type: tiered-feature
-   body: This page applies to Grid and {{% names/dedicated-gen-3 %}} projects. To ensure you have enough resources to support multiple apps, you need at least a [{{< partial "plans/multiapp-plan-name" >}} plan](/administration/pricing/_index.md#multiple-apps-in-a-single-project). To set up multiple apps on {{% names/dedicated-gen-2 %}} environments, [contact Sales](https://platform.sh/contact/).
 ---
 
 When you set up a project containing multiple applications,

--- a/sites/upsun/src/environments/_index.md
+++ b/sites/upsun/src/environments/_index.md
@@ -48,12 +48,10 @@ These are called [inactive environments](#environment-status).
 
 ## Default environment
 
-Your default environment comes from your default branch and is a [production environment](../administration/users.md#environment-type-roles).
-Your project must have a default environment,
-but you can [name it as you want](/environments/default-environment.md).
-
-If you subscribed to a production plan, this environment is your **live site**.
-You might want to give it a [custom domain name](../domains/steps/_index.md).
+Your default environment comes from your default branch and is a
+[production environment](../administration/users.md#environment-type-roles). Your project must have a default
+environment, but you can [name it as you want](/environments/default-environment.md). This environment is your
+**live site**. You might want to give it a [custom domain name](../domains/steps/_index.md).
 
 ## Environment status
 

--- a/sites/upsun/src/learn/bestpractices/oneormany.md
+++ b/sites/upsun/src/learn/bestpractices/oneormany.md
@@ -97,7 +97,7 @@ Leveraging the multi-site capabilities of an app are appropriate only in the fol
 
 - There is only a single team working on all of the "sites" involved
 - All "sites" should be updated simultaneously as a single unit
-- Each individual site is relatively low traffic, such that the aggregate traffic is appropriate for the site's
+- Each individual site is relatively low traffic. This means that the total traffic for all sites is appropriate for the resources that have been allocated. 
   [allocated resources](/manage-resources.md)
 - All sites really do use the same codebase with no variation, just different data
 

--- a/sites/upsun/src/learn/bestpractices/oneormany.md
+++ b/sites/upsun/src/learn/bestpractices/oneormany.md
@@ -97,7 +97,8 @@ Leveraging the multi-site capabilities of an app are appropriate only in the fol
 
 - There is only a single team working on all of the "sites" involved
 - All "sites" should be updated simultaneously as a single unit
-- Each individual site is relatively low traffic, such that the aggregate traffic is appropriate for your plan size
+- Each individual site is relatively low traffic, such that the aggregate traffic is appropriate for the site's
+  [allocated resources](/manage-resources.md)
 - All sites really do use the same codebase with no variation, just different data
 
 Otherwise, [separate projects](#separate-projects) are a better long-term plan.

--- a/sites/upsun/src/projects/region-migration.md
+++ b/sites/upsun/src/projects/region-migration.md
@@ -121,7 +121,7 @@ After you have finished all your testing, sync all your data (code, files, datab
 
 Now that you know the new project works, switch public traffic to that site:
 
-1. Make sure your new project has the right plan size.
+1. Make sure your new project has the [necessary resources](/manage-resources/adjust-resources.md).
 2. If possible, put your site into read-only mode or maintenance mode.
 3. Add your domain names to your new project and remove them from the old project.
 4. (Optional) Add any custom SSL certificates you have.


### PR DESCRIPTION
## Why

Closes #4605 

## What's changed

In general, removes all mentions of "plans" as it related to projects as Upsun does not utilize plans.

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
