### PR TITLE
feat: added note about SSO for machine users

### DIFF
--- a/sites/platform/src/administration/cli/api-tokens.md
+++ b/sites/platform/src/administration/cli/api-tokens.md
@@ -56,7 +56,7 @@ title=In the Console
 
 {{< note theme="info" >}}
 
-Machine users with an email address under your SSO domain can be excluded from the SSO enforcement rule so they aren’t required to authenticate through your identity provider. See the [SSO documentation](/administration/security/sso.html#service-users) for more information.
+Machine users with an email address under your Single Sign-On (SSO) domain can be excluded from the SSO enforcement rule so they aren’t required to authenticate through your identity provider. See the [SSO documentation](/administration/security/sso.html#service-users) for more information.
 
 {{< /note >}}
 

--- a/sites/platform/src/administration/cli/api-tokens.md
+++ b/sites/platform/src/administration/cli/api-tokens.md
@@ -54,6 +54,12 @@ title=In the Console
 
 {{< /codetabs >}}
 
+{{< note theme="info" >}}
+
+Machine users with an email address under your SSO domain can be excluded from the SSO enforcement rule so they aren’t required to authenticate through your identity provider. See the [SSO documentation](/administration/security/sso.html#service-users) for more information.
+
+{{< /note >}}
+
 
 ## 2. Create an API token
 


### PR DESCRIPTION
added note about SSO for machine users

## Why

Closes #4648 

## What's changed
added note about SSO for machine users

## Where are changes
https://docs.platform.sh/administration/cli/api-tokens.html#1-create-a-machine-user

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
