### PR TITLE
4661 4662 broken links

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -28,3 +28,4 @@ ignoreerrors=
     ^https://www\.cloudflare\.com/.*$ ^403 Forbidden
     ^https://mkyong.com/java/java-how-to-send-email/$ ^403 Forbidden
     ^https://www.baeldung.com/maven-wrapper$ ^403 Forbidden
+    ^https://dzone\.com/$ ^403 Forbidden

--- a/sites/platform/src/security/web-application-firewall/fastly-waf.md
+++ b/sites/platform/src/security/web-application-firewall/fastly-waf.md
@@ -36,7 +36,7 @@ Included features may present limitations compared to those advertised by Fastly
 | [Default dashboards](https://docs.fastly.com/signalsciences/using-signal-sciences/web-interface/about-the-site-overview-page/)                      | No              | During quarterly business reviews |
 | [Custom response codes](https://docs.fastly.com/signalsciences/using-signal-sciences/custom-response-codes/)                                        | No              | No                                |
 | [Custom signals](https://docs.fastly.com/signalsciences/using-signal-sciences/signals/working-with-custom-signals/)                                 | No              | No                                |
-| [Standard API & ATO signals](https://docs.fastly.com/signalsciences/using-signal-sciences/rules/working-with-templated-rules/)                      | No              | No                                |
+| [Standard API & ATO signals](https://www.fastly.com/documentation/guides/next-gen-waf/using-ngwaf/rules/working-with-templated-rules/)              | No              | No                                |
 
 To subscribe to a Fastly Next-Gen WAF offer through {{% vendor/name %}},
 [contact Sales](https://platform.sh/contact/).


### PR DESCRIPTION
## Why

Closes #4661 
Closes #4662 

## What's changed

- updates link to fastly docs
- adds ignore on 403 errors from dzone.com to linkchecker config

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
