### PR TITLE
feat: removed stray bracket from shortcode

### DIFF
--- a/themes/psh-docs/layouts/shortcodes/region-location.md
+++ b/themes/psh-docs/layouts/shortcodes/region-location.md
@@ -3,5 +3,5 @@
 
 | Name | Provider | Geographic Zone | Timezone |
 | ------- | ------ | ------------------ |------------------|-----------------------| {{ range sort $registry "name" }}
-| {{ .name }} |  {{ .provider }}) | {{ .zone }} | {{ .timezone }} |{{ end }}
+| {{ .name }} |  {{ .provider }} | {{ .zone }} | {{ .timezone }} |{{ end }}
 <!-- shortcode end {{ .Name }} -->


### PR DESCRIPTION
### removed stray bracket from region location shortcode

## Why

Closes #4669 

## What's changed
removed stray open bracket from region locations shortcode

## Where are changes
region-location.md

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
