### PR TITLE
feat: updated installation intro and added note

### DIFF
--- a/sites/platform/src/get-started/introduction.md
+++ b/sites/platform/src/get-started/introduction.md
@@ -58,6 +58,12 @@ This lets you carry out various actions from a terminal.
 
 {{< cli-installation >}}
 
+{{< note theme="info" >}}
+
+If you are using Scoop, you **must** have the [Extras bucket](https://github.com/ScoopInstaller/Extras) already installed before installing the {{% vendor/name %}} CLI.
+
+{{< /note >}}
+
 ### Code
 
 To start a project, you should have code on your computer that you'd like to deploy.

--- a/sites/upsun/src/administration/cli/_index.md
+++ b/sites/upsun/src/administration/cli/_index.md
@@ -19,6 +19,12 @@ Its source code is hosted on [GitHub](https://github.com/platformsh/cli).
 
 {{< cli-installation >}}
 
+{{< note theme="info" >}}
+
+If you are using Scoop, you **must** have the [Extras bucket](https://github.com/ScoopInstaller/Extras) already installed before installing the {{% vendor/name %}} CLI.
+
+{{< /note >}}
+
 ## 2. Authenticate
 
 To list and manage your projects, authenticate by running the following command:

--- a/themes/psh-docs/layouts/shortcodes/cli-installation.html
+++ b/themes/psh-docs/layouts/shortcodes/cli-installation.html
@@ -1,6 +1,6 @@
 <p>To install the CLI, use a <a href="https://github.com/platformsh/cli#user-content-bash-installer">Bash installation script</a>.
 You can also install with <a href="https://brew.sh/">Homebrew</a> (on Linux, macOS, or the Windows Subsystem for Linux)
-or <a href="https://scoop.sh/">Scoop</a> (on Windows).</p>
+or <a href="https://scoop.sh/">Scoop</a> (on Windows. You must also have the <a href="https://github.com/ScoopInstaller/Extras">Extras bucket</a> already installed for this).</p>
 
 {{ $Inner := "" }}
 {{ if eq .Site.Params.vendor.config.version 1 }}


### PR DESCRIPTION
### Updated installation intro and added note for Scoop users

## Why

Closes #4638 

## What's changed

I have updated the cli-installation shortcode with a new intro and added a note for Scoop users after tabs. 

## Where are changes

https://docs.platform.sh/get-started/introduction.html#cli
https://docs.upsun.com/administration/cli.html

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
