### PR TITLE
feat: removed line about autogenerated organizations

### DIFF
--- a/sites/platform/src/administration/organizations.md
+++ b/sites/platform/src/administration/organizations.md
@@ -63,8 +63,6 @@ title=Using the Console
 
 ## Create a new organization
 
-When you create a new project, if you don't already have an organization, one is created for you automatically.
-
 You can create new organizations with different payment methods and billing addresses
 and organize your projects as you want.
 

--- a/sites/upsun/src/administration/organizations.md
+++ b/sites/upsun/src/administration/organizations.md
@@ -63,8 +63,6 @@ title=Using the Console
 
 ## Create a new organization
 
-When you create a new project, if you don't already have an organization, one is created for you automatically.
-
 You can create new organizations with different payment methods and billing addresses
 and organize your projects as you want.
 


### PR DESCRIPTION
Removed line: "When you create a new project, if you don't already have an organization, one is created for you automatically."

## Why

Closes #4671 

## What's changed

Removed line: "When you create a new project, if you don't already have an organization, one is created for you automatically."

## Where are changes

https://docs.platform.sh/administration/organizations.html#create-a-new-organization
https://docs.upsun.com/administration/organizations.html#create-a-new-organization

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
