### PR TITLE
Update Dedicated Gen 2 supported/deprecated versions for all relevant services

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -133,16 +133,17 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "7.2",
+        "7.5",
+        "7.6",
+        "7.7",
+        "7.9",
+        "7.10",
+        "7.17",
         "8.5",
-        "7.17"
+        "8.8"
       ],
       "deprecated": [
-        "7.10",
-        "7.9",
-        "7.7",
-        "7.6",
-        "7.5",
-        "7.2",
         "6.8",
         "6.5",
         "5.6",
@@ -462,18 +463,18 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "11.4 Galera",
         "10.11 Galera",
-        "10.8 Galera",
-        "10.7 Galera",
         "10.6 Galera",
         "10.5 Galera",
-        "10.4 Galera",
-        "10.3 Galera"
+        "10.4 Galera"
       ],
       "deprecated": [
+        "11.2 Galera",
         "10.2 Galera",
         "10.1 Galera",
-        "10.0 Galera"
+        "10.0 Galera",
+        "10.3 Galera"
       ]
     },
     "versions-dedicated-gen-3": {
@@ -522,11 +523,16 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "11.4 Galera",
+        "10.11 Galera",
+        "10.6 Galera",
         "10.5 Galera",
-        "10.4 Galera",
-        "10.3 Galera"
+        "10.5 Galera",
+        "10.4 Galera"
       ],
       "deprecated": [
+        "11.2 Galera",
+        "10.3 Galera",
         "10.2 Galera",
         "10.1 Galera",
         "10.0 Galera"
@@ -570,7 +576,8 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
-        "1.4*"
+        "1.5",
+        "1.4"
       ]
     }
   },
@@ -628,6 +635,7 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "7.0",
         "6.0",
         "5.0",
         "4.4"
@@ -705,7 +713,11 @@
       ]
     },
     "versions-dedicated-gen-2": {
-      "supported": [],
+      "supported": [
+        "20",
+        "19",
+        "18"
+      ],
       "deprecated": [
         "16",
         "14",
@@ -745,8 +757,14 @@
     "versions-dedicated-gen-2": {
       "deprecated": [],
       "supported": [
+        "1.2",
+        "1.99",
+        "2.12",
+        "2.14",
         "2.5",
-        "1.2"
+        "2.18",
+        "2.19",
+        "2.99"
       ]
     },
     "versions-dedicated-gen-3": {
@@ -815,6 +833,8 @@
     "type": "php",
     "versions-dedicated-gen-2": {
       "supported": [
+        "8.4",
+        "8.3",     
         "8.2",
         "8.1",
         "8.0"
@@ -863,7 +883,6 @@
     "type": "postgresql",
     "versions": {
       "deprecated": [
-        "12",
         "11",
         "10",
         "9.6",
@@ -876,7 +895,8 @@
         "16",
         "15",
         "14",
-        "13"
+        "13",
+        "12"
       ]
     },
     "versions-dedicated-gen-2": {
@@ -891,7 +911,6 @@
     },
     "versions-dedicated-gen-3": {
       "deprecated": [
-        "12",
         "11",
         "10"
       ],
@@ -900,7 +919,8 @@
         "16",
         "15",
         "14",
-        "13"
+        "13",
+        "12"
       ]
     }
   },
@@ -990,6 +1010,8 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "4.1",
+        "4.0",
         "3.13",
         "3.12"
       ],
@@ -1048,6 +1070,8 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "8.0",
+        "7.4",
         "7.2"
       ],
       "deprecated": [
@@ -1223,6 +1247,12 @@
     },
     "versions-dedicated-gen-2": {
       "supported": [
+        "9.7",
+        "9.6",
+        "9.4",
+        "9.2",
+        "9.1",
+        "9.0",
         "8.11"
       ],
       "deprecated": [


### PR DESCRIPTION


## Why
To update supported/deprecated versions for for all relevant services under Dedicated Gen 2 

Closes [#SRE-652](https://linear.app/platformsh/issue/SRE-652/update-docsplatformsh-with-correct-version)



## What's changed

Supported/Deprecated version section for relevant services in 

## Where are changes
In shared/data/registry.json

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
