### PR TITLE
corrects mongo shell utility name from 'mongo' to 'mongosh'.

### DIFF
--- a/sites/platform/src/add-services/mongodb.md
+++ b/sites/platform/src/add-services/mongodb.md
@@ -454,13 +454,13 @@ Get the `host` from your [relationship](#relationship-reference).
 Then run the following command:
 
 ```bash
-mongo {{< variable "MONGODB_HOST" >}}
+mongosh {{< variable "MONGODB_HOST" >}}
 ```
 
 With the example value, that would be the following:
 
 ```bash
-mongo mongodb.internal
+mongosh mongodb.internal
 ```
 
 Note that the information about the relationship can change when an app is redeployed or restarted or the relationship is changed. So your apps should only rely on the `{{% vendor/prefix %}}_RELATIONSHIPS` environment variable directly rather than hard coding any values.

--- a/sites/platform/src/administration/cli/reference.md
+++ b/sites/platform/src/administration/cli/reference.md
@@ -6667,7 +6667,7 @@ Aliases: `mongo`
 ### Usage
 
 ```
-platform mongo [--eval EVAL] [-r|--relationship RELATIONSHIP] [-p|--project PROJECT] [-e|--environment ENVIRONMENT] [-A|--app APP]
+platform mongosh [--eval EVAL] [-r|--relationship RELATIONSHIP] [-p|--project PROJECT] [-e|--environment ENVIRONMENT] [-A|--app APP]
 ```
 
 #### Options

--- a/sites/upsun/src/add-services/mongodb.md
+++ b/sites/upsun/src/add-services/mongodb.md
@@ -593,13 +593,13 @@ Get the `host` from your [relationship](#relationship-reference).
 Then run the following command:
 
 ```bash
-mongo {{< variable "MONGODB_HOST" >}}
+mongosh {{< variable "MONGODB_HOST" >}}
 ```
 
 With the example value, that would be the following:
 
 ```bash
-mongo mongodb.internal
+mongosh mongodb.internal
 ```
 
 You can obtain the complete list of available service environment variables in your app container by running ``{{% vendor/cli %}} ssh env``.

--- a/sites/upsun/src/administration/cli/reference.md
+++ b/sites/upsun/src/administration/cli/reference.md
@@ -6774,7 +6774,7 @@ Aliases: `mongo`
 ### Usage
 
 ```
-upsun mongo [--eval EVAL] [-r|--relationship RELATIONSHIP] [-p|--project PROJECT] [-e|--environment ENVIRONMENT] [-A|--app APP]
+upsun mongosh [--eval EVAL] [-r|--relationship RELATIONSHIP] [-p|--project PROJECT] [-e|--environment ENVIRONMENT] [-A|--app APP]
 ```
 
 #### Options


### PR DESCRIPTION

## Why

Closes #4675 

## What's changed

Updates name for the mongo shell utility

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
