### PR TITLE
Json version of outbound ips

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -23,12 +23,16 @@
     hooks:
         # Build hooks can modify the application files on disk but not access any services like databases.
         build: |
-            set -e
-            cd $SITE_DIR
-            cp ../../themes/psh-docs/postcss.config.js .
-            npm install
-            npm run build
-            ./build_docs.sh
+          set -e
+          cd $SITE_DIR
+          cp ../../themes/psh-docs/postcss.config.js .
+          npm install
+          npm run build
+          ./build_docs.sh
+          # temporary generation of json version of public regions + ip addresses
+          # if this is still here after 20250621 ping @gilzow and ask why
+          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${SITE_DIR}/public/regions.json"
+
         deploy: |
             cd $SITE_DIR
             ./deploy.sh
@@ -93,11 +97,15 @@
     hooks:
         # Build hooks can modify the application files on disk but not access any services like databases.
         build: |
-            cd $SITE_DIR
-            cp ../../themes/psh-docs/postcss.config.js .
-            npm install
-            npm run build
-            ./build_docs.sh
+          cd $SITE_DIR
+          cp ../../themes/psh-docs/postcss.config.js .
+          npm install
+          npm run build
+          ./build_docs.sh
+          # temporary generation of json version of public regions + ip addresses
+          # if this is still here after 20250621 ping @gilzow and ask why
+          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${SITE_DIR}/public/regions.json"
+
         deploy: |
             cd $SITE_DIR
             ./deploy.sh

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -29,9 +29,6 @@
           npm install
           npm run build
           ./build_docs.sh
-          # temporary generation of json version of public regions + ip addresses
-          # if this is still here after 20250621 ping @gilzow and ask why
-          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/regions.json"
 
         deploy: |
             cd $SITE_DIR

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -104,7 +104,7 @@
           ./build_docs.sh
           # temporary generation of json version of public regions + ip addresses
           # if this is still here after 20250621 ping @gilzow and ask why
-          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/regions.json"
+          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' | jq '[.. | objects | .outbound_ips? // empty] | add' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/regions.json"
 
         deploy: |
             cd $SITE_DIR

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -31,7 +31,7 @@
           ./build_docs.sh
           # temporary generation of json version of public regions + ip addresses
           # if this is still here after 20250621 ping @gilzow and ask why
-          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${SITE_DIR}/public/regions.json"
+          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/regions.json"
 
         deploy: |
             cd $SITE_DIR
@@ -104,7 +104,7 @@
           ./build_docs.sh
           # temporary generation of json version of public regions + ip addresses
           # if this is still here after 20250621 ping @gilzow and ask why
-          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${SITE_DIR}/public/regions.json"
+          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/regions.json"
 
         deploy: |
             cd $SITE_DIR

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -101,7 +101,7 @@
           ./build_docs.sh
           # temporary generation of json version of public regions + ip addresses
           # if this is still here after 20250621 ping @gilzow and ask why
-          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' | jq '[.. | objects | .outbound_ips? // empty] | add' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/regions.json"
+          cat "${PLATFORM_APP_DIR}/shared/data/regions.yaml" | python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(str(sys.stdin.read()))))' | jq '[.. | objects | .outbound_ips? // empty] | add' > "${PLATFORM_APP_DIR}/${SITE_DIR}/public/outbound_ips.json"
 
         deploy: |
             cd $SITE_DIR


### PR DESCRIPTION
## Why

Request for a json version of regions.yaml that contains only outbound IP addresses

## What's changed
Adds a "one line" command to the build step on docs.upsun.com to convert the yaml to json, filter down to just the outbound IP addresses and save the file as `outbound_ips.json` in the root of the site. 

This **should be a _temporary_ solution** until we can find a more appropriate location for this information to live.

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
