### PR TITLE
feat: added note about route limits

### DIFF
--- a/sites/platform/src/define-routes/redirects.md
+++ b/sites/platform/src/define-routes/redirects.md
@@ -8,6 +8,12 @@ description: |
 
 You can manage redirection rules on your {{% vendor/name %}} projects in two different ways, which we describe here. If neither of these options satisfy your redirection needs, you can still implement redirects directly from within your application, which if implemented with the appropriate caching headers would be almost as efficient as using the configuration options provided by {{% vendor/name %}}.
 
+{{% note theme="info" title="Route limits" %}}
+
+Please note that the maximum size of the routes document is 128 KB, which should fit around 300 different routes. [Read more about route limits here.](/define-routes.html#route-limits) 
+
+{{% /note %}}
+
 ## Whole-route redirects
 
 Using whole-route redirects, you can define very basic routes in your [`{{< vendor/configfile "routes" >}}`](/define-routes/_index.md) file whose sole purpose is to redirect. A typical use case for this type of route is adding or removing a `www.` prefix to your domain, as the following example shows:

--- a/sites/upsun/src/define-routes/redirects.md
+++ b/sites/upsun/src/define-routes/redirects.md
@@ -8,6 +8,12 @@ description: |
 
 You can manage redirection rules on your {{% vendor/name %}} projects in two different ways, which we describe here. If neither of these options satisfy your redirection needs, you can still implement redirects directly from within your application, which if implemented with the appropriate caching headers would be almost as efficient as using the configuration options provided by {{% vendor/name %}}.
 
+{{% note theme="info" title="Route limits" %}}
+
+Please note that the maximum size of the routes document is 128 KB, which should fit around 300 different routes. [Read more about route limits here.](/define-routes.html#route-limits) 
+
+{{% /note %}}
+
 ## Whole-route redirects
 
 Using whole-route redirects, you can define very basic routes in your [`{{< vendor/configfile "routes" >}}`](/define-routes/_index.md) file whose sole purpose is to redirect. A typical use case for this type of route is adding or removing a `www.` prefix to your domain, as the following example shows:


### PR DESCRIPTION
added note about route limits in redirects page

## Why

Closes #4656 

## What's changed

A note has been added in the redirects page to make the maximum route limit clearer to users.

## Where are changes

https://docs.platform.sh/define-routes/redirects.html
https://docs.upsun.com/define-routes/redirects.html

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
