### PR TITLE
Expand MariaDB/MySQL External Replication info [4700]

### DIFF
--- a/sites/platform/src/add-services/mysql/mysql-replication.md
+++ b/sites/platform/src/add-services/mysql/mysql-replication.md
@@ -6,16 +6,15 @@ description: In rare cases, it may be useful to maintain a replica instance of y
 
 In rare cases, it may be useful to maintain a replica instance of your MySQL/MariaDB database outside of {{% vendor/name %}}.
 
-Normally an automated backup is better for short-term usage and a `mysqldump` for longer term storage, but in some cases the data set is large enough that `mysqldump` is prohibitive.
+Typically, an automated backup is better for short-term usage and a `mysqldump` for longer term storage, but in some cases the data set is large enough that `mysqldump` is prohibitive.
 In that case, you can enable external replication using an extra permission.
 
-Note that this guide covers the {{% vendor/name %}} side; you need to set up and maintain your own replica instance.
-Consult the MySQL or MariaDB documentation for steps to do so.
+This guide explains replication on the {{% vendor/name %}} side only; you must also set up and maintain your own replica instance. Consult the MySQL or MariaDB documentation for details.
 
 ## Create a replication user
 
 To set up replication you need to create a replication-enabled user.
-For each database that you'd like to replicate, you need to assign a `replication` permission/role, under a corresponding `endpoint`:
+For each database that you'd like to replicate, you need to assign a `replication` permission/role under a corresponding `endpoint`:
 
 ```yaml {configFile="services"}
 # The name of the service container. Must be unique within a project.
@@ -35,12 +34,16 @@ mariadb:
         privileges:
           main: replication
 ```
-
-This creates a `replicator` user, and grants read-only and table locking rights on the `main` database (namely `Select_priv`, `Show_view_priv`, `Create_tmp_table_priv`, `Lock_tables_priv` privileges) along with global replication rights (namely `Repl_slave_priv` and `Repl_client_priv` privileges) and flushing rights (`Reload_priv` used for flushing before reading the binary log position). If there is at least one `replication` permission defined, the bin-logging is enabled on the primary server, which is essential for the replication.
+The preceding example:
+- Creates a `replicator` user. 
+- Grants read-only and table locking rights on the `main` database (namely `Select_priv`, `Show_view_priv`, `Create_tmp_table_priv`, `Lock_tables_priv` privileges). 
+- Grants global replication rights (namely `Repl_slave_priv` and `Repl_client_priv` privileges).
+- Grants flushing rights (`Reload_priv` used for flushing before reading the binary log position). 
+- If at least one `replication` permission is defined, the bin-logging is enabled on the primary server, which is essential for the replication.
 
 ## Add a relationship for the new endpoint
 
-Even if you won't be accessing the replication endpoint from your application, you still need to expose it to an application as a relationship so that you can connect to it over SSH.
+Even if your application won't access the replication endpoint, you still need to expose the endpoint to an application as a relationship so that you can connect to it over SSH.
 Add a new relationship to your application container:
 
 ```yaml {configFile="app"}
@@ -60,9 +63,9 @@ relationships:
     endpoint: "replicator"
 ```
 
-## Getting the Primary's Binary Log Co-ordinates
+## Get the primary's binary log co-ordinates
 
-Open the MySQL CLI to the `replication` relationship, either by accessing the credentials while on the app container or using the following command.
+Open the MySQL CLI to the `replication` relationship, either by accessing the credentials while on the app container or using the following command:
 
 ```bash
 {{% vendor/cli %}} sql -r replication
@@ -84,30 +87,30 @@ mysql> SHOW MASTER STATUS;
 
 Record the `File` and `Position` details. If binary logging has just been enabled, these are blank. Now, with the lock still in place, copy the data from the primary to the replica.
 
-Login to the app container, then run:
+Log in to the app container, then run:
 
 ```sh
 # Dump the data from primary. Note that it dumps only the databases, which "replicator" user has access to.
 $ mysqldump --all-databases --single-transaction -h database.internal -P 3306 -u replicator -p > /path/to/dump.sql
 ```
 
-Download the dump file, then move it to the server where your replica lives to import it.
+Download the dump file, then move it to the server where your replica lives so that the replica can import it.
 
 ```bash
 # Copy the dump to your replica
 $ mysql -u root < /path/to/dump.sql
 ```
 
-Note for live databases: You just need to make a local copy of the data, you don't need to keep the primary locked until the replica has imported the data.
+Note for live databases: It is sufficient to make a local copy of the data; you don't need to keep the primary locked until the replica has imported the data.
 Once the `mysqldump` has completed, you can release the lock on the primary by running `UNLOCK TABLES`.
 
 ```sql
 mysql> UNLOCK TABLES;
 ```
 
-## Setting up the replica
+## Set up the replica
 
-### Configuring the replica
+### Configure the replica
 
 As mentioned above you have to set up a replica on your own. Assuming that you have a running MariaDB/MySQL replica instance, give the replica a unique `server_id` (distinct from primary). You can find out primary's `server_id` by running:
 
@@ -128,25 +131,38 @@ Then set a distinct `server_id` number (e.g. server_id+1) in your replica config
 server_id=2
 ```
 
-And reload the replica instance for the changes to take an effect.
+Next, reload the replica instance for the changes to take effect.
 
 ### Set up SSH tunneling
 
 You need to set up an SSH tunnel from the replica server to the primary, tunneled through the application.
-To do so using the {{% vendor/name %}} CLI, run the following
-(replacing `{{< variable "BRANCH_NAME" >}}` with the name of your production branch):
-
-```bash
-{{% vendor/cli %}} tunnel:open --project {{< variable "PROJECT_ID" >}} --environment {{< variable "BRANCH_NAME" >}}
-```
-
-This opens local SSH tunnels to all services accessible from the application. In practice, you may be better served by setting up the tunnel manually using SSH. Consult the SSH documentation for the best way to do so.
 
 {{< note >}}
-The SSH connection is interrupted every time the environment redeploys. For replication to continue you must setup an auto-restart for the connection. There are many ways to do so that are out of the scope of this documentation.
+The SSH tunnel is interrupted every time the environment redeploys. For replication to continue you must set up an auto-restart for the tunnel. There are many ways to do so that are out of the scope of this documentation.
 {{< /note >}}
 
-### Starting the Replica
+You can set up an SSH tunnel using one of the following methods:
+- Manually using SSH. Using this method makes it easier to set up an auto-restart for the tunnel. Consult the SSH documentation for details on setting up the tunnel and the auto-restart.
+
+- Run the following {{% vendor/name %}} CLI command
+(replacing `{{< variable "BRANCH_NAME" >}}` with the name of your production branch):
+
+  ```bash
+    {{% vendor/cli %}} tunnel:open --project {{< variable "PROJECT_ID" >}} --environment {{< variable "BRANCH_NAME" >}}
+  ```
+  This command opens local SSH tunnels to all services accessible from the application. 
+  
+To configure an auto-restart, you need the project's SSH address, which you can retrieve by running: 
+
+  ```bash
+  {{% vendor/cli %}} ssh --pipe --project {{< variable "PROJECT_ID" >}}
+  ``` 
+For details about this command, see the [{{% vendor/name %}} CLI reference](/administration/cli/reference.md#usage-54).
+
+### Binary log retention and cleanup
+When replication is disabled, the MariaDB service stops managing the binary logs and they remain on the file system. **You must delete these logs manually**. If the remote replica has been unreachable for some time, these logs can consume a significant amount of storage.
+
+### Start the Replica
 
 Once the data has been imported, you are ready to start replicating. Begin by running a `CHANGE MASTER TO`, making sure that `MASTER_LOG_FILE` matches the file and `MASTER_LOG_POS` the position returned by the earlier `SHOW MASTER STATUS` on the {{% vendor/name %}} database. For example:
 
@@ -169,7 +185,7 @@ Now start the replica with the `START SLAVE` command:
 mysql> START SLAVE;
 ```
 
-Check that the replication is working by executing the `SHOW SLAVE STATUS` command:
+Check that the replication is working by running the `SHOW SLAVE STATUS` command:
 
 ```sql
 mysql> SHOW SLAVE STATUS \G
@@ -191,4 +207,4 @@ mysql> STOP SLAVE; SET GLOBAL SQL_SLAVE_SKIP_COUNTER = 1; START SLAVE;
 mysql> SHOW SLAVE STATUS \G
 ```
 
-In case you have multiple errors you would need to repeat the steps above (preferred) or set `SQL_SLAVE_SKIP_COUNTER` (which corresponds to skipping the next N events from the primary) to something greater.
+In case you have multiple errors you would need to repeat the steps above (preferred) or set `SQL_SLAVE_SKIP_COUNTER` (which corresponds to skipping the next N events from the primary) to a larger value.


### PR DESCRIPTION

## Why

Closes #4700  


## What's changed
New:
- Binary log retention and cleanup section

Changed:
- Set up SSH tunneling section: Changed the organization. Please verify the technical meaning is intact.
- Create a replication user section: changed paragraph to a bulleted list for easier scanning
- Assorted minor style changes

## Where are changes
/add-services/mysql/mysql-replication.html 

Updates are for:

- [ X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
