### PR TITLE
composer require alt repos and schema properties in global php dependencies

### DIFF
--- a/sites/platform/src/languages/php/_index.md
+++ b/sites/platform/src/languages/php/_index.md
@@ -211,8 +211,8 @@ use the following:
 ```yaml {configFile="app"}
 dependencies:
   php:
-    composer/composer: '^2'
     require:
+      composer/composer: '^2'
       "platformsh/client": "2.x-dev"
     repositories:
       - type: vcs

--- a/sites/platform/src/languages/php/_index.md
+++ b/sites/platform/src/languages/php/_index.md
@@ -218,6 +218,47 @@ dependencies:
       - type: vcs
         url: "git@github.com:platformsh/platformsh-client-php.git"
 ```
+
+### Additional Composer schema properties
+In addition to [alternate repositories](#alternative-repositories), other
+[Composer schema properties](https://getcomposer.org/doc/04-schema.md) can be added to the global dependencies. For
+example, one of your dependencies may be a plugin where you need to explicitly whitelist it as an
+[allowed-plugin](https://getcomposer.org/doc/06-config.md#allow-plugins).
+
+To add additional composer schema properties:
+
+1. Set an explicit `require` block:
+
+```yaml {configFile="app"}
+applications:
+  # The app's name, which must be unique within the project.
+  myapp:
+    type: 'php:{{% latest "php" %}}'
+    <snip>
+    dependencies:
+      php:
+        require:
+          "third-party/required-plugin"": "^3.0"
+```
+
+2. Add each additional property as a block at the same indentation as the `require` block:
+
+```yaml {configFile="app"}
+applications:
+  # The app's name, which must be unique within the project.
+  myapp:
+    type: 'php:{{% latest "php" %}}'
+    <snip>
+    dependencies:
+      php:
+        require:
+          symfony/runtime: '*'
+        config:
+          "allow-plugins":
+            symfony/runtime: true
+```
+
+
 ## Connect to services
 
 The following examples show how to use PHP to access various [services](/add-services/_index.md).

--- a/sites/upsun/src/languages/php/_index.md
+++ b/sites/upsun/src/languages/php/_index.md
@@ -133,7 +133,7 @@ applications:
   # The app's name, which must be unique within the project.
   myapp:
     type: 'php:{{% latest "php" %}}'
-    [...]
+    <snip>
     dependencies:
       php:
         composer/composer: '^2'
@@ -159,7 +159,7 @@ applications:
   # The app's name, which must be unique within the project.
   myapp:
     type: 'php:{{% latest "php" %}}'
-    [...]
+    <snip>
     build:
       flavor: none
 
@@ -188,7 +188,7 @@ applications:
   # The app's name, which must be unique within the project.
   myapp:
     type: 'php:{{% latest "php" %}}'
-    [...]
+    <snip>
     dependencies:
       php:
         require:
@@ -203,7 +203,7 @@ applications:
   # The app's name, which must be unique within the project.
   myapp:
     type: 'php:{{% latest "php" %}}'
-    [...]
+    <snip>
     dependencies:
       php:
         require:
@@ -225,8 +225,8 @@ applications:
     [...]
     dependencies:
       php:
-        composer/composer: '^2'
         require:
+          composer/composer: '^2'
           "platformsh/client": "2.x-dev"
         repositories:
           - type: vcs

--- a/sites/upsun/src/languages/php/_index.md
+++ b/sites/upsun/src/languages/php/_index.md
@@ -232,6 +232,46 @@ applications:
           - type: vcs
             url: "git@github.com:platformsh/platformsh-client-php.git"
 ```
+
+### Additional Composer schema properties
+In addition to [alternate repositories](#alternative-repositories), other
+[Composer schema properties](https://getcomposer.org/doc/04-schema.md) can be added to the global dependencies. For
+example, one of your dependencies may be a plugin where you need to explicitly whitelist it as an
+[allowed-plugin](https://getcomposer.org/doc/06-config.md#allow-plugins).
+
+To add additional composer schema properties:
+
+1. Set an explicit `require` block:
+
+```yaml {configFile="app"}
+applications:
+  # The app's name, which must be unique within the project.
+  myapp:
+    type: 'php:{{% latest "php" %}}'
+    <snip>
+    dependencies:
+      php:
+        require:
+          "third-party/required-plugin"": "^3.0"
+```
+
+2. Add each additional property as a block at the same indentation as the `require` block:
+
+```yaml {configFile="app"}
+applications:
+  # The app's name, which must be unique within the project.
+  myapp:
+    type: 'php:{{% latest "php" %}}'
+    <snip>
+    dependencies:
+      php:
+        require:
+          symfony/runtime: '*'
+        config:
+          "allow-plugins":
+            symfony/runtime: true
+```
+
 ## Connect to services
 
 {{< codetabs v2hide="true" >}}


### PR DESCRIPTION
## Why

Closes #4591 

## What's changed

- Fixes the example that mixed the default dependencies section with `require`
- Adds section on using other composer schema properties in the global php dependencies area 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
