### PR TITLE
Prepare docs for api docs

### DIFF
--- a/.github/workflows/check-openapi-spec-update.yaml
+++ b/.github/workflows/check-openapi-spec-update.yaml
@@ -34,14 +34,10 @@ jobs:
           # @todo switch this to using the python method so we're consistent?
           PROJECT_ENCODED=$(echo "$PROJECT_PATH" | sed 's/\//%2F/g')
 
-          # Download into P.sh using the GitLab API
+          # Download into shared data using the GitLab API
+          # @todo should we also copy over the stylesheet? or should the version in docs be canonical?
           curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
-            --output sites/platform/src/api.html \
-            "https://lab.plat.farm/api/v4/projects/${PROJECT_ENCODED}/repository/files/$(python3 -c "import urllib.parse; print(urllib.parse.quote('web/redoc-static.html',safe=''))")/raw?ref=${REF}"
-
-          # Download into Upsun using the GitLab API
-          curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
-            --output sites/upsun/src/api.html \
+            --output shared/pages/api.html \
             "https://lab.plat.farm/api/v4/projects/${PROJECT_ENCODED}/repository/files/$(python3 -c "import urllib.parse; print(urllib.parse.quote('web/redoc-static.html',safe=''))")/raw?ref=${REF}"
 
       - name: Create Pull Request if changes

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -24,11 +24,23 @@
         # Build hooks can modify the application files on disk but not access any services like databases.
         build: |
           set -e
+          #copy API docs into correct location
+          # @todo once api docs are fully moved we can alter the template.hbs file so style.css can be in /api
+          mkdir -p ${PLATFORM_APP_DIR}/${SITE_DIR}/public/api"
+          if [ -f "${PLATFORM_APP_DIR}/shared/pages/api.html" ]; then
+            cp "${PLATFORM_APP_DIR}/shared/pages/api.html" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
+            cp "${PLATFORM_APP_DIR}/shared/pages/api-style.css" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles/style.css"
+          else
+            echo "<p>Currently under maintenance. Please check back later.</p>" >> "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
+          fi
+
           cd $SITE_DIR
           cp ../../themes/psh-docs/postcss.config.js .
           npm install
           npm run build
           ./build_docs.sh
+
+
 
         deploy: |
             cd $SITE_DIR
@@ -60,6 +72,10 @@
                     \.txt$:
                       headers:
                         Content-Type: "text/plain; charset=UTF-8"
+            '/api':
+              root: 'sites/platform/public/api'
+              index: [ 'index.html' ]
+              expires: 24h
     disk: 1024
 
     mounts:
@@ -94,6 +110,15 @@
     hooks:
         # Build hooks can modify the application files on disk but not access any services like databases.
         build: |
+          #copy API docs into correct location
+          # @todo once api docs are fully moved we can alter the template.hbs file so style.css can be in /api
+          mkdir -p ${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles"
+          if [ -f "${PLATFORM_APP_DIR}/shared/pages/api.html" ]; then
+            cp "${PLATFORM_APP_DIR}/shared/pages/api.html" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
+            cp "${PLATFORM_APP_DIR}/shared/pages/api-style.css" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles/style.css"
+          else
+            echo "<p>Currently under maintenance. Please check back later.</p>" >> "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
+          fi
           cd $SITE_DIR
           cp ../../themes/psh-docs/postcss.config.js .
           npm install
@@ -135,7 +160,10 @@
                     '^/favicon.ico$':
                         allow: true
                         passthru: '/images/favicon.ico'
-
+            '/api':
+              root: 'sites/platform/public/api'
+              index: [ 'index.html' ]
+              expires: 24h
 
     disk: 1024
 

--- a/shared/pages/api-style.css
+++ b/shared/pages/api-style.css
@@ -1,0 +1,16519 @@
+body {
+  padding: 0;
+  margin: 0;
+}
+
+label[role="menuitem"][type="group"] {
+  margin-top: 1.5rem;
+  margin-bottom: 1em;
+
+  border-bottom: 1px solid #e1e1e1;
+  margin-left: 20px;
+  margin-right: 20px;
+
+  /* Offset Background Boxes */
+  /* background-color: #FFBDBB;
+    margin-left: 30px;
+    margin-top: 45px;
+    padding-bottom: 1em;
+    height: 0;
+    display: inline-block; */
+}
+
+label[role="menuitem"][type="group"] > span {
+  margin-left: -20px;
+
+  /* Offset Background Boxes */
+  /* margin-top: -2.5em;
+    margin-left: -1.5em;
+    font-size: 1.5em;
+    font-weight: 900;
+    color: #000; */
+}
+
+label[role="menuitem"][type="tag"] {
+  padding-top: 10px;
+  padding-bottom: 5px;
+  font-size: 1.1em;
+}
+
+p {
+  margin-bottom: 1.4rem;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+}
+
+/*Padding for logo */
+#redoc > div > div.menu-content > div > a > img {    width: 80%;    padding: 5%;    margin: auto; margin-bottom: 1em;}
+@charset "UTF-8";
+/* Mixins */
+/* Global */
+/****** Fonts *******/
+@import url("https://fonts.googleapis.com/css?family=Overpass:300,400,500,700,900");
+@font-face {
+  font-family: 'Moderat';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Regular.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Regular.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Regular.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 400;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'Moderat';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Medium.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Medium.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Medium.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 500;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'Moderat';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Bold.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Bold.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Bold.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 700;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'Moderat Black';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Black.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Black.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Black.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'Moderat Mono';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Bold.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Bold.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Mono-Bold.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 700;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'Moderat Mono';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Medium.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Medium.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Mono-Medium.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 400;
+  font-style: normal; }
+
+.platform_sh_standalone {
+  /* Mixins */
+  /* Global */
+  /****** Fonts *******/
+  /* @import url("https://fonts.googleapis.com/css?family=Overpass:300,400,500,700,900"); */
+  /****** colors ******/
+  /* Type */
+  /* Grid */
+  /* Forms */
+  /* buttons */
+  /*!
+     * Bootstrap v4.3.1 (https://getbootstrap.com/)
+     * Copyright 2011-2019 The Bootstrap Authors
+     * Copyright 2011-2019 Twitter, Inc.
+     * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+     */
+  /* import what we need to override */
+  /* set the overriding variables */
+  /* override the !default vars with the values we set above */
+  /*!
+     * Bootstrap v4.3.1 (https://getbootstrap.com/)
+     * Copyright 2011-2019 The Bootstrap Authors
+     * Copyright 2011-2019 Twitter, Inc.
+     * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+     */
+  /*******************
+      Style Guide
+    *******************/
+  /*******************
+      background colors
+    *******************/
+  /* Colors */
+  /* Line Heights */
+  /* Components */
+  /*****
+     * Parent element
+     *******************/
+  /***********
+     Sizing element
+     ******************/
+  /*******
+      Logo
+      ************/
+  /*****
+     Burger Menu
+     ******************/
+  /******
+     Sub menu controller
+     *********************/
+  /*******
+     Top Level Links
+     *************/
+  /******
+     Divider line
+     ****************/
+  /*****
+      Sub Level Links Wrapper
+      *************************/
+  /*****
+      Sub Level Links
+      *************************/
+  /*****
+     * Target elements when navbar at position 0
+     ********************************************/
+  /*********
+     Custom Logged In widget
+     ************************/
+  /*****
+     Any pages that do not want the default transparent nav-top.
+     ***************************/ }
+@font-face {
+.platform_sh_standalone {
+  font-family: 'Moderat';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Regular.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Regular.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Regular.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 400;
+  font-style: normal; } }
+@font-face {
+.platform_sh_standalone {
+  font-family: 'Moderat';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Medium.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Medium.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Medium.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 500;
+  font-style: normal; } }
+@font-face {
+.platform_sh_standalone {
+  font-family: 'Moderat';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Bold.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Bold.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Bold.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 700;
+  font-style: normal; } }
+@font-face {
+.platform_sh_standalone {
+  font-family: 'Moderat Black';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Black.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Black.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Black.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: normal;
+  font-style: normal; } }
+@font-face {
+.platform_sh_standalone {
+  font-family: 'Moderat Mono';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Bold.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Bold.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Mono-Bold.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 700;
+  font-style: normal; } }
+@font-face {
+.platform_sh_standalone {
+  font-family: 'Moderat Mono';
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Medium.eot");
+  /* IE9 Compat Modes */
+  src: url("https://platform.sh/fonts/Moderat/Moderat-Mono-Medium.woff2") format("woff2"), url("https://platform.sh/fonts/Moderat/Moderat-Mono-Medium.woff") format("woff");
+  /* Pretty Modern Browsers */
+  font-weight: 400;
+  font-style: normal; } }
+.platform_sh_standalone :root {
+  --blue: #145CC6;
+  --indigo: #6610f2;
+  --purple: #6f42c1;
+  --pink: #FFBDBB;
+  --red: #dc3545;
+  --orange: #FB3728;
+  --yellow: #F4BA37;
+  --green: #28a745;
+  --teal: #20c997;
+  --cyan: #17a2b8;
+  --white: #fff;
+  --gray: #6c757d;
+  --gray-dark: #343a40;
+  --primary: #145CC6;
+  --secondary: #6c757d;
+  --success: #28a745;
+  --info: #17a2b8;
+  --warning: #F4BA37;
+  --danger: #dc3545;
+  --light: #f8f9fa;
+  --dark: #343a40;
+  --breakpoint-xs: 0;
+  --breakpoint-sm: 576px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 992px;
+  --breakpoint-xl: 1200px;
+  --font-family-sans-serif: Overpass, Arial;
+  --font-family-monospace: "Moderat Mono", "Courier New", monospace; }
+.platform_sh_standalone *,
+.platform_sh_standalone *::before,
+.platform_sh_standalone *::after {
+  box-sizing: border-box; }
+.platform_sh_standalone html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+.platform_sh_standalone article, .platform_sh_standalone aside, .platform_sh_standalone figcaption, .platform_sh_standalone figure, .platform_sh_standalone footer, .platform_sh_standalone header, .platform_sh_standalone hgroup, .platform_sh_standalone main, .platform_sh_standalone nav, .platform_sh_standalone section {
+  display: block; }
+.platform_sh_standalone body {
+  margin: 0;
+  font-family: Overpass, Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #49475F;
+  text-align: left;
+  background-color: #fff; }
+.platform_sh_standalone [tabindex="-1"]:focus {
+  outline: 0 !important; }
+.platform_sh_standalone hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible; }
+.platform_sh_standalone h1, .platform_sh_standalone h2, .platform_sh_standalone h3, .platform_sh_standalone h4, .platform_sh_standalone h5, .platform_sh_standalone h6 {
+  margin-top: 0;
+  margin-bottom: 0.5rem; }
+.platform_sh_standalone p {
+  margin-top: 0;
+  margin-bottom: 1rem; }
+.platform_sh_standalone abbr[title],
+.platform_sh_standalone abbr[data-original-title] {
+  text-decoration: underline;
+  text-decoration: underline dotted;
+  cursor: help;
+  border-bottom: 0;
+  text-decoration-skip-ink: none; }
+.platform_sh_standalone address {
+  margin-bottom: 1rem;
+  font-style: normal;
+  line-height: inherit; }
+.platform_sh_standalone ol,
+.platform_sh_standalone ul,
+.platform_sh_standalone dl {
+  margin-top: 0;
+  margin-bottom: 1rem; }
+.platform_sh_standalone ol ol,
+.platform_sh_standalone ul ul,
+.platform_sh_standalone ol ul,
+.platform_sh_standalone ul ol {
+  margin-bottom: 0; }
+.platform_sh_standalone dt {
+  font-weight: 700; }
+.platform_sh_standalone dd {
+  margin-bottom: .5rem;
+  margin-left: 0; }
+.platform_sh_standalone blockquote {
+  margin: 0 0 1rem; }
+.platform_sh_standalone b,
+.platform_sh_standalone strong {
+  font-weight: 900; }
+.platform_sh_standalone small {
+  font-size: 80%; }
+.platform_sh_standalone sub,
+.platform_sh_standalone sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline; }
+.platform_sh_standalone sub {
+  bottom: -.25em; }
+.platform_sh_standalone sup {
+  top: -.5em; }
+.platform_sh_standalone a {
+  color: #145CC6;
+  text-decoration: none;
+  background-color: transparent; }
+.platform_sh_standalone a:hover {
+  color: #0d3c81;
+  text-decoration: underline; }
+.platform_sh_standalone a:not([href]):not([tabindex]) {
+  color: inherit;
+  text-decoration: none; }
+.platform_sh_standalone a:not([href]):not([tabindex]):hover, .platform_sh_standalone a:not([href]):not([tabindex]):focus {
+  color: inherit;
+  text-decoration: none; }
+.platform_sh_standalone a:not([href]):not([tabindex]):focus {
+  outline: 0; }
+.platform_sh_standalone pre,
+.platform_sh_standalone code,
+.platform_sh_standalone kbd,
+.platform_sh_standalone samp {
+  font-family: "Moderat Mono", "Courier New", monospace;
+  font-size: 1em; }
+.platform_sh_standalone pre {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  overflow: auto; }
+.platform_sh_standalone figure {
+  margin: 0 0 1rem; }
+.platform_sh_standalone img {
+  vertical-align: middle;
+  border-style: none; }
+.platform_sh_standalone svg {
+  overflow: hidden;
+  vertical-align: middle; }
+.platform_sh_standalone table {
+  border-collapse: collapse; }
+.platform_sh_standalone caption {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: #6c757d;
+  text-align: left;
+  caption-side: bottom; }
+.platform_sh_standalone th {
+  text-align: inherit; }
+.platform_sh_standalone label {
+  display: inline-block;
+  margin-bottom: 0.5rem; }
+.platform_sh_standalone button {
+  border-radius: 0; }
+.platform_sh_standalone button:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color; }
+.platform_sh_standalone input,
+.platform_sh_standalone button,
+.platform_sh_standalone select,
+.platform_sh_standalone optgroup,
+.platform_sh_standalone textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit; }
+.platform_sh_standalone button,
+.platform_sh_standalone input {
+  overflow: visible; }
+.platform_sh_standalone button,
+.platform_sh_standalone select {
+  text-transform: none; }
+.platform_sh_standalone select {
+  word-wrap: normal; }
+.platform_sh_standalone button,
+.platform_sh_standalone [type="button"],
+.platform_sh_standalone [type="reset"],
+.platform_sh_standalone [type="submit"] {
+  -webkit-appearance: button; }
+.platform_sh_standalone button:not(:disabled),
+.platform_sh_standalone [type="button"]:not(:disabled),
+.platform_sh_standalone [type="reset"]:not(:disabled),
+.platform_sh_standalone [type="submit"]:not(:disabled) {
+  cursor: pointer; }
+.platform_sh_standalone button::-moz-focus-inner,
+.platform_sh_standalone [type="button"]::-moz-focus-inner,
+.platform_sh_standalone [type="reset"]::-moz-focus-inner,
+.platform_sh_standalone [type="submit"]::-moz-focus-inner {
+  padding: 0;
+  border-style: none; }
+.platform_sh_standalone input[type="radio"],
+.platform_sh_standalone input[type="checkbox"] {
+  box-sizing: border-box;
+  padding: 0; }
+.platform_sh_standalone input[type="date"],
+.platform_sh_standalone input[type="time"],
+.platform_sh_standalone input[type="datetime-local"],
+.platform_sh_standalone input[type="month"] {
+  -webkit-appearance: listbox; }
+.platform_sh_standalone textarea {
+  overflow: auto;
+  resize: vertical; }
+.platform_sh_standalone fieldset {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0; }
+.platform_sh_standalone legend {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
+  margin-bottom: .5rem;
+  font-size: 1.5rem;
+  line-height: inherit;
+  color: inherit;
+  white-space: normal; }
+.platform_sh_standalone progress {
+  vertical-align: baseline; }
+.platform_sh_standalone [type="number"]::-webkit-inner-spin-button,
+.platform_sh_standalone [type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+.platform_sh_standalone [type="search"] {
+  outline-offset: -2px;
+  -webkit-appearance: none; }
+.platform_sh_standalone [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none; }
+.platform_sh_standalone ::-webkit-file-upload-button {
+  font: inherit;
+  -webkit-appearance: button; }
+.platform_sh_standalone output {
+  display: inline-block; }
+.platform_sh_standalone summary {
+  display: list-item;
+  cursor: pointer; }
+.platform_sh_standalone template {
+  display: none; }
+.platform_sh_standalone [hidden] {
+  display: none !important; }
+.platform_sh_standalone h1, .platform_sh_standalone h2, .platform_sh_standalone h3, .platform_sh_standalone h4, .platform_sh_standalone h5, .platform_sh_standalone h6,
+.platform_sh_standalone .h1, .platform_sh_standalone .h2, .platform_sh_standalone .h3, .platform_sh_standalone .h4, .platform_sh_standalone .h5, .platform_sh_standalone .h6 {
+  margin-bottom: 0.5rem;
+  font-family: "Moderat", "Helvetica Neue", Arial;
+  font-weight: 700;
+  line-height: 1.1;
+  color: #1A182A; }
+.platform_sh_standalone h1, .platform_sh_standalone .h1 {
+  font-size: 3.75rem; }
+.platform_sh_standalone h2, .platform_sh_standalone .h2 {
+  font-size: 3rem; }
+.platform_sh_standalone h3, .platform_sh_standalone .h3 {
+  font-size: 5.625rem; }
+.platform_sh_standalone h4, .platform_sh_standalone .h4 {
+  font-size: 2.125rem; }
+.platform_sh_standalone h5, .platform_sh_standalone .h5 {
+  font-size: 1.5rem; }
+.platform_sh_standalone h6, .platform_sh_standalone .h6 {
+  font-size: 1rem; }
+.platform_sh_standalone .lead {
+  font-size: 1.25rem;
+  font-weight: 300; }
+.platform_sh_standalone .display-1 {
+  font-size: 6rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone .display-2 {
+  font-size: 5.5rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone .display-3 {
+  font-size: 4.5rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone .display-4 {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone hr {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1); }
+.platform_sh_standalone small,
+.platform_sh_standalone .small {
+  font-size: 80%;
+  font-weight: 400; }
+.platform_sh_standalone mark,
+.platform_sh_standalone .mark {
+  padding: 0.2em;
+  background-color: #fcf8e3; }
+.platform_sh_standalone .list-unstyled {
+  padding-left: 0;
+  list-style: none; }
+.platform_sh_standalone .list-inline {
+  padding-left: 0;
+  list-style: none; }
+.platform_sh_standalone .list-inline-item {
+  display: inline-block; }
+.platform_sh_standalone .list-inline-item:not(:last-child) {
+  margin-right: 0.5rem; }
+.platform_sh_standalone .initialism {
+  font-size: 90%;
+  text-transform: uppercase; }
+.platform_sh_standalone .blockquote {
+  margin-bottom: 1rem;
+  font-size: 1.25rem; }
+.platform_sh_standalone .blockquote-footer {
+  display: block;
+  font-size: 80%;
+  color: #6c757d; }
+.platform_sh_standalone .blockquote-footer::before {
+  content: "\2014\00A0"; }
+.platform_sh_standalone .img-fluid {
+  max-width: 100%;
+  height: auto; }
+.platform_sh_standalone .img-thumbnail {
+  padding: 0.25rem;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 0;
+  max-width: 100%;
+  height: auto; }
+.platform_sh_standalone .figure {
+  display: inline-block; }
+.platform_sh_standalone .figure-img {
+  margin-bottom: 0.5rem;
+  line-height: 1; }
+.platform_sh_standalone .figure-caption {
+  font-size: 90%;
+  color: #6c757d; }
+.platform_sh_standalone code {
+  font-size: 87.5%;
+  color: #FFBDBB;
+  word-break: break-word; }
+a > .platform_sh_standalone code {
+  color: inherit; }
+.platform_sh_standalone kbd {
+  padding: 0.2rem 0.4rem;
+  font-size: 87.5%;
+  color: #fff;
+  background-color: #212529;
+  border-radius: 0; }
+.platform_sh_standalone kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: 700; }
+.platform_sh_standalone pre {
+  display: block;
+  font-size: 87.5%;
+  color: #212529; }
+.platform_sh_standalone pre code {
+  font-size: inherit;
+  color: inherit;
+  word-break: normal; }
+.platform_sh_standalone .pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll; }
+.platform_sh_standalone .container {
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .container {
+    max-width: 540px; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .container {
+    max-width: 720px; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .container {
+    max-width: 960px; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .container {
+    max-width: 1140px; } }
+.platform_sh_standalone .container-fluid {
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto; }
+.platform_sh_standalone .row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -20px;
+  margin-left: -20px; }
+.platform_sh_standalone .no-gutters {
+  margin-right: 0;
+  margin-left: 0; }
+.platform_sh_standalone .no-gutters > .col,
+.platform_sh_standalone .no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .col-1, .platform_sh_standalone .col-2, .platform_sh_standalone .col-3, .platform_sh_standalone .col-4, .platform_sh_standalone .col-5, .platform_sh_standalone .col-6, .platform_sh_standalone .col-7, .platform_sh_standalone .col-8, .platform_sh_standalone .col-9, .platform_sh_standalone .col-10, .platform_sh_standalone .col-11, .platform_sh_standalone .col-12, .platform_sh_standalone .col,
+.platform_sh_standalone .col-auto, .platform_sh_standalone .col-sm-1, .platform_sh_standalone .col-sm-2, .platform_sh_standalone .col-sm-3, .platform_sh_standalone .col-sm-4, .platform_sh_standalone .col-sm-5, .platform_sh_standalone .col-sm-6, .platform_sh_standalone .col-sm-7, .platform_sh_standalone .col-sm-8, .platform_sh_standalone .col-sm-9, .platform_sh_standalone .col-sm-10, .platform_sh_standalone .col-sm-11, .platform_sh_standalone .col-sm-12, .platform_sh_standalone .col-sm,
+.platform_sh_standalone .col-sm-auto, .platform_sh_standalone .col-md-1, .platform_sh_standalone .col-md-2, .platform_sh_standalone .col-md-3, .platform_sh_standalone .col-md-4, .platform_sh_standalone .col-md-5, .platform_sh_standalone .col-md-6, .platform_sh_standalone .col-md-7, .platform_sh_standalone .col-md-8, .platform_sh_standalone .col-md-9, .platform_sh_standalone .col-md-10, .platform_sh_standalone .col-md-11, .platform_sh_standalone .col-md-12, .platform_sh_standalone .col-md,
+.platform_sh_standalone .col-md-auto, .platform_sh_standalone .col-lg-1, .platform_sh_standalone .col-lg-2, .platform_sh_standalone .col-lg-3, .platform_sh_standalone .col-lg-4, .platform_sh_standalone .col-lg-5, .platform_sh_standalone .col-lg-6, .platform_sh_standalone .col-lg-7, .platform_sh_standalone .col-lg-8, .platform_sh_standalone .col-lg-9, .platform_sh_standalone .col-lg-10, .platform_sh_standalone .col-lg-11, .platform_sh_standalone .col-lg-12, .platform_sh_standalone .col-lg,
+.platform_sh_standalone .col-lg-auto, .platform_sh_standalone .col-xl-1, .platform_sh_standalone .col-xl-2, .platform_sh_standalone .col-xl-3, .platform_sh_standalone .col-xl-4, .platform_sh_standalone .col-xl-5, .platform_sh_standalone .col-xl-6, .platform_sh_standalone .col-xl-7, .platform_sh_standalone .col-xl-8, .platform_sh_standalone .col-xl-9, .platform_sh_standalone .col-xl-10, .platform_sh_standalone .col-xl-11, .platform_sh_standalone .col-xl-12, .platform_sh_standalone .col-xl,
+.platform_sh_standalone .col-xl-auto, .platform_sh_standalone .col-xxs-1, .platform_sh_standalone .col-xxs-2, .platform_sh_standalone .col-xxs-3, .platform_sh_standalone .col-xxs-4, .platform_sh_standalone .col-xxs-5, .platform_sh_standalone .col-xxs-6, .platform_sh_standalone .col-xxs-7, .platform_sh_standalone .col-xxs-8, .platform_sh_standalone .col-xxs-9, .platform_sh_standalone .col-xxs-10, .platform_sh_standalone .col-xxs-11, .platform_sh_standalone .col-xxs-12, .platform_sh_standalone .col-xxs,
+.platform_sh_standalone .col-xxs-auto, .platform_sh_standalone .col-xs-1, .platform_sh_standalone .col-xs-2, .platform_sh_standalone .col-xs-3, .platform_sh_standalone .col-xs-4, .platform_sh_standalone .col-xs-5, .platform_sh_standalone .col-xs-6, .platform_sh_standalone .col-xs-7, .platform_sh_standalone .col-xs-8, .platform_sh_standalone .col-xs-9, .platform_sh_standalone .col-xs-10, .platform_sh_standalone .col-xs-11, .platform_sh_standalone .col-xs-12, .platform_sh_standalone .col-xs,
+.platform_sh_standalone .col-xs-auto, .platform_sh_standalone .col-xxl-1, .platform_sh_standalone .col-xxl-2, .platform_sh_standalone .col-xxl-3, .platform_sh_standalone .col-xxl-4, .platform_sh_standalone .col-xxl-5, .platform_sh_standalone .col-xxl-6, .platform_sh_standalone .col-xxl-7, .platform_sh_standalone .col-xxl-8, .platform_sh_standalone .col-xxl-9, .platform_sh_standalone .col-xxl-10, .platform_sh_standalone .col-xxl-11, .platform_sh_standalone .col-xxl-12, .platform_sh_standalone .col-xxl,
+.platform_sh_standalone .col-xxl-auto, .platform_sh_standalone .col-xxxl-1, .platform_sh_standalone .col-xxxl-2, .platform_sh_standalone .col-xxxl-3, .platform_sh_standalone .col-xxxl-4, .platform_sh_standalone .col-xxxl-5, .platform_sh_standalone .col-xxxl-6, .platform_sh_standalone .col-xxxl-7, .platform_sh_standalone .col-xxxl-8, .platform_sh_standalone .col-xxxl-9, .platform_sh_standalone .col-xxxl-10, .platform_sh_standalone .col-xxxl-11, .platform_sh_standalone .col-xxxl-12, .platform_sh_standalone .col-xxxl,
+.platform_sh_standalone .col-xxxl-auto {
+  position: relative;
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px; }
+.platform_sh_standalone .col {
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%; }
+.platform_sh_standalone .col-auto {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: 100%; }
+.platform_sh_standalone .col-1 {
+  flex: 0 0 8.3333333333%;
+  max-width: 8.3333333333%; }
+.platform_sh_standalone .col-2 {
+  flex: 0 0 16.6666666667%;
+  max-width: 16.6666666667%; }
+.platform_sh_standalone .col-3 {
+  flex: 0 0 25%;
+  max-width: 25%; }
+.platform_sh_standalone .col-4 {
+  flex: 0 0 33.3333333333%;
+  max-width: 33.3333333333%; }
+.platform_sh_standalone .col-5 {
+  flex: 0 0 41.6666666667%;
+  max-width: 41.6666666667%; }
+.platform_sh_standalone .col-6 {
+  flex: 0 0 50%;
+  max-width: 50%; }
+.platform_sh_standalone .col-7 {
+  flex: 0 0 58.3333333333%;
+  max-width: 58.3333333333%; }
+.platform_sh_standalone .col-8 {
+  flex: 0 0 66.6666666667%;
+  max-width: 66.6666666667%; }
+.platform_sh_standalone .col-9 {
+  flex: 0 0 75%;
+  max-width: 75%; }
+.platform_sh_standalone .col-10 {
+  flex: 0 0 83.3333333333%;
+  max-width: 83.3333333333%; }
+.platform_sh_standalone .col-11 {
+  flex: 0 0 91.6666666667%;
+  max-width: 91.6666666667%; }
+.platform_sh_standalone .col-12 {
+  flex: 0 0 100%;
+  max-width: 100%; }
+.platform_sh_standalone .order-first {
+  order: -1; }
+.platform_sh_standalone .order-last {
+  order: 13; }
+.platform_sh_standalone .order-0 {
+  order: 0; }
+.platform_sh_standalone .order-1 {
+  order: 1; }
+.platform_sh_standalone .order-2 {
+  order: 2; }
+.platform_sh_standalone .order-3 {
+  order: 3; }
+.platform_sh_standalone .order-4 {
+  order: 4; }
+.platform_sh_standalone .order-5 {
+  order: 5; }
+.platform_sh_standalone .order-6 {
+  order: 6; }
+.platform_sh_standalone .order-7 {
+  order: 7; }
+.platform_sh_standalone .order-8 {
+  order: 8; }
+.platform_sh_standalone .order-9 {
+  order: 9; }
+.platform_sh_standalone .order-10 {
+  order: 10; }
+.platform_sh_standalone .order-11 {
+  order: 11; }
+.platform_sh_standalone .order-12 {
+  order: 12; }
+.platform_sh_standalone .offset-1 {
+  margin-left: 8.3333333333%; }
+.platform_sh_standalone .offset-2 {
+  margin-left: 16.6666666667%; }
+.platform_sh_standalone .offset-3 {
+  margin-left: 25%; }
+.platform_sh_standalone .offset-4 {
+  margin-left: 33.3333333333%; }
+.platform_sh_standalone .offset-5 {
+  margin-left: 41.6666666667%; }
+.platform_sh_standalone .offset-6 {
+  margin-left: 50%; }
+.platform_sh_standalone .offset-7 {
+  margin-left: 58.3333333333%; }
+.platform_sh_standalone .offset-8 {
+  margin-left: 66.6666666667%; }
+.platform_sh_standalone .offset-9 {
+  margin-left: 75%; }
+.platform_sh_standalone .offset-10 {
+  margin-left: 83.3333333333%; }
+.platform_sh_standalone .offset-11 {
+  margin-left: 91.6666666667%; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .col-sm {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-sm-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-sm-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-sm-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-sm-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-sm-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-sm-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-sm-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-sm-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-sm-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-sm-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-sm-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-sm-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-sm-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-sm-first {
+    order: -1; }
+  .platform_sh_standalone .order-sm-last {
+    order: 13; }
+  .platform_sh_standalone .order-sm-0 {
+    order: 0; }
+  .platform_sh_standalone .order-sm-1 {
+    order: 1; }
+  .platform_sh_standalone .order-sm-2 {
+    order: 2; }
+  .platform_sh_standalone .order-sm-3 {
+    order: 3; }
+  .platform_sh_standalone .order-sm-4 {
+    order: 4; }
+  .platform_sh_standalone .order-sm-5 {
+    order: 5; }
+  .platform_sh_standalone .order-sm-6 {
+    order: 6; }
+  .platform_sh_standalone .order-sm-7 {
+    order: 7; }
+  .platform_sh_standalone .order-sm-8 {
+    order: 8; }
+  .platform_sh_standalone .order-sm-9 {
+    order: 9; }
+  .platform_sh_standalone .order-sm-10 {
+    order: 10; }
+  .platform_sh_standalone .order-sm-11 {
+    order: 11; }
+  .platform_sh_standalone .order-sm-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-sm-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-sm-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-sm-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-sm-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-sm-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-sm-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-sm-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-sm-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-sm-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-sm-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-sm-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-sm-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .col-md {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-md-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-md-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-md-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-md-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-md-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-md-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-md-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-md-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-md-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-md-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-md-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-md-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-md-first {
+    order: -1; }
+  .platform_sh_standalone .order-md-last {
+    order: 13; }
+  .platform_sh_standalone .order-md-0 {
+    order: 0; }
+  .platform_sh_standalone .order-md-1 {
+    order: 1; }
+  .platform_sh_standalone .order-md-2 {
+    order: 2; }
+  .platform_sh_standalone .order-md-3 {
+    order: 3; }
+  .platform_sh_standalone .order-md-4 {
+    order: 4; }
+  .platform_sh_standalone .order-md-5 {
+    order: 5; }
+  .platform_sh_standalone .order-md-6 {
+    order: 6; }
+  .platform_sh_standalone .order-md-7 {
+    order: 7; }
+  .platform_sh_standalone .order-md-8 {
+    order: 8; }
+  .platform_sh_standalone .order-md-9 {
+    order: 9; }
+  .platform_sh_standalone .order-md-10 {
+    order: 10; }
+  .platform_sh_standalone .order-md-11 {
+    order: 11; }
+  .platform_sh_standalone .order-md-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-md-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-md-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-md-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-md-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-md-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-md-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-md-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-md-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-md-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-md-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-md-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-md-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .col-lg {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-lg-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-lg-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-lg-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-lg-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-lg-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-lg-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-lg-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-lg-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-lg-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-lg-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-lg-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-lg-first {
+    order: -1; }
+  .platform_sh_standalone .order-lg-last {
+    order: 13; }
+  .platform_sh_standalone .order-lg-0 {
+    order: 0; }
+  .platform_sh_standalone .order-lg-1 {
+    order: 1; }
+  .platform_sh_standalone .order-lg-2 {
+    order: 2; }
+  .platform_sh_standalone .order-lg-3 {
+    order: 3; }
+  .platform_sh_standalone .order-lg-4 {
+    order: 4; }
+  .platform_sh_standalone .order-lg-5 {
+    order: 5; }
+  .platform_sh_standalone .order-lg-6 {
+    order: 6; }
+  .platform_sh_standalone .order-lg-7 {
+    order: 7; }
+  .platform_sh_standalone .order-lg-8 {
+    order: 8; }
+  .platform_sh_standalone .order-lg-9 {
+    order: 9; }
+  .platform_sh_standalone .order-lg-10 {
+    order: 10; }
+  .platform_sh_standalone .order-lg-11 {
+    order: 11; }
+  .platform_sh_standalone .order-lg-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-lg-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-lg-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-lg-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-lg-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-lg-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-lg-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-lg-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-lg-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-lg-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-lg-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-lg-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-lg-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .col-xl {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xl-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-xl-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-xl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-xl-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-xl-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-xl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-xl-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-xl-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-xl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-xl-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-xl-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-xl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-xl-first {
+    order: -1; }
+  .platform_sh_standalone .order-xl-last {
+    order: 13; }
+  .platform_sh_standalone .order-xl-0 {
+    order: 0; }
+  .platform_sh_standalone .order-xl-1 {
+    order: 1; }
+  .platform_sh_standalone .order-xl-2 {
+    order: 2; }
+  .platform_sh_standalone .order-xl-3 {
+    order: 3; }
+  .platform_sh_standalone .order-xl-4 {
+    order: 4; }
+  .platform_sh_standalone .order-xl-5 {
+    order: 5; }
+  .platform_sh_standalone .order-xl-6 {
+    order: 6; }
+  .platform_sh_standalone .order-xl-7 {
+    order: 7; }
+  .platform_sh_standalone .order-xl-8 {
+    order: 8; }
+  .platform_sh_standalone .order-xl-9 {
+    order: 9; }
+  .platform_sh_standalone .order-xl-10 {
+    order: 10; }
+  .platform_sh_standalone .order-xl-11 {
+    order: 11; }
+  .platform_sh_standalone .order-xl-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-xl-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-xl-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-xl-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-xl-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-xl-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-xl-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-xl-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-xl-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-xl-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-xl-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-xl-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-xl-11 {
+    margin-left: 91.6666666667%; } }
+.platform_sh_standalone .table {
+  width: 100%;
+  margin-bottom: 1rem;
+  color: #49475F; }
+.platform_sh_standalone .table th,
+.platform_sh_standalone .table td {
+  padding: 0.75rem;
+  vertical-align: top;
+  border-top: 1px solid #dee2e6; }
+.platform_sh_standalone .table thead th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #dee2e6; }
+.platform_sh_standalone .table tbody + tbody {
+  border-top: 2px solid #dee2e6; }
+.platform_sh_standalone .table-sm th,
+.platform_sh_standalone .table-sm td {
+  padding: 0.3rem; }
+.platform_sh_standalone .table-bordered {
+  border: 1px solid #dee2e6; }
+.platform_sh_standalone .table-bordered th,
+.platform_sh_standalone .table-bordered td {
+  border: 1px solid #dee2e6; }
+.platform_sh_standalone .table-bordered thead th,
+.platform_sh_standalone .table-bordered thead td {
+  border-bottom-width: 2px; }
+.platform_sh_standalone .table-borderless th,
+.platform_sh_standalone .table-borderless td,
+.platform_sh_standalone .table-borderless thead th,
+.platform_sh_standalone .table-borderless tbody + tbody {
+  border: 0; }
+.platform_sh_standalone .table-striped tbody tr:nth-of-type(odd) {
+  background-color: rgba(0, 0, 0, 0.05); }
+.platform_sh_standalone .table-hover tbody tr:hover {
+  color: #49475F;
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table-primary,
+.platform_sh_standalone .table-primary > th,
+.platform_sh_standalone .table-primary > td {
+  background-color: #bdd1ef; }
+.platform_sh_standalone .table-primary th,
+.platform_sh_standalone .table-primary td,
+.platform_sh_standalone .table-primary thead th,
+.platform_sh_standalone .table-primary tbody + tbody {
+  border-color: #85aae1; }
+.platform_sh_standalone .table-hover .table-primary:hover {
+  background-color: #a8c3ea; }
+.platform_sh_standalone .table-hover .table-primary:hover > td,
+.platform_sh_standalone .table-hover .table-primary:hover > th {
+  background-color: #a8c3ea; }
+.platform_sh_standalone .table-secondary,
+.platform_sh_standalone .table-secondary > th,
+.platform_sh_standalone .table-secondary > td {
+  background-color: #d6d8db; }
+.platform_sh_standalone .table-secondary th,
+.platform_sh_standalone .table-secondary td,
+.platform_sh_standalone .table-secondary thead th,
+.platform_sh_standalone .table-secondary tbody + tbody {
+  border-color: #b3b7bb; }
+.platform_sh_standalone .table-hover .table-secondary:hover {
+  background-color: #c8cbcf; }
+.platform_sh_standalone .table-hover .table-secondary:hover > td,
+.platform_sh_standalone .table-hover .table-secondary:hover > th {
+  background-color: #c8cbcf; }
+.platform_sh_standalone .table-success,
+.platform_sh_standalone .table-success > th,
+.platform_sh_standalone .table-success > td {
+  background-color: #c3e6cb; }
+.platform_sh_standalone .table-success th,
+.platform_sh_standalone .table-success td,
+.platform_sh_standalone .table-success thead th,
+.platform_sh_standalone .table-success tbody + tbody {
+  border-color: #8fd19e; }
+.platform_sh_standalone .table-hover .table-success:hover {
+  background-color: #b1dfbb; }
+.platform_sh_standalone .table-hover .table-success:hover > td,
+.platform_sh_standalone .table-hover .table-success:hover > th {
+  background-color: #b1dfbb; }
+.platform_sh_standalone .table-info,
+.platform_sh_standalone .table-info > th,
+.platform_sh_standalone .table-info > td {
+  background-color: #bee5eb; }
+.platform_sh_standalone .table-info th,
+.platform_sh_standalone .table-info td,
+.platform_sh_standalone .table-info thead th,
+.platform_sh_standalone .table-info tbody + tbody {
+  border-color: #86cfda; }
+.platform_sh_standalone .table-hover .table-info:hover {
+  background-color: #abdde5; }
+.platform_sh_standalone .table-hover .table-info:hover > td,
+.platform_sh_standalone .table-hover .table-info:hover > th {
+  background-color: #abdde5; }
+.platform_sh_standalone .table-warning,
+.platform_sh_standalone .table-warning > th,
+.platform_sh_standalone .table-warning > td {
+  background-color: #fcecc7; }
+.platform_sh_standalone .table-warning th,
+.platform_sh_standalone .table-warning td,
+.platform_sh_standalone .table-warning thead th,
+.platform_sh_standalone .table-warning tbody + tbody {
+  border-color: #f9db97; }
+.platform_sh_standalone .table-hover .table-warning:hover {
+  background-color: #fbe4af; }
+.platform_sh_standalone .table-hover .table-warning:hover > td,
+.platform_sh_standalone .table-hover .table-warning:hover > th {
+  background-color: #fbe4af; }
+.platform_sh_standalone .table-danger,
+.platform_sh_standalone .table-danger > th,
+.platform_sh_standalone .table-danger > td {
+  background-color: #f5c6cb; }
+.platform_sh_standalone .table-danger th,
+.platform_sh_standalone .table-danger td,
+.platform_sh_standalone .table-danger thead th,
+.platform_sh_standalone .table-danger tbody + tbody {
+  border-color: #ed969e; }
+.platform_sh_standalone .table-hover .table-danger:hover {
+  background-color: #f1b0b7; }
+.platform_sh_standalone .table-hover .table-danger:hover > td,
+.platform_sh_standalone .table-hover .table-danger:hover > th {
+  background-color: #f1b0b7; }
+.platform_sh_standalone .table-light,
+.platform_sh_standalone .table-light > th,
+.platform_sh_standalone .table-light > td {
+  background-color: #fdfdfe; }
+.platform_sh_standalone .table-light th,
+.platform_sh_standalone .table-light td,
+.platform_sh_standalone .table-light thead th,
+.platform_sh_standalone .table-light tbody + tbody {
+  border-color: #fbfcfc; }
+.platform_sh_standalone .table-hover .table-light:hover {
+  background-color: #ececf6; }
+.platform_sh_standalone .table-hover .table-light:hover > td,
+.platform_sh_standalone .table-hover .table-light:hover > th {
+  background-color: #ececf6; }
+.platform_sh_standalone .table-dark,
+.platform_sh_standalone .table-dark > th,
+.platform_sh_standalone .table-dark > td {
+  background-color: #c6c8ca; }
+.platform_sh_standalone .table-dark th,
+.platform_sh_standalone .table-dark td,
+.platform_sh_standalone .table-dark thead th,
+.platform_sh_standalone .table-dark tbody + tbody {
+  border-color: #95999c; }
+.platform_sh_standalone .table-hover .table-dark:hover {
+  background-color: #b9bbbe; }
+.platform_sh_standalone .table-hover .table-dark:hover > td,
+.platform_sh_standalone .table-hover .table-dark:hover > th {
+  background-color: #b9bbbe; }
+.platform_sh_standalone .table-active,
+.platform_sh_standalone .table-active > th,
+.platform_sh_standalone .table-active > td {
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table-hover .table-active:hover {
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table-hover .table-active:hover > td,
+.platform_sh_standalone .table-hover .table-active:hover > th {
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table .thead-dark th {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #454d55; }
+.platform_sh_standalone .table .thead-light th {
+  color: #495057;
+  background-color: #e9ecef;
+  border-color: #dee2e6; }
+.platform_sh_standalone .table-dark {
+  color: #fff;
+  background-color: #343a40; }
+.platform_sh_standalone .table-dark th,
+.platform_sh_standalone .table-dark td,
+.platform_sh_standalone .table-dark thead th {
+  border-color: #454d55; }
+.platform_sh_standalone .table-dark.table-bordered {
+  border: 0; }
+.platform_sh_standalone .table-dark.table-striped tbody tr:nth-of-type(odd) {
+  background-color: rgba(255, 255, 255, 0.05); }
+.platform_sh_standalone .table-dark.table-hover tbody tr:hover {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.075); }
+@media (max-width: 575.98px) {
+  .platform_sh_standalone .table-responsive-sm {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-sm > .table-bordered {
+    border: 0; } }
+@media (max-width: 767.98px) {
+  .platform_sh_standalone .table-responsive-md {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-md > .table-bordered {
+    border: 0; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .table-responsive-lg {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-lg > .table-bordered {
+    border: 0; } }
+@media (max-width: 1199.98px) {
+  .platform_sh_standalone .table-responsive-xl {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-xl > .table-bordered {
+    border: 0; } }
+.platform_sh_standalone .table-responsive {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch; }
+.platform_sh_standalone .table-responsive > .table-bordered {
+  border: 0; }
+.platform_sh_standalone .form-control {
+  display: block;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid #ced4da;
+  border-radius: 0;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .form-control {
+    transition: none; } }
+.platform_sh_standalone .form-control::-ms-expand {
+  background-color: transparent;
+  border: 0; }
+.platform_sh_standalone .form-control:focus {
+  color: #495057;
+  background-color: #fff;
+  border-color: #6aa0f0;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .form-control::placeholder {
+  color: #6c757d;
+  opacity: 1; }
+.platform_sh_standalone .form-control:disabled, .platform_sh_standalone .form-control[readonly] {
+  background-color: #e9ecef;
+  opacity: 1; }
+.platform_sh_standalone select.form-control:focus::-ms-value {
+  color: #495057;
+  background-color: #fff; }
+.platform_sh_standalone .form-control-file,
+.platform_sh_standalone .form-control-range {
+  display: block;
+  width: 100%; }
+.platform_sh_standalone .col-form-label {
+  padding-top: calc(0.375rem + 1px);
+  padding-bottom: calc(0.375rem + 1px);
+  margin-bottom: 0;
+  font-size: inherit;
+  line-height: 1; }
+.platform_sh_standalone .col-form-label-lg {
+  padding-top: calc(0.5rem + 1px);
+  padding-bottom: calc(0.5rem + 1px);
+  font-size: 1.25rem;
+  line-height: 1.5; }
+.platform_sh_standalone .col-form-label-sm {
+  padding-top: calc(0.25rem + 1px);
+  padding-bottom: calc(0.25rem + 1px);
+  font-size: 0.875rem;
+  line-height: 1.5; }
+.platform_sh_standalone .form-control-plaintext {
+  display: block;
+  width: 100%;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  margin-bottom: 0;
+  line-height: 1;
+  color: #49475F;
+  background-color: transparent;
+  border: solid transparent;
+  border-width: 1px 0; }
+.platform_sh_standalone .form-control-plaintext.form-control-sm, .platform_sh_standalone .form-control-plaintext.form-control-lg {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .form-control-sm {
+  height: calc(1.5em + 0.5rem + 2px);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .form-control-lg {
+  height: calc(1.5em + 1rem + 2px);
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone select.form-control[size], .platform_sh_standalone select.form-control[multiple] {
+  height: auto; }
+.platform_sh_standalone textarea.form-control {
+  height: auto; }
+.platform_sh_standalone .form-group {
+  margin-bottom: 1rem; }
+.platform_sh_standalone .form-text {
+  display: block;
+  margin-top: 0.25rem; }
+.platform_sh_standalone .form-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -5px;
+  margin-left: -5px; }
+.platform_sh_standalone .form-row > .col,
+.platform_sh_standalone .form-row > [class*="col-"] {
+  padding-right: 5px;
+  padding-left: 5px; }
+.platform_sh_standalone .form-check {
+  position: relative;
+  display: block;
+  padding-left: 1.25rem; }
+.platform_sh_standalone .form-check-input {
+  position: absolute;
+  margin-top: 0.3rem;
+  margin-left: -1.25rem; }
+.platform_sh_standalone .form-check-input:disabled ~ .form-check-label {
+  color: #6c757d; }
+.platform_sh_standalone .form-check-label {
+  margin-bottom: 0; }
+.platform_sh_standalone .form-check-inline {
+  display: inline-flex;
+  align-items: center;
+  padding-left: 0;
+  margin-right: 0.75rem; }
+.platform_sh_standalone .form-check-inline .form-check-input {
+  position: static;
+  margin-top: 0;
+  margin-right: 0.3125rem;
+  margin-left: 0; }
+.platform_sh_standalone .valid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #28a745; }
+.platform_sh_standalone .valid-tooltip {
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+  display: none;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin-top: .1rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: #fff;
+  background-color: rgba(40, 167, 69, 0.9);
+  border-radius: 0; }
+.was-validated .platform_sh_standalone .form-control:valid, .platform_sh_standalone .form-control.is-valid {
+  border-color: #28a745;
+  padding-right: calc(1em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: center right calc(0.25em + 0.1875rem);
+  background-size: calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .form-control:valid:focus, .platform_sh_standalone .form-control.is-valid:focus {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.was-validated .platform_sh_standalone .form-control:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .form-control:valid ~ .valid-tooltip, .platform_sh_standalone .form-control.is-valid ~ .valid-feedback,
+.platform_sh_standalone .form-control.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone textarea.form-control:valid, .platform_sh_standalone textarea.form-control.is-valid {
+  padding-right: calc(1em + 0.75rem);
+  background-position: top calc(0.25em + 0.1875rem) right calc(0.25em + 0.1875rem); }
+.was-validated .platform_sh_standalone .custom-select:valid, .platform_sh_standalone .custom-select.is-valid {
+  border-color: #28a745;
+  padding-right: calc((1em + 0.75rem) * 3 / 4 + 1.75rem);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") #fff no-repeat center right 1.75rem/calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .custom-select:valid:focus, .platform_sh_standalone .custom-select.is-valid:focus {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-select:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .custom-select:valid ~ .valid-tooltip, .platform_sh_standalone .custom-select.is-valid ~ .valid-feedback,
+.platform_sh_standalone .custom-select.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-control-file:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .form-control-file:valid ~ .valid-tooltip, .platform_sh_standalone .form-control-file.is-valid ~ .valid-feedback,
+.platform_sh_standalone .form-control-file.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-check-input:valid ~ .form-check-label, .platform_sh_standalone .form-check-input.is-valid ~ .form-check-label {
+  color: #28a745; }
+.was-validated .platform_sh_standalone .form-check-input:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .form-check-input:valid ~ .valid-tooltip, .platform_sh_standalone .form-check-input.is-valid ~ .valid-feedback,
+.platform_sh_standalone .form-check-input.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .custom-control-label, .platform_sh_standalone .custom-control-input.is-valid ~ .custom-control-label {
+  color: #28a745; }
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid ~ .custom-control-label::before {
+  border-color: #28a745; }
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .valid-tooltip, .platform_sh_standalone .custom-control-input.is-valid ~ .valid-feedback,
+.platform_sh_standalone .custom-control-input.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:valid:checked ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid:checked ~ .custom-control-label::before {
+  border-color: #34ce57;
+  background-color: #34ce57; }
+.was-validated .platform_sh_standalone .custom-control-input:valid:focus ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-control-input:valid:focus:not(:checked) ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #28a745; }
+.was-validated .platform_sh_standalone .custom-file-input:valid ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-valid ~ .custom-file-label {
+  border-color: #28a745; }
+.was-validated .platform_sh_standalone .custom-file-input:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .custom-file-input:valid ~ .valid-tooltip, .platform_sh_standalone .custom-file-input.is-valid ~ .valid-feedback,
+.platform_sh_standalone .custom-file-input.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-file-input:valid:focus ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-valid:focus ~ .custom-file-label {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.platform_sh_standalone .invalid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #dc3545; }
+.platform_sh_standalone .invalid-tooltip {
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+  display: none;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin-top: .1rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: #fff;
+  background-color: rgba(220, 53, 69, 0.9);
+  border-radius: 0; }
+.was-validated .platform_sh_standalone .form-control:invalid, .platform_sh_standalone .form-control.is-invalid {
+  border-color: #dc3545;
+  padding-right: calc(1em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23dc3545' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23dc3545' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center right calc(0.25em + 0.1875rem);
+  background-size: calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .form-control:invalid:focus, .platform_sh_standalone .form-control.is-invalid:focus {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.was-validated .platform_sh_standalone .form-control:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .form-control:invalid ~ .invalid-tooltip, .platform_sh_standalone .form-control.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .form-control.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone textarea.form-control:invalid, .platform_sh_standalone textarea.form-control.is-invalid {
+  padding-right: calc(1em + 0.75rem);
+  background-position: top calc(0.25em + 0.1875rem) right calc(0.25em + 0.1875rem); }
+.was-validated .platform_sh_standalone .custom-select:invalid, .platform_sh_standalone .custom-select.is-invalid {
+  border-color: #dc3545;
+  padding-right: calc((1em + 0.75rem) * 3 / 4 + 1.75rem);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23dc3545' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23dc3545' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E") #fff no-repeat center right 1.75rem/calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .custom-select:invalid:focus, .platform_sh_standalone .custom-select.is-invalid:focus {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-select:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .custom-select:invalid ~ .invalid-tooltip, .platform_sh_standalone .custom-select.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .custom-select.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-control-file:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .form-control-file:invalid ~ .invalid-tooltip, .platform_sh_standalone .form-control-file.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .form-control-file.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-check-input:invalid ~ .form-check-label, .platform_sh_standalone .form-check-input.is-invalid ~ .form-check-label {
+  color: #dc3545; }
+.was-validated .platform_sh_standalone .form-check-input:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .form-check-input:invalid ~ .invalid-tooltip, .platform_sh_standalone .form-check-input.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .form-check-input.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .custom-control-label, .platform_sh_standalone .custom-control-input.is-invalid ~ .custom-control-label {
+  color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid ~ .custom-control-label::before {
+  border-color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .invalid-tooltip, .platform_sh_standalone .custom-control-input.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .custom-control-input.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid:checked ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid:checked ~ .custom-control-label::before {
+  border-color: #e4606d;
+  background-color: #e4606d; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid:focus ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-control-input:invalid:focus:not(:checked) ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-file-input:invalid ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-invalid ~ .custom-file-label {
+  border-color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-file-input:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .custom-file-input:invalid ~ .invalid-tooltip, .platform_sh_standalone .custom-file-input.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .custom-file-input.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-file-input:invalid:focus ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-invalid:focus ~ .custom-file-label {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.platform_sh_standalone .form-inline {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center; }
+.platform_sh_standalone .form-inline .form-check {
+  width: 100%; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .form-inline label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 0; }
+  .platform_sh_standalone .form-inline .form-group {
+    display: flex;
+    flex: 0 0 auto;
+    flex-flow: row wrap;
+    align-items: center;
+    margin-bottom: 0; }
+  .platform_sh_standalone .form-inline .form-control {
+    display: inline-block;
+    width: auto;
+    vertical-align: middle; }
+  .platform_sh_standalone .form-inline .form-control-plaintext {
+    display: inline-block; }
+  .platform_sh_standalone .form-inline .input-group,
+  .platform_sh_standalone .form-inline .custom-select {
+    width: auto; }
+  .platform_sh_standalone .form-inline .form-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: auto;
+    padding-left: 0; }
+  .platform_sh_standalone .form-inline .form-check-input {
+    position: relative;
+    flex-shrink: 0;
+    margin-top: 0;
+    margin-right: 0.25rem;
+    margin-left: 0; }
+  .platform_sh_standalone .form-inline .custom-control {
+    align-items: center;
+    justify-content: center; }
+  .platform_sh_standalone .form-inline .custom-control-label {
+    margin-bottom: 0; } }
+.platform_sh_standalone .btn, .platform_sh_standalone #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .user-widget__free-trial {
+  display: inline-block;
+  font-weight: 400;
+  color: #49475F;
+  text-align: center;
+  vertical-align: middle;
+  user-select: none;
+  background-color: transparent;
+  border: 0 solid transparent;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  line-height: 1;
+  border-radius: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .btn, .platform_sh_standalone #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .user-widget__free-trial {
+    transition: none; } }
+.platform_sh_standalone .btn:hover, .platform_sh_standalone #user-widget .user-widget__log-in:hover, .platform_sh_standalone #user-widget .user-widget__free-trial:hover {
+  color: #49475F;
+  text-decoration: none; }
+.platform_sh_standalone .btn:focus, .platform_sh_standalone #user-widget .user-widget__log-in:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:focus, .platform_sh_standalone .btn.focus, .platform_sh_standalone #user-widget .focus.user-widget__log-in, .platform_sh_standalone #user-widget .focus.user-widget__free-trial {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .btn.disabled, .platform_sh_standalone #user-widget .disabled.user-widget__log-in, .platform_sh_standalone #user-widget .disabled.user-widget__free-trial, .platform_sh_standalone .btn:disabled, .platform_sh_standalone #user-widget .user-widget__log-in:disabled, .platform_sh_standalone #user-widget .user-widget__free-trial:disabled {
+  opacity: 0.65; }
+.platform_sh_standalone a.btn.disabled, .platform_sh_standalone #user-widget a.disabled.user-widget__log-in, .platform_sh_standalone #user-widget a.disabled.user-widget__free-trial,
+.platform_sh_standalone fieldset:disabled a.btn,
+.platform_sh_standalone fieldset:disabled #user-widget a.user-widget__log-in,
+.platform_sh_standalone #user-widget fieldset:disabled a.user-widget__log-in,
+.platform_sh_standalone fieldset:disabled #user-widget a.user-widget__free-trial,
+.platform_sh_standalone #user-widget fieldset:disabled a.user-widget__free-trial {
+  pointer-events: none; }
+.platform_sh_standalone .btn-primary, .platform_sh_standalone #user-widget .user-widget__free-trial {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-primary:hover, .platform_sh_standalone #user-widget .user-widget__free-trial:hover {
+  color: #fff;
+  background-color: #104ca3;
+  border-color: #0f4698; }
+.platform_sh_standalone .btn-primary:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:focus, .platform_sh_standalone .btn-primary.focus, .platform_sh_standalone #user-widget .focus.user-widget__free-trial {
+  box-shadow: 0 0 0 0.2rem rgba(55, 116, 207, 0.5); }
+.platform_sh_standalone .btn-primary.disabled, .platform_sh_standalone #user-widget .disabled.user-widget__free-trial, .platform_sh_standalone .btn-primary:disabled, .platform_sh_standalone #user-widget .user-widget__free-trial:disabled {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-primary:not(:disabled):not(.disabled):active, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-primary:not(:disabled):not(.disabled).active, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-primary.dropdown-toggle, .show > .platform_sh_standalone #user-widget .dropdown-toggle.user-widget__free-trial {
+  color: #fff;
+  background-color: #0f4698;
+  border-color: #0e418c; }
+.platform_sh_standalone .btn-primary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-primary:not(:disabled):not(.disabled).active:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-primary.dropdown-toggle:focus, .show > .platform_sh_standalone #user-widget .dropdown-toggle.user-widget__free-trial:focus {
+  box-shadow: 0 0 0 0.2rem rgba(55, 116, 207, 0.5); }
+.platform_sh_standalone .btn-secondary {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-secondary:hover {
+  color: #fff;
+  background-color: #5a6268;
+  border-color: #545b62; }
+.platform_sh_standalone .btn-secondary:focus, .platform_sh_standalone .btn-secondary.focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5); }
+.platform_sh_standalone .btn-secondary.disabled, .platform_sh_standalone .btn-secondary:disabled {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-secondary.dropdown-toggle {
+  color: #fff;
+  background-color: #545b62;
+  border-color: #4e555b; }
+.platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-secondary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5); }
+.platform_sh_standalone .btn-success {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-success:hover {
+  color: #fff;
+  background-color: #218838;
+  border-color: #1e7e34; }
+.platform_sh_standalone .btn-success:focus, .platform_sh_standalone .btn-success.focus {
+  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5); }
+.platform_sh_standalone .btn-success.disabled, .platform_sh_standalone .btn-success:disabled {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-success:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-success:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-success.dropdown-toggle {
+  color: #fff;
+  background-color: #1e7e34;
+  border-color: #1c7430; }
+.platform_sh_standalone .btn-success:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-success:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-success.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5); }
+.platform_sh_standalone .btn-info {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-info:hover {
+  color: #fff;
+  background-color: #138496;
+  border-color: #117a8b; }
+.platform_sh_standalone .btn-info:focus, .platform_sh_standalone .btn-info.focus {
+  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5); }
+.platform_sh_standalone .btn-info.disabled, .platform_sh_standalone .btn-info:disabled {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-info:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-info:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-info.dropdown-toggle {
+  color: #fff;
+  background-color: #117a8b;
+  border-color: #10707f; }
+.platform_sh_standalone .btn-info:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-info:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-info.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5); }
+.platform_sh_standalone .btn-warning {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-warning:hover {
+  color: #212529;
+  background-color: #f2ad13;
+  border-color: #eba70d; }
+.platform_sh_standalone .btn-warning:focus, .platform_sh_standalone .btn-warning.focus {
+  box-shadow: 0 0 0 0.2rem rgba(212, 164, 53, 0.5); }
+.platform_sh_standalone .btn-warning.disabled, .platform_sh_standalone .btn-warning:disabled {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-warning:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-warning:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-warning.dropdown-toggle {
+  color: #212529;
+  background-color: #eba70d;
+  border-color: #df9e0c; }
+.platform_sh_standalone .btn-warning:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-warning:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-warning.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(212, 164, 53, 0.5); }
+.platform_sh_standalone .btn-danger {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-danger:hover {
+  color: #fff;
+  background-color: #c82333;
+  border-color: #bd2130; }
+.platform_sh_standalone .btn-danger:focus, .platform_sh_standalone .btn-danger.focus {
+  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5); }
+.platform_sh_standalone .btn-danger.disabled, .platform_sh_standalone .btn-danger:disabled {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-danger:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-danger:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-danger.dropdown-toggle {
+  color: #fff;
+  background-color: #bd2130;
+  border-color: #b21f2d; }
+.platform_sh_standalone .btn-danger:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-danger:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-danger.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5); }
+.platform_sh_standalone .btn-light {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-light:hover {
+  color: #212529;
+  background-color: #e2e6ea;
+  border-color: #dae0e5; }
+.platform_sh_standalone .btn-light:focus, .platform_sh_standalone .btn-light.focus {
+  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5); }
+.platform_sh_standalone .btn-light.disabled, .platform_sh_standalone .btn-light:disabled {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-light:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-light:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-light.dropdown-toggle {
+  color: #212529;
+  background-color: #dae0e5;
+  border-color: #d3d9df; }
+.platform_sh_standalone .btn-light:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-light:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-light.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5); }
+.platform_sh_standalone .btn-dark {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-dark:hover {
+  color: #fff;
+  background-color: #23272b;
+  border-color: #1d2124; }
+.platform_sh_standalone .btn-dark:focus, .platform_sh_standalone .btn-dark.focus {
+  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5); }
+.platform_sh_standalone .btn-dark.disabled, .platform_sh_standalone .btn-dark:disabled {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-dark:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-dark:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-dark.dropdown-toggle {
+  color: #fff;
+  background-color: #1d2124;
+  border-color: #171a1d; }
+.platform_sh_standalone .btn-dark:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-dark:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-dark.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5); }
+.platform_sh_standalone .btn-outline-primary {
+  color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-outline-primary:hover {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-outline-primary:focus, .platform_sh_standalone .btn-outline-primary.focus {
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .btn-outline-primary.disabled, .platform_sh_standalone .btn-outline-primary:disabled {
+  color: #145CC6;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-primary.dropdown-toggle {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-primary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .btn-outline-secondary {
+  color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-outline-secondary:hover {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-outline-secondary:focus, .platform_sh_standalone .btn-outline-secondary.focus {
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
+.platform_sh_standalone .btn-outline-secondary.disabled, .platform_sh_standalone .btn-outline-secondary:disabled {
+  color: #6c757d;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-secondary.dropdown-toggle {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-secondary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
+.platform_sh_standalone .btn-outline-success {
+  color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-outline-success:hover {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-outline-success:focus, .platform_sh_standalone .btn-outline-success.focus {
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
+.platform_sh_standalone .btn-outline-success.disabled, .platform_sh_standalone .btn-outline-success:disabled {
+  color: #28a745;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-success.dropdown-toggle {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-success.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
+.platform_sh_standalone .btn-outline-info {
+  color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-outline-info:hover {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-outline-info:focus, .platform_sh_standalone .btn-outline-info.focus {
+  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
+.platform_sh_standalone .btn-outline-info.disabled, .platform_sh_standalone .btn-outline-info:disabled {
+  color: #17a2b8;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-info.dropdown-toggle {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-info.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
+.platform_sh_standalone .btn-outline-warning {
+  color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-outline-warning:hover {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-outline-warning:focus, .platform_sh_standalone .btn-outline-warning.focus {
+  box-shadow: 0 0 0 0.2rem rgba(244, 186, 55, 0.5); }
+.platform_sh_standalone .btn-outline-warning.disabled, .platform_sh_standalone .btn-outline-warning:disabled {
+  color: #F4BA37;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-warning.dropdown-toggle {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-warning.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(244, 186, 55, 0.5); }
+.platform_sh_standalone .btn-outline-danger {
+  color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-outline-danger:hover {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-outline-danger:focus, .platform_sh_standalone .btn-outline-danger.focus {
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
+.platform_sh_standalone .btn-outline-danger.disabled, .platform_sh_standalone .btn-outline-danger:disabled {
+  color: #dc3545;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-danger.dropdown-toggle {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-danger.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
+.platform_sh_standalone .btn-outline-light {
+  color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-outline-light:hover {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-outline-light:focus, .platform_sh_standalone .btn-outline-light.focus {
+  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
+.platform_sh_standalone .btn-outline-light.disabled, .platform_sh_standalone .btn-outline-light:disabled {
+  color: #f8f9fa;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-light.dropdown-toggle {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-light.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
+.platform_sh_standalone .btn-outline-dark {
+  color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-outline-dark:hover {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-outline-dark:focus, .platform_sh_standalone .btn-outline-dark.focus {
+  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
+.platform_sh_standalone .btn-outline-dark.disabled, .platform_sh_standalone .btn-outline-dark:disabled {
+  color: #343a40;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-dark.dropdown-toggle {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-dark.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
+.platform_sh_standalone .btn-link {
+  font-weight: 400;
+  color: #145CC6;
+  text-decoration: none; }
+.platform_sh_standalone .btn-link:hover {
+  color: #0d3c81;
+  text-decoration: underline; }
+.platform_sh_standalone .btn-link:focus, .platform_sh_standalone .btn-link.focus {
+  text-decoration: underline;
+  box-shadow: none; }
+.platform_sh_standalone .btn-link:disabled, .platform_sh_standalone .btn-link.disabled {
+  color: #6c757d;
+  pointer-events: none; }
+.platform_sh_standalone .btn-lg, .platform_sh_standalone .btn-group-lg > .btn, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__free-trial {
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .btn-sm, .platform_sh_standalone .btn-group-sm > .btn, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__free-trial {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .btn-block {
+  display: block;
+  width: 100%; }
+.platform_sh_standalone .btn-block + .btn-block {
+  margin-top: 0.5rem; }
+.platform_sh_standalone input[type="submit"].btn-block,
+.platform_sh_standalone input[type="reset"].btn-block,
+.platform_sh_standalone input[type="button"].btn-block {
+  width: 100%; }
+.platform_sh_standalone .fade {
+  transition: opacity 0.15s linear; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .fade {
+    transition: none; } }
+.platform_sh_standalone .fade:not(.show) {
+  opacity: 0; }
+.platform_sh_standalone .collapse:not(.show) {
+  display: none; }
+.platform_sh_standalone .collapsing {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  transition: height 0.35s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .collapsing {
+    transition: none; } }
+.platform_sh_standalone .dropup,
+.platform_sh_standalone .dropright,
+.platform_sh_standalone .dropdown,
+.platform_sh_standalone .dropleft {
+  position: relative; }
+.platform_sh_standalone .dropdown-toggle {
+  white-space: nowrap; }
+.platform_sh_standalone .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0;
+  border-left: 0.3em solid transparent; }
+.platform_sh_standalone .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 10rem;
+  padding: 0.5rem 0;
+  margin: 0.125rem 0 0;
+  font-size: 1rem;
+  color: #49475F;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0; }
+.platform_sh_standalone .dropdown-menu-left {
+  right: auto;
+  left: 0; }
+.platform_sh_standalone .dropdown-menu-right {
+  right: 0;
+  left: auto; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .dropdown-menu-sm-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-sm-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .dropdown-menu-md-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-md-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .dropdown-menu-lg-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-lg-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .dropdown-menu-xl-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-xl-right {
+    right: 0;
+    left: auto; } }
+.platform_sh_standalone .dropup .dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 0.125rem; }
+.platform_sh_standalone .dropup .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0.3em solid;
+  border-left: 0.3em solid transparent; }
+.platform_sh_standalone .dropup .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropright .dropdown-menu {
+  top: 0;
+  right: auto;
+  left: 100%;
+  margin-top: 0;
+  margin-left: 0.125rem; }
+.platform_sh_standalone .dropright .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0;
+  border-bottom: 0.3em solid transparent;
+  border-left: 0.3em solid; }
+.platform_sh_standalone .dropright .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropright .dropdown-toggle::after {
+  vertical-align: 0; }
+.platform_sh_standalone .dropleft .dropdown-menu {
+  top: 0;
+  right: 100%;
+  left: auto;
+  margin-top: 0;
+  margin-right: 0.125rem; }
+.platform_sh_standalone .dropleft .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: ""; }
+.platform_sh_standalone .dropleft .dropdown-toggle::after {
+  display: none; }
+.platform_sh_standalone .dropleft .dropdown-toggle::before {
+  display: inline-block;
+  margin-right: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0.3em solid;
+  border-bottom: 0.3em solid transparent; }
+.platform_sh_standalone .dropleft .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropleft .dropdown-toggle::before {
+  vertical-align: 0; }
+.platform_sh_standalone .dropdown-menu[x-placement^="top"], .platform_sh_standalone .dropdown-menu[x-placement^="right"], .platform_sh_standalone .dropdown-menu[x-placement^="bottom"], .platform_sh_standalone .dropdown-menu[x-placement^="left"] {
+  right: auto;
+  bottom: auto; }
+.platform_sh_standalone .dropdown-divider {
+  height: 0;
+  margin: 0.5rem 0;
+  overflow: hidden;
+  border-top: 1px solid #e9ecef; }
+.platform_sh_standalone .dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 1.5rem;
+  clear: both;
+  font-weight: 400;
+  color: #212529;
+  text-align: inherit;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0; }
+.platform_sh_standalone .dropdown-item:hover, .platform_sh_standalone .dropdown-item:focus {
+  color: #16181b;
+  text-decoration: none;
+  background-color: #f8f9fa; }
+.platform_sh_standalone .dropdown-item.active, .platform_sh_standalone .dropdown-item:active {
+  color: #fff;
+  text-decoration: none;
+  background-color: #145CC6; }
+.platform_sh_standalone .dropdown-item.disabled, .platform_sh_standalone .dropdown-item:disabled {
+  color: #6c757d;
+  pointer-events: none;
+  background-color: transparent; }
+.platform_sh_standalone .dropdown-menu.show {
+  display: block; }
+.platform_sh_standalone .dropdown-header {
+  display: block;
+  padding: 0.5rem 1.5rem;
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  color: #6c757d;
+  white-space: nowrap; }
+.platform_sh_standalone .dropdown-item-text {
+  display: block;
+  padding: 0.25rem 1.5rem;
+  color: #212529; }
+.platform_sh_standalone .btn-group,
+.platform_sh_standalone .btn-group-vertical {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle; }
+.platform_sh_standalone .btn-group > .btn, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial,
+.platform_sh_standalone .btn-group-vertical > .btn,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial {
+  position: relative;
+  flex: 1 1 auto; }
+.platform_sh_standalone .btn-group > .btn:hover, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:hover, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:hover,
+.platform_sh_standalone .btn-group-vertical > .btn:hover,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:hover,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:hover {
+  z-index: 1; }
+.platform_sh_standalone .btn-group > .btn:focus, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:focus, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:focus, .platform_sh_standalone .btn-group > .btn:active, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:active, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:active, .platform_sh_standalone .btn-group > .btn.active, .platform_sh_standalone #user-widget .btn-group > .active.user-widget__log-in, .platform_sh_standalone #user-widget .btn-group > .active.user-widget__free-trial,
+.platform_sh_standalone .btn-group-vertical > .btn:focus,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:focus,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:focus,
+.platform_sh_standalone .btn-group-vertical > .btn:active,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:active,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:active,
+.platform_sh_standalone .btn-group-vertical > .btn.active,
+.platform_sh_standalone #user-widget .btn-group-vertical > .active.user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .active.user-widget__free-trial {
+  z-index: 1; }
+.platform_sh_standalone .btn-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start; }
+.platform_sh_standalone .btn-toolbar .input-group {
+  width: auto; }
+.platform_sh_standalone .btn-group > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group > .btn-group:not(:first-child) {
+  margin-left: 0; }
+.platform_sh_standalone .btn-group > .btn:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone .btn-group > .btn-group:not(:last-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:last-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:last-child) > .user-widget__free-trial {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .btn-group > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group > .btn-group:not(:first-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:first-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:first-child) > .user-widget__free-trial {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .dropdown-toggle-split {
+  padding-right: 0.9375rem;
+  padding-left: 0.9375rem; }
+.platform_sh_standalone .dropdown-toggle-split::after, .dropup .platform_sh_standalone .dropdown-toggle-split::after, .dropright .platform_sh_standalone .dropdown-toggle-split::after {
+  margin-left: 0; }
+.dropleft .platform_sh_standalone .dropdown-toggle-split::before {
+  margin-right: 0; }
+.platform_sh_standalone .btn-sm + .dropdown-toggle-split, .platform_sh_standalone .btn-group-sm > .btn + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__log-in + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__free-trial + .dropdown-toggle-split {
+  padding-right: 0.375rem;
+  padding-left: 0.375rem; }
+.platform_sh_standalone .btn-lg + .dropdown-toggle-split, .platform_sh_standalone .btn-group-lg > .btn + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__log-in + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__free-trial + .dropdown-toggle-split {
+  padding-right: 0.75rem;
+  padding-left: 0.75rem; }
+.platform_sh_standalone .btn-group-vertical {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center; }
+.platform_sh_standalone .btn-group-vertical > .btn, .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial,
+.platform_sh_standalone .btn-group-vertical > .btn-group {
+  width: 100%; }
+.platform_sh_standalone .btn-group-vertical > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group-vertical > .btn-group:not(:first-child) {
+  margin-top: 0; }
+.platform_sh_standalone .btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone .btn-group-vertical > .btn-group:not(:last-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:last-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:last-child) > .user-widget__free-trial {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .btn-group-vertical > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group-vertical > .btn-group:not(:first-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:first-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:first-child) > .user-widget__free-trial {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .btn-group-toggle > .btn, .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__free-trial,
+.platform_sh_standalone .btn-group-toggle > .btn-group > .btn,
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__free-trial {
+  margin-bottom: 0; }
+.platform_sh_standalone .btn-group-toggle > .btn input[type="radio"], .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__log-in input[type="radio"], .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__free-trial input[type="radio"],
+.platform_sh_standalone .btn-group-toggle > .btn input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__log-in input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__free-trial input[type="checkbox"],
+.platform_sh_standalone .btn-group-toggle > .btn-group > .btn input[type="radio"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__log-in input[type="radio"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__free-trial input[type="radio"],
+.platform_sh_standalone .btn-group-toggle > .btn-group > .btn input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__log-in input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__free-trial input[type="checkbox"] {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+  pointer-events: none; }
+.platform_sh_standalone .input-group {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  width: 100%; }
+.platform_sh_standalone .input-group > .form-control,
+.platform_sh_standalone .input-group > .form-control-plaintext,
+.platform_sh_standalone .input-group > .custom-select,
+.platform_sh_standalone .input-group > .custom-file {
+  position: relative;
+  flex: 1 1 auto;
+  width: 1%;
+  margin-bottom: 0; }
+.platform_sh_standalone .input-group > .form-control + .form-control,
+.platform_sh_standalone .input-group > .form-control + .custom-select,
+.platform_sh_standalone .input-group > .form-control + .custom-file,
+.platform_sh_standalone .input-group > .form-control-plaintext + .form-control,
+.platform_sh_standalone .input-group > .form-control-plaintext + .custom-select,
+.platform_sh_standalone .input-group > .form-control-plaintext + .custom-file,
+.platform_sh_standalone .input-group > .custom-select + .form-control,
+.platform_sh_standalone .input-group > .custom-select + .custom-select,
+.platform_sh_standalone .input-group > .custom-select + .custom-file,
+.platform_sh_standalone .input-group > .custom-file + .form-control,
+.platform_sh_standalone .input-group > .custom-file + .custom-select,
+.platform_sh_standalone .input-group > .custom-file + .custom-file {
+  margin-left: -1px; }
+.platform_sh_standalone .input-group > .form-control:focus,
+.platform_sh_standalone .input-group > .custom-select:focus,
+.platform_sh_standalone .input-group > .custom-file .custom-file-input:focus ~ .custom-file-label {
+  z-index: 3; }
+.platform_sh_standalone .input-group > .custom-file .custom-file-input:focus {
+  z-index: 4; }
+.platform_sh_standalone .input-group > .form-control:not(:last-child),
+.platform_sh_standalone .input-group > .custom-select:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .input-group > .form-control:not(:first-child),
+.platform_sh_standalone .input-group > .custom-select:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .input-group > .custom-file {
+  display: flex;
+  align-items: center; }
+.platform_sh_standalone .input-group > .custom-file:not(:last-child) .custom-file-label, .platform_sh_standalone .input-group > .custom-file:not(:last-child) .custom-file-label::after {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .input-group > .custom-file:not(:first-child) .custom-file-label {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .input-group-prepend,
+.platform_sh_standalone .input-group-append {
+  display: flex; }
+.platform_sh_standalone .input-group-prepend .btn, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial,
+.platform_sh_standalone .input-group-append .btn,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial {
+  position: relative;
+  z-index: 2; }
+.platform_sh_standalone .input-group-prepend .btn:focus, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in:focus, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in:focus, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial:focus, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial:focus,
+.platform_sh_standalone .input-group-append .btn:focus,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in:focus,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in:focus,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial:focus,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial:focus {
+  z-index: 3; }
+.platform_sh_standalone .input-group-prepend .btn + .btn, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .btn, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .btn, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .btn, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .btn, .platform_sh_standalone .input-group-prepend #user-widget .btn + .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .btn + .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .btn + .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .btn + .user-widget__free-trial, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .user-widget__free-trial, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .user-widget__free-trial,
+.platform_sh_standalone .input-group-prepend .btn + .input-group-text,
+.platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .input-group-text,
+.platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone .input-group-prepend .input-group-text + .input-group-text,
+.platform_sh_standalone .input-group-prepend .input-group-text + .btn,
+.platform_sh_standalone .input-group-prepend #user-widget .input-group-text + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-prepend .input-group-text + .user-widget__log-in,
+.platform_sh_standalone .input-group-prepend #user-widget .input-group-text + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-prepend .input-group-text + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append .btn + .btn,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .btn,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .btn,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .btn,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .btn,
+.platform_sh_standalone .input-group-append #user-widget .btn + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .btn + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .btn + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .btn + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append .btn + .input-group-text,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .input-group-text,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone .input-group-append .input-group-text + .input-group-text,
+.platform_sh_standalone .input-group-append .input-group-text + .btn,
+.platform_sh_standalone .input-group-append #user-widget .input-group-text + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .input-group-text + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .input-group-text + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .input-group-text + .user-widget__free-trial {
+  margin-left: -1px; }
+.platform_sh_standalone .input-group-prepend {
+  margin-right: -1px; }
+.platform_sh_standalone .input-group-append {
+  margin-left: -1px; }
+.platform_sh_standalone .input-group-text {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #e9ecef;
+  border: 1px solid #ced4da;
+  border-radius: 0; }
+.platform_sh_standalone .input-group-text input[type="radio"],
+.platform_sh_standalone .input-group-text input[type="checkbox"] {
+  margin-top: 0; }
+.platform_sh_standalone .input-group-lg > .form-control:not(textarea),
+.platform_sh_standalone .input-group-lg > .custom-select {
+  height: calc(1.5em + 1rem + 2px); }
+.platform_sh_standalone .input-group-lg > .form-control,
+.platform_sh_standalone .input-group-lg > .custom-select,
+.platform_sh_standalone .input-group-lg > .input-group-prepend > .input-group-text,
+.platform_sh_standalone .input-group-lg > .input-group-append > .input-group-text,
+.platform_sh_standalone .input-group-lg > .input-group-prepend > .btn,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-prepend > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-prepend > .user-widget__free-trial,
+.platform_sh_standalone .input-group-lg > .input-group-append > .btn,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-append > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-append > .user-widget__free-trial {
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .input-group-sm > .form-control:not(textarea),
+.platform_sh_standalone .input-group-sm > .custom-select {
+  height: calc(1.5em + 0.5rem + 2px); }
+.platform_sh_standalone .input-group-sm > .form-control,
+.platform_sh_standalone .input-group-sm > .custom-select,
+.platform_sh_standalone .input-group-sm > .input-group-prepend > .input-group-text,
+.platform_sh_standalone .input-group-sm > .input-group-append > .input-group-text,
+.platform_sh_standalone .input-group-sm > .input-group-prepend > .btn,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-prepend > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-prepend > .user-widget__free-trial,
+.platform_sh_standalone .input-group-sm > .input-group-append > .btn,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-append > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-append > .user-widget__free-trial {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .input-group-lg > .custom-select,
+.platform_sh_standalone .input-group-sm > .custom-select {
+  padding-right: 1.75rem; }
+.platform_sh_standalone .input-group > .input-group-prepend > .btn, .platform_sh_standalone #user-widget .input-group > .input-group-prepend > .user-widget__log-in, .platform_sh_standalone #user-widget .input-group > .input-group-prepend > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-prepend > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-append:not(:last-child) > .btn,
+.platform_sh_standalone #user-widget .input-group > .input-group-append:not(:last-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group > .input-group-append:not(:last-child) > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-append:not(:last-child) > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone #user-widget .input-group > .input-group-append:last-child > .user-widget__log-in:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone #user-widget .input-group > .input-group-append:last-child > .user-widget__free-trial:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone .input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .input-group > .input-group-append > .btn, .platform_sh_standalone #user-widget .input-group > .input-group-append > .user-widget__log-in, .platform_sh_standalone #user-widget .input-group > .input-group-append > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-append > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-prepend:not(:first-child) > .btn,
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:not(:first-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:not(:first-child) > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-prepend:not(:first-child) > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-prepend:first-child > .btn:not(:first-child),
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:first-child > .user-widget__log-in:not(:first-child),
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:first-child > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .custom-control {
+  position: relative;
+  display: block;
+  min-height: 1rem;
+  padding-left: 1.5rem; }
+.platform_sh_standalone .custom-control-inline {
+  display: inline-flex;
+  margin-right: 1rem; }
+.platform_sh_standalone .custom-control-input {
+  position: absolute;
+  z-index: -1;
+  opacity: 0; }
+.platform_sh_standalone .custom-control-input:checked ~ .custom-control-label::before {
+  color: #fff;
+  border-color: #145CC6;
+  background-color: #145CC6; }
+.platform_sh_standalone .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #6aa0f0; }
+.platform_sh_standalone .custom-control-input:not(:disabled):active ~ .custom-control-label::before {
+  color: #fff;
+  background-color: #98bdf5;
+  border-color: #98bdf5; }
+.platform_sh_standalone .custom-control-input:disabled ~ .custom-control-label {
+  color: #6c757d; }
+.platform_sh_standalone .custom-control-input:disabled ~ .custom-control-label::before {
+  background-color: #e9ecef; }
+.platform_sh_standalone .custom-control-label {
+  position: relative;
+  margin-bottom: 0;
+  vertical-align: top; }
+.platform_sh_standalone .custom-control-label::before {
+  position: absolute;
+  top: 0rem;
+  left: -1.5rem;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  pointer-events: none;
+  content: "";
+  background-color: #fff;
+  border: #adb5bd solid 1px; }
+.platform_sh_standalone .custom-control-label::after {
+  position: absolute;
+  top: 0rem;
+  left: -1.5rem;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  content: "";
+  background: no-repeat 50% / 50% 50%; }
+.platform_sh_standalone .custom-checkbox .custom-control-label::before {
+  border-radius: 0; }
+.platform_sh_standalone .custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
+  border-color: #145CC6;
+  background-color: #145CC6; }
+.platform_sh_standalone .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='%23fff' d='M0 2h4'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-checkbox .custom-control-input:disabled:indeterminate ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-radio .custom-control-label::before {
+  border-radius: 50%; }
+.platform_sh_standalone .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-switch {
+  padding-left: 2.25rem; }
+.platform_sh_standalone .custom-switch .custom-control-label::before {
+  left: -2.25rem;
+  width: 1.75rem;
+  pointer-events: all;
+  border-radius: 0.5rem; }
+.platform_sh_standalone .custom-switch .custom-control-label::after {
+  top: calc(0rem + 2px);
+  left: calc(-2.25rem + 2px);
+  width: calc(1rem - 4px);
+  height: calc(1rem - 4px);
+  background-color: #adb5bd;
+  border-radius: 0.5rem;
+  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-switch .custom-control-label::after {
+    transition: none; } }
+.platform_sh_standalone .custom-switch .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fff;
+  transform: translateX(0.75rem); }
+.platform_sh_standalone .custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-select {
+  display: inline-block;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  padding: 0.375rem 1.75rem 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  vertical-align: middle;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0;
+  appearance: none; }
+.platform_sh_standalone .custom-select:focus {
+  border-color: #6aa0f0;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-select:focus::-ms-value {
+  color: #495057;
+  background-color: #fff; }
+.platform_sh_standalone .custom-select[multiple], .platform_sh_standalone .custom-select[size]:not([size="1"]) {
+  height: auto;
+  padding-right: 0.75rem;
+  background-image: none; }
+.platform_sh_standalone .custom-select:disabled {
+  color: #6c757d;
+  background-color: #e9ecef; }
+.platform_sh_standalone .custom-select::-ms-expand {
+  display: none; }
+.platform_sh_standalone .custom-select-sm {
+  height: calc(1.5em + 0.5rem + 2px);
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  font-size: 0.875rem; }
+.platform_sh_standalone .custom-select-lg {
+  height: calc(1.5em + 1rem + 2px);
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  font-size: 1.25rem; }
+.platform_sh_standalone .custom-file {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  margin-bottom: 0; }
+.platform_sh_standalone .custom-file-input {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  margin: 0;
+  opacity: 0; }
+.platform_sh_standalone .custom-file-input:focus ~ .custom-file-label {
+  border-color: #6aa0f0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-file-input:disabled ~ .custom-file-label {
+  background-color: #e9ecef; }
+.platform_sh_standalone .custom-file-input:lang(en) ~ .custom-file-label::after {
+  content: "Browse"; }
+.platform_sh_standalone .custom-file-input ~ .custom-file-label[data-browse]::after {
+  content: attr(data-browse); }
+.platform_sh_standalone .custom-file-label {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1;
+  height: calc(1em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0; }
+.platform_sh_standalone .custom-file-label::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 3;
+  display: block;
+  height: calc(1em + 0.75rem);
+  padding: 0.375rem 0.75rem;
+  line-height: 1;
+  color: #495057;
+  content: "Browse";
+  background-color: #e9ecef;
+  border-left: inherit;
+  border-radius: 0 0 0 0; }
+.platform_sh_standalone .custom-range {
+  width: 100%;
+  height: calc(1rem + 0.4rem);
+  padding: 0;
+  background-color: transparent;
+  appearance: none; }
+.platform_sh_standalone .custom-range:focus {
+  outline: none; }
+.platform_sh_standalone .custom-range:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-range:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-range:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-range::-moz-focus-outer {
+  border: 0; }
+.platform_sh_standalone .custom-range::-webkit-slider-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: -0.25rem;
+  background-color: #145CC6;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  appearance: none; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-range::-webkit-slider-thumb {
+    transition: none; } }
+.platform_sh_standalone .custom-range::-webkit-slider-thumb:active {
+  background-color: #98bdf5; }
+.platform_sh_standalone .custom-range::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: #dee2e6;
+  border-color: transparent;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  background-color: #145CC6;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  appearance: none; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-range::-moz-range-thumb {
+    transition: none; } }
+.platform_sh_standalone .custom-range::-moz-range-thumb:active {
+  background-color: #98bdf5; }
+.platform_sh_standalone .custom-range::-moz-range-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: #dee2e6;
+  border-color: transparent;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range::-ms-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0;
+  margin-right: 0.2rem;
+  margin-left: 0.2rem;
+  background-color: #145CC6;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  appearance: none; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-range::-ms-thumb {
+    transition: none; } }
+.platform_sh_standalone .custom-range::-ms-thumb:active {
+  background-color: #98bdf5; }
+.platform_sh_standalone .custom-range::-ms-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: transparent;
+  border-color: transparent;
+  border-width: 0.5rem; }
+.platform_sh_standalone .custom-range::-ms-fill-lower {
+  background-color: #dee2e6;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range::-ms-fill-upper {
+  margin-right: 15px;
+  background-color: #dee2e6;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range:disabled::-webkit-slider-thumb {
+  background-color: #adb5bd; }
+.platform_sh_standalone .custom-range:disabled::-webkit-slider-runnable-track {
+  cursor: default; }
+.platform_sh_standalone .custom-range:disabled::-moz-range-thumb {
+  background-color: #adb5bd; }
+.platform_sh_standalone .custom-range:disabled::-moz-range-track {
+  cursor: default; }
+.platform_sh_standalone .custom-range:disabled::-ms-thumb {
+  background-color: #adb5bd; }
+.platform_sh_standalone .custom-control-label::before,
+.platform_sh_standalone .custom-file-label,
+.platform_sh_standalone .custom-select {
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-control-label::before,
+  .platform_sh_standalone .custom-file-label,
+  .platform_sh_standalone .custom-select {
+    transition: none; } }
+.platform_sh_standalone .nav {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none; }
+.platform_sh_standalone .nav-link {
+  display: block;
+  padding: 0.5rem 1rem; }
+.platform_sh_standalone .nav-link:hover, .platform_sh_standalone .nav-link:focus {
+  text-decoration: none; }
+.platform_sh_standalone .nav-link.disabled {
+  color: #6c757d;
+  pointer-events: none;
+  cursor: default; }
+.platform_sh_standalone .nav-tabs {
+  border-bottom: 1px solid #dee2e6; }
+.platform_sh_standalone .nav-tabs .nav-item {
+  margin-bottom: -1px; }
+.platform_sh_standalone .nav-tabs .nav-link {
+  border: 1px solid transparent;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .nav-tabs .nav-link:hover, .platform_sh_standalone .nav-tabs .nav-link:focus {
+  border-color: #e9ecef #e9ecef #dee2e6; }
+.platform_sh_standalone .nav-tabs .nav-link.disabled {
+  color: #6c757d;
+  background-color: transparent;
+  border-color: transparent; }
+.platform_sh_standalone .nav-tabs .nav-link.active,
+.platform_sh_standalone .nav-tabs .nav-item.show .nav-link {
+  color: #495057;
+  background-color: #fff;
+  border-color: #dee2e6 #dee2e6 #fff; }
+.platform_sh_standalone .nav-tabs .dropdown-menu {
+  margin-top: -1px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .nav-pills .nav-link {
+  border-radius: 0; }
+.platform_sh_standalone .nav-pills .nav-link.active,
+.platform_sh_standalone .nav-pills .show > .nav-link {
+  color: #fff;
+  background-color: #145CC6; }
+.platform_sh_standalone .nav-fill .nav-item {
+  flex: 1 1 auto;
+  text-align: center; }
+.platform_sh_standalone .nav-justified .nav-item {
+  flex-basis: 0;
+  flex-grow: 1;
+  text-align: center; }
+.platform_sh_standalone .tab-content > .tab-pane {
+  display: none; }
+.platform_sh_standalone .tab-content > .active {
+  display: block; }
+.platform_sh_standalone .navbar {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem; }
+.platform_sh_standalone .navbar > .container,
+.platform_sh_standalone .navbar > .container-fluid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between; }
+.platform_sh_standalone .navbar-brand {
+  display: inline-block;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  margin-right: 1rem;
+  font-size: 1.25rem;
+  line-height: inherit;
+  white-space: nowrap; }
+.platform_sh_standalone .navbar-brand:hover, .platform_sh_standalone .navbar-brand:focus {
+  text-decoration: none; }
+.platform_sh_standalone .navbar-nav {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none; }
+.platform_sh_standalone .navbar-nav .nav-link {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .navbar-nav .dropdown-menu {
+  position: static;
+  float: none; }
+.platform_sh_standalone .navbar-text {
+  display: inline-block;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem; }
+.platform_sh_standalone .navbar-collapse {
+  flex-basis: 100%;
+  flex-grow: 1;
+  align-items: center; }
+.platform_sh_standalone .navbar-toggler {
+  padding: 0.25rem 0.75rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0; }
+.platform_sh_standalone .navbar-toggler:hover, .platform_sh_standalone .navbar-toggler:focus {
+  text-decoration: none; }
+.platform_sh_standalone .navbar-toggler-icon {
+  display: inline-block;
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: middle;
+  content: "";
+  background: no-repeat center center;
+  background-size: 100% 100%; }
+@media (max-width: 575.98px) {
+  .platform_sh_standalone .navbar-expand-sm > .container,
+  .platform_sh_standalone .navbar-expand-sm > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 576px) {
+  .platform_sh_standalone .navbar-expand-sm {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-sm > .container,
+  .platform_sh_standalone .navbar-expand-sm > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-toggler {
+    display: none; } }
+@media (max-width: 767.98px) {
+  .platform_sh_standalone .navbar-expand-md > .container,
+  .platform_sh_standalone .navbar-expand-md > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .navbar-expand-md {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-md .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-md .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-md .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-md > .container,
+  .platform_sh_standalone .navbar-expand-md > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-md .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-md .navbar-toggler {
+    display: none; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .navbar-expand-lg > .container,
+  .platform_sh_standalone .navbar-expand-lg > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-expand-lg {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-lg > .container,
+  .platform_sh_standalone .navbar-expand-lg > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-toggler {
+    display: none; } }
+@media (max-width: 1199.98px) {
+  .platform_sh_standalone .navbar-expand-xl > .container,
+  .platform_sh_standalone .navbar-expand-xl > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .navbar-expand-xl {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-xl > .container,
+  .platform_sh_standalone .navbar-expand-xl > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-toggler {
+    display: none; } }
+.platform_sh_standalone .navbar-expand {
+  flex-flow: row nowrap;
+  justify-content: flex-start; }
+.platform_sh_standalone .navbar-expand > .container,
+.platform_sh_standalone .navbar-expand > .container-fluid {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .navbar-expand .navbar-nav {
+  flex-direction: row; }
+.platform_sh_standalone .navbar-expand .navbar-nav .dropdown-menu {
+  position: absolute; }
+.platform_sh_standalone .navbar-expand .navbar-nav .nav-link {
+  padding-right: 0.5rem;
+  padding-left: 0.5rem; }
+.platform_sh_standalone .navbar-expand > .container,
+.platform_sh_standalone .navbar-expand > .container-fluid {
+  flex-wrap: nowrap; }
+.platform_sh_standalone .navbar-expand .navbar-collapse {
+  display: flex !important;
+  flex-basis: auto; }
+.platform_sh_standalone .navbar-expand .navbar-toggler {
+  display: none; }
+.platform_sh_standalone .navbar-light .navbar-brand {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-brand:hover, .platform_sh_standalone .navbar-light .navbar-brand:focus {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link {
+  color: rgba(0, 0, 0, 0.5); }
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link:hover, .platform_sh_standalone .navbar-light .navbar-nav .nav-link:focus {
+  color: rgba(0, 0, 0, 0.7); }
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link.disabled {
+  color: rgba(0, 0, 0, 0.3); }
+.platform_sh_standalone .navbar-light .navbar-nav .show > .nav-link,
+.platform_sh_standalone .navbar-light .navbar-nav .active > .nav-link,
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link.show,
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link.active {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-toggler {
+  color: rgba(0, 0, 0, 0.5);
+  border-color: rgba(0, 0, 0, 0.1); }
+.platform_sh_standalone .navbar-light .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .navbar-light .navbar-text {
+  color: rgba(0, 0, 0, 0.5); }
+.platform_sh_standalone .navbar-light .navbar-text a {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-text a:hover, .platform_sh_standalone .navbar-light .navbar-text a:focus {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-dark .navbar-brand {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-brand:hover, .platform_sh_standalone .navbar-dark .navbar-brand:focus {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link {
+  color: rgba(255, 255, 255, 0.5); }
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link:hover, .platform_sh_standalone .navbar-dark .navbar-nav .nav-link:focus {
+  color: rgba(255, 255, 255, 0.75); }
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link.disabled {
+  color: rgba(255, 255, 255, 0.25); }
+.platform_sh_standalone .navbar-dark .navbar-nav .show > .nav-link,
+.platform_sh_standalone .navbar-dark .navbar-nav .active > .nav-link,
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link.show,
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link.active {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-toggler {
+  color: rgba(255, 255, 255, 0.5);
+  border-color: rgba(255, 255, 255, 0.1); }
+.platform_sh_standalone .navbar-dark .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .navbar-dark .navbar-text {
+  color: rgba(255, 255, 255, 0.5); }
+.platform_sh_standalone .navbar-dark .navbar-text a {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-text a:hover, .platform_sh_standalone .navbar-dark .navbar-text a:focus {
+  color: #fff; }
+.platform_sh_standalone .card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  word-wrap: break-word;
+  background-color: #fff;
+  background-clip: border-box;
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-radius: 0; }
+.platform_sh_standalone .card > hr {
+  margin-right: 0;
+  margin-left: 0; }
+.platform_sh_standalone .card > .list-group:first-child .list-group-item:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .card > .list-group:last-child .list-group-item:last-child {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .card-body {
+  flex: 1 1 auto;
+  padding: 1.25rem; }
+.platform_sh_standalone .card-title {
+  margin-bottom: 0.75rem; }
+.platform_sh_standalone .card-subtitle {
+  margin-top: -0.375rem;
+  margin-bottom: 0; }
+.platform_sh_standalone .card-text:last-child {
+  margin-bottom: 0; }
+.platform_sh_standalone .card-link:hover {
+  text-decoration: none; }
+.platform_sh_standalone .card-link + .card-link {
+  margin-left: 1.25rem; }
+.platform_sh_standalone .card-header {
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 0;
+  background-color: rgba(0, 0, 0, 0.03);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125); }
+.platform_sh_standalone .card-header:first-child {
+  border-radius: calc(0 - 1px) calc(0 - 1px) 0 0; }
+.platform_sh_standalone .card-header + .list-group .list-group-item:first-child {
+  border-top: 0; }
+.platform_sh_standalone .card-footer {
+  padding: 0.75rem 1.25rem;
+  background-color: rgba(0, 0, 0, 0.03);
+  border-top: 1px solid rgba(0, 0, 0, 0.125); }
+.platform_sh_standalone .card-footer:last-child {
+  border-radius: 0 0 calc(0 - 1px) calc(0 - 1px); }
+.platform_sh_standalone .card-header-tabs {
+  margin-right: -0.625rem;
+  margin-bottom: -0.75rem;
+  margin-left: -0.625rem;
+  border-bottom: 0; }
+.platform_sh_standalone .card-header-pills {
+  margin-right: -0.625rem;
+  margin-left: -0.625rem; }
+.platform_sh_standalone .card-img-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 1.25rem; }
+.platform_sh_standalone .card-img {
+  width: 100%;
+  border-radius: calc(0 - 1px); }
+.platform_sh_standalone .card-img-top {
+  width: 100%;
+  border-top-left-radius: calc(0 - 1px);
+  border-top-right-radius: calc(0 - 1px); }
+.platform_sh_standalone .card-img-bottom {
+  width: 100%;
+  border-bottom-right-radius: calc(0 - 1px);
+  border-bottom-left-radius: calc(0 - 1px); }
+.platform_sh_standalone .card-deck {
+  display: flex;
+  flex-direction: column; }
+.platform_sh_standalone .card-deck .card {
+  margin-bottom: 20px; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .card-deck {
+    flex-flow: row wrap;
+    margin-right: -20px;
+    margin-left: -20px; }
+  .platform_sh_standalone .card-deck .card {
+    display: flex;
+    flex: 1 0 0%;
+    flex-direction: column;
+    margin-right: 20px;
+    margin-bottom: 0;
+    margin-left: 20px; } }
+.platform_sh_standalone .card-group {
+  display: flex;
+  flex-direction: column; }
+.platform_sh_standalone .card-group > .card {
+  margin-bottom: 20px; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .card-group {
+    flex-flow: row wrap; }
+  .platform_sh_standalone .card-group > .card {
+    flex: 1 0 0%;
+    margin-bottom: 0; }
+  .platform_sh_standalone .card-group > .card + .card {
+    margin-left: 0;
+    border-left: 0; }
+  .platform_sh_standalone .card-group > .card:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-img-top,
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-header {
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-img-bottom,
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-footer {
+    border-bottom-right-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-img-top,
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-header {
+    border-top-left-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-img-bottom,
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-footer {
+    border-bottom-left-radius: 0; } }
+.platform_sh_standalone .card-columns .card {
+  margin-bottom: 0.75rem; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .card-columns {
+    column-count: 3;
+    column-gap: 1.25rem;
+    orphans: 1;
+    widows: 1; }
+  .platform_sh_standalone .card-columns .card {
+    display: inline-block;
+    width: 100%; } }
+.platform_sh_standalone .accordion > .card {
+  overflow: hidden; }
+.platform_sh_standalone .accordion > .card:not(:first-of-type) .card-header:first-child {
+  border-radius: 0; }
+.platform_sh_standalone .accordion > .card:not(:first-of-type):not(:last-of-type) {
+  border-bottom: 0;
+  border-radius: 0; }
+.platform_sh_standalone .accordion > .card:first-of-type {
+  border-bottom: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .accordion > .card:last-of-type {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .accordion > .card .card-header {
+  margin-bottom: -1px; }
+.platform_sh_standalone .breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  list-style: none;
+  background-color: #e9ecef;
+  border-radius: 0; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item {
+  padding-left: 0.5rem; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item::before {
+  display: inline-block;
+  padding-right: 0.5rem;
+  color: #6c757d;
+  content: "/"; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item:hover::before {
+  text-decoration: underline; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item:hover::before {
+  text-decoration: none; }
+.platform_sh_standalone .breadcrumb-item.active {
+  color: #6c757d; }
+.platform_sh_standalone .pagination {
+  display: flex;
+  padding-left: 0;
+  list-style: none;
+  border-radius: 0; }
+.platform_sh_standalone .page-link {
+  position: relative;
+  display: block;
+  padding: 0.5rem 0.75rem;
+  margin-left: -1px;
+  line-height: 1.25;
+  color: #145CC6;
+  background-color: #fff;
+  border: 1px solid #dee2e6; }
+.platform_sh_standalone .page-link:hover {
+  z-index: 2;
+  color: #0d3c81;
+  text-decoration: none;
+  background-color: #e9ecef;
+  border-color: #dee2e6; }
+.platform_sh_standalone .page-link:focus {
+  z-index: 2;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .page-item:first-child .page-link {
+  margin-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .page-item:last-child .page-link {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .page-item.active .page-link {
+  z-index: 1;
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .page-item.disabled .page-link {
+  color: #6c757d;
+  pointer-events: none;
+  cursor: auto;
+  background-color: #fff;
+  border-color: #dee2e6; }
+.platform_sh_standalone .pagination-lg .page-link {
+  padding: 0.75rem 1.5rem;
+  font-size: 1.25rem;
+  line-height: 1.5; }
+.platform_sh_standalone .pagination-lg .page-item:first-child .page-link {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .pagination-lg .page-item:last-child .page-link {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .pagination-sm .page-link {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5; }
+.platform_sh_standalone .pagination-sm .page-item:first-child .page-link {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .pagination-sm .page-item:last-child .page-link {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .badge {
+  display: inline-block;
+  padding: 0.25em 0.4em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .badge {
+    transition: none; } }
+a.platform_sh_standalone .badge:hover, a.platform_sh_standalone .badge:focus {
+  text-decoration: none; }
+.platform_sh_standalone .badge:empty {
+  display: none; }
+.platform_sh_standalone .btn .badge, .platform_sh_standalone #user-widget .user-widget__log-in .badge, .platform_sh_standalone #user-widget .user-widget__free-trial .badge {
+  position: relative;
+  top: -1px; }
+.platform_sh_standalone .badge-pill {
+  padding-right: 0.6em;
+  padding-left: 0.6em;
+  border-radius: 10rem; }
+.platform_sh_standalone .badge-primary {
+  color: #fff;
+  background-color: #145CC6; }
+a.platform_sh_standalone .badge-primary:hover, a.platform_sh_standalone .badge-primary:focus {
+  color: #fff;
+  background-color: #0f4698; }
+a.platform_sh_standalone .badge-primary:focus, a.platform_sh_standalone .badge-primary.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .badge-secondary {
+  color: #fff;
+  background-color: #6c757d; }
+a.platform_sh_standalone .badge-secondary:hover, a.platform_sh_standalone .badge-secondary:focus {
+  color: #fff;
+  background-color: #545b62; }
+a.platform_sh_standalone .badge-secondary:focus, a.platform_sh_standalone .badge-secondary.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
+.platform_sh_standalone .badge-success {
+  color: #fff;
+  background-color: #28a745; }
+a.platform_sh_standalone .badge-success:hover, a.platform_sh_standalone .badge-success:focus {
+  color: #fff;
+  background-color: #1e7e34; }
+a.platform_sh_standalone .badge-success:focus, a.platform_sh_standalone .badge-success.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
+.platform_sh_standalone .badge-info {
+  color: #fff;
+  background-color: #17a2b8; }
+a.platform_sh_standalone .badge-info:hover, a.platform_sh_standalone .badge-info:focus {
+  color: #fff;
+  background-color: #117a8b; }
+a.platform_sh_standalone .badge-info:focus, a.platform_sh_standalone .badge-info.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
+.platform_sh_standalone .badge-warning {
+  color: #212529;
+  background-color: #F4BA37; }
+a.platform_sh_standalone .badge-warning:hover, a.platform_sh_standalone .badge-warning:focus {
+  color: #212529;
+  background-color: #eba70d; }
+a.platform_sh_standalone .badge-warning:focus, a.platform_sh_standalone .badge-warning.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(244, 186, 55, 0.5); }
+.platform_sh_standalone .badge-danger {
+  color: #fff;
+  background-color: #dc3545; }
+a.platform_sh_standalone .badge-danger:hover, a.platform_sh_standalone .badge-danger:focus {
+  color: #fff;
+  background-color: #bd2130; }
+a.platform_sh_standalone .badge-danger:focus, a.platform_sh_standalone .badge-danger.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
+.platform_sh_standalone .badge-light {
+  color: #212529;
+  background-color: #f8f9fa; }
+a.platform_sh_standalone .badge-light:hover, a.platform_sh_standalone .badge-light:focus {
+  color: #212529;
+  background-color: #dae0e5; }
+a.platform_sh_standalone .badge-light:focus, a.platform_sh_standalone .badge-light.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
+.platform_sh_standalone .badge-dark {
+  color: #fff;
+  background-color: #343a40; }
+a.platform_sh_standalone .badge-dark:hover, a.platform_sh_standalone .badge-dark:focus {
+  color: #fff;
+  background-color: #1d2124; }
+a.platform_sh_standalone .badge-dark:focus, a.platform_sh_standalone .badge-dark.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
+.platform_sh_standalone .jumbotron {
+  padding: 2rem 1rem;
+  margin-bottom: 2rem;
+  background-color: #e9ecef;
+  border-radius: 0; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .jumbotron {
+    padding: 4rem 2rem; } }
+.platform_sh_standalone .jumbotron-fluid {
+  padding-right: 0;
+  padding-left: 0;
+  border-radius: 0; }
+.platform_sh_standalone .alert {
+  position: relative;
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: 0; }
+.platform_sh_standalone .alert-heading {
+  color: inherit; }
+.platform_sh_standalone .alert-link {
+  font-weight: 700; }
+.platform_sh_standalone .alert-dismissible {
+  padding-right: 4rem; }
+.platform_sh_standalone .alert-dismissible .close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.75rem 1.25rem;
+  color: inherit; }
+.platform_sh_standalone .alert-primary {
+  color: #0a3067;
+  background-color: #d0def4;
+  border-color: #bdd1ef; }
+.platform_sh_standalone .alert-primary hr {
+  border-top-color: #a8c3ea; }
+.platform_sh_standalone .alert-primary .alert-link {
+  color: #051a39; }
+.platform_sh_standalone .alert-secondary {
+  color: #383d41;
+  background-color: #e2e3e5;
+  border-color: #d6d8db; }
+.platform_sh_standalone .alert-secondary hr {
+  border-top-color: #c8cbcf; }
+.platform_sh_standalone .alert-secondary .alert-link {
+  color: #202326; }
+.platform_sh_standalone .alert-success {
+  color: #155724;
+  background-color: #d4edda;
+  border-color: #c3e6cb; }
+.platform_sh_standalone .alert-success hr {
+  border-top-color: #b1dfbb; }
+.platform_sh_standalone .alert-success .alert-link {
+  color: #0b2e13; }
+.platform_sh_standalone .alert-info {
+  color: #0c5460;
+  background-color: #d1ecf1;
+  border-color: #bee5eb; }
+.platform_sh_standalone .alert-info hr {
+  border-top-color: #abdde5; }
+.platform_sh_standalone .alert-info .alert-link {
+  color: #062c33; }
+.platform_sh_standalone .alert-warning {
+  color: #7f611d;
+  background-color: #fdf1d7;
+  border-color: #fcecc7; }
+.platform_sh_standalone .alert-warning hr {
+  border-top-color: #fbe4af; }
+.platform_sh_standalone .alert-warning .alert-link {
+  color: #554114; }
+.platform_sh_standalone .alert-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb; }
+.platform_sh_standalone .alert-danger hr {
+  border-top-color: #f1b0b7; }
+.platform_sh_standalone .alert-danger .alert-link {
+  color: #491217; }
+.platform_sh_standalone .alert-light {
+  color: #818182;
+  background-color: #fefefe;
+  border-color: #fdfdfe; }
+.platform_sh_standalone .alert-light hr {
+  border-top-color: #ececf6; }
+.platform_sh_standalone .alert-light .alert-link {
+  color: #686868; }
+.platform_sh_standalone .alert-dark {
+  color: #1b1e21;
+  background-color: #d6d8d9;
+  border-color: #c6c8ca; }
+.platform_sh_standalone .alert-dark hr {
+  border-top-color: #b9bbbe; }
+.platform_sh_standalone .alert-dark .alert-link {
+  color: #040505; }
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 1rem 0; }
+  to {
+    background-position: 0 0; } }
+.platform_sh_standalone .progress {
+  display: flex;
+  height: 1rem;
+  overflow: hidden;
+  font-size: 0.75rem;
+  background-color: #e9ecef;
+  border-radius: 0; }
+.platform_sh_standalone .progress-bar {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #145CC6;
+  transition: width 0.6s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .progress-bar {
+    transition: none; } }
+.platform_sh_standalone .progress-bar-striped {
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-size: 1rem 1rem; }
+.platform_sh_standalone .progress-bar-animated {
+  animation: progress-bar-stripes 1s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .progress-bar-animated {
+    animation: none; } }
+.platform_sh_standalone .media {
+  display: flex;
+  align-items: flex-start; }
+.platform_sh_standalone .media-body {
+  flex: 1; }
+.platform_sh_standalone .list-group {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0; }
+.platform_sh_standalone .list-group-item-action {
+  width: 100%;
+  color: #495057;
+  text-align: inherit; }
+.platform_sh_standalone .list-group-item-action:hover, .platform_sh_standalone .list-group-item-action:focus {
+  z-index: 1;
+  color: #495057;
+  text-decoration: none;
+  background-color: #f8f9fa; }
+.platform_sh_standalone .list-group-item-action:active {
+  color: #49475F;
+  background-color: #e9ecef; }
+.platform_sh_standalone .list-group-item {
+  position: relative;
+  display: block;
+  padding: 0.75rem 1.25rem;
+  margin-bottom: -1px;
+  background-color: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.125); }
+.platform_sh_standalone .list-group-item:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .list-group-item:last-child {
+  margin-bottom: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .list-group-item.disabled, .platform_sh_standalone .list-group-item:disabled {
+  color: #6c757d;
+  pointer-events: none;
+  background-color: #fff; }
+.platform_sh_standalone .list-group-item.active {
+  z-index: 2;
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .list-group-horizontal {
+  flex-direction: row; }
+.platform_sh_standalone .list-group-horizontal .list-group-item {
+  margin-right: -1px;
+  margin-bottom: 0; }
+.platform_sh_standalone .list-group-horizontal .list-group-item:first-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .list-group-horizontal .list-group-item:last-child {
+  margin-right: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .list-group-horizontal-sm {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-sm .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-sm .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-sm .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .list-group-horizontal-md {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-md .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-md .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-md .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .list-group-horizontal-lg {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-lg .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-lg .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-lg .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .list-group-horizontal-xl {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-xl .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-xl .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-xl .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+.platform_sh_standalone .list-group-flush .list-group-item {
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0; }
+.platform_sh_standalone .list-group-flush .list-group-item:last-child {
+  margin-bottom: -1px; }
+.platform_sh_standalone .list-group-flush:first-child .list-group-item:first-child {
+  border-top: 0; }
+.platform_sh_standalone .list-group-flush:last-child .list-group-item:last-child {
+  margin-bottom: 0;
+  border-bottom: 0; }
+.platform_sh_standalone .list-group-item-primary {
+  color: #0a3067;
+  background-color: #bdd1ef; }
+.platform_sh_standalone .list-group-item-primary.list-group-item-action:hover, .platform_sh_standalone .list-group-item-primary.list-group-item-action:focus {
+  color: #0a3067;
+  background-color: #a8c3ea; }
+.platform_sh_standalone .list-group-item-primary.list-group-item-action.active {
+  color: #fff;
+  background-color: #0a3067;
+  border-color: #0a3067; }
+.platform_sh_standalone .list-group-item-secondary {
+  color: #383d41;
+  background-color: #d6d8db; }
+.platform_sh_standalone .list-group-item-secondary.list-group-item-action:hover, .platform_sh_standalone .list-group-item-secondary.list-group-item-action:focus {
+  color: #383d41;
+  background-color: #c8cbcf; }
+.platform_sh_standalone .list-group-item-secondary.list-group-item-action.active {
+  color: #fff;
+  background-color: #383d41;
+  border-color: #383d41; }
+.platform_sh_standalone .list-group-item-success {
+  color: #155724;
+  background-color: #c3e6cb; }
+.platform_sh_standalone .list-group-item-success.list-group-item-action:hover, .platform_sh_standalone .list-group-item-success.list-group-item-action:focus {
+  color: #155724;
+  background-color: #b1dfbb; }
+.platform_sh_standalone .list-group-item-success.list-group-item-action.active {
+  color: #fff;
+  background-color: #155724;
+  border-color: #155724; }
+.platform_sh_standalone .list-group-item-info {
+  color: #0c5460;
+  background-color: #bee5eb; }
+.platform_sh_standalone .list-group-item-info.list-group-item-action:hover, .platform_sh_standalone .list-group-item-info.list-group-item-action:focus {
+  color: #0c5460;
+  background-color: #abdde5; }
+.platform_sh_standalone .list-group-item-info.list-group-item-action.active {
+  color: #fff;
+  background-color: #0c5460;
+  border-color: #0c5460; }
+.platform_sh_standalone .list-group-item-warning {
+  color: #7f611d;
+  background-color: #fcecc7; }
+.platform_sh_standalone .list-group-item-warning.list-group-item-action:hover, .platform_sh_standalone .list-group-item-warning.list-group-item-action:focus {
+  color: #7f611d;
+  background-color: #fbe4af; }
+.platform_sh_standalone .list-group-item-warning.list-group-item-action.active {
+  color: #fff;
+  background-color: #7f611d;
+  border-color: #7f611d; }
+.platform_sh_standalone .list-group-item-danger {
+  color: #721c24;
+  background-color: #f5c6cb; }
+.platform_sh_standalone .list-group-item-danger.list-group-item-action:hover, .platform_sh_standalone .list-group-item-danger.list-group-item-action:focus {
+  color: #721c24;
+  background-color: #f1b0b7; }
+.platform_sh_standalone .list-group-item-danger.list-group-item-action.active {
+  color: #fff;
+  background-color: #721c24;
+  border-color: #721c24; }
+.platform_sh_standalone .list-group-item-light {
+  color: #818182;
+  background-color: #fdfdfe; }
+.platform_sh_standalone .list-group-item-light.list-group-item-action:hover, .platform_sh_standalone .list-group-item-light.list-group-item-action:focus {
+  color: #818182;
+  background-color: #ececf6; }
+.platform_sh_standalone .list-group-item-light.list-group-item-action.active {
+  color: #fff;
+  background-color: #818182;
+  border-color: #818182; }
+.platform_sh_standalone .list-group-item-dark {
+  color: #1b1e21;
+  background-color: #c6c8ca; }
+.platform_sh_standalone .list-group-item-dark.list-group-item-action:hover, .platform_sh_standalone .list-group-item-dark.list-group-item-action:focus {
+  color: #1b1e21;
+  background-color: #b9bbbe; }
+.platform_sh_standalone .list-group-item-dark.list-group-item-action.active {
+  color: #fff;
+  background-color: #1b1e21;
+  border-color: #1b1e21; }
+.platform_sh_standalone .close {
+  float: right;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #000;
+  text-shadow: 0 1px 0 #fff;
+  opacity: .5; }
+.platform_sh_standalone .close:hover {
+  color: #000;
+  text-decoration: none; }
+.platform_sh_standalone .close:not(:disabled):not(.disabled):hover, .platform_sh_standalone .close:not(:disabled):not(.disabled):focus {
+  opacity: .75; }
+.platform_sh_standalone button.close {
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  appearance: none; }
+.platform_sh_standalone a.close.disabled {
+  pointer-events: none; }
+.platform_sh_standalone .toast {
+  max-width: 350px;
+  overflow: hidden;
+  font-size: 0.875rem;
+  background-color: rgba(255, 255, 255, 0.85);
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  opacity: 0;
+  border-radius: 0.25rem; }
+.platform_sh_standalone .toast:not(:last-child) {
+  margin-bottom: 0.75rem; }
+.platform_sh_standalone .toast.showing {
+  opacity: 1; }
+.platform_sh_standalone .toast.show {
+  display: block;
+  opacity: 1; }
+.platform_sh_standalone .toast.hide {
+  display: none; }
+.platform_sh_standalone .toast-header {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  color: #6c757d;
+  background-color: rgba(255, 255, 255, 0.85);
+  background-clip: padding-box;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05); }
+.platform_sh_standalone .toast-body {
+  padding: 0.75rem; }
+.platform_sh_standalone .modal-open {
+  overflow: hidden; }
+.platform_sh_standalone .modal-open .modal {
+  overflow-x: hidden;
+  overflow-y: auto; }
+.platform_sh_standalone .modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1050;
+  display: none;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  outline: 0; }
+.platform_sh_standalone .modal-dialog {
+  position: relative;
+  width: auto;
+  margin: 0.5rem;
+  pointer-events: none; }
+.modal.fade .platform_sh_standalone .modal-dialog {
+  transition: transform 0.3s ease-out;
+  transform: translate(0, -50px); }
+@media (prefers-reduced-motion: reduce) {
+  .modal.fade .platform_sh_standalone .modal-dialog {
+    transition: none; } }
+.modal.show .platform_sh_standalone .modal-dialog {
+  transform: none; }
+.platform_sh_standalone .modal-dialog-scrollable {
+  display: flex;
+  max-height: calc(100% - 1rem); }
+.platform_sh_standalone .modal-dialog-scrollable .modal-content {
+  max-height: calc(100vh - 1rem);
+  overflow: hidden; }
+.platform_sh_standalone .modal-dialog-scrollable .modal-header,
+.platform_sh_standalone .modal-dialog-scrollable .modal-footer {
+  flex-shrink: 0; }
+.platform_sh_standalone .modal-dialog-scrollable .modal-body {
+  overflow-y: auto; }
+.platform_sh_standalone .modal-dialog-centered {
+  display: flex;
+  align-items: center;
+  min-height: calc(100% - 1rem); }
+.platform_sh_standalone .modal-dialog-centered::before {
+  display: block;
+  height: calc(100vh - 1rem);
+  content: ""; }
+.platform_sh_standalone .modal-dialog-centered.modal-dialog-scrollable {
+  flex-direction: column;
+  justify-content: center;
+  height: 100%; }
+.platform_sh_standalone .modal-dialog-centered.modal-dialog-scrollable .modal-content {
+  max-height: none; }
+.platform_sh_standalone .modal-dialog-centered.modal-dialog-scrollable::before {
+  content: none; }
+.platform_sh_standalone .modal-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  pointer-events: auto;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0;
+  outline: 0; }
+.platform_sh_standalone .modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1040;
+  width: 100vw;
+  height: 100vh;
+  background-color: #000; }
+.platform_sh_standalone .modal-backdrop.fade {
+  opacity: 0; }
+.platform_sh_standalone .modal-backdrop.show {
+  opacity: 0.5; }
+.platform_sh_standalone .modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1rem 1rem;
+  border-bottom: 1px solid #dee2e6;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .modal-header .close {
+  padding: 1rem 1rem;
+  margin: -1rem -1rem -1rem auto; }
+.platform_sh_standalone .modal-title {
+  margin-bottom: 0;
+  line-height: 1; }
+.platform_sh_standalone .modal-body {
+  position: relative;
+  flex: 1 1 auto;
+  padding: 1rem; }
+.platform_sh_standalone .modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 1rem;
+  border-top: 1px solid #dee2e6;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .modal-footer > :not(:first-child) {
+  margin-left: .25rem; }
+.platform_sh_standalone .modal-footer > :not(:last-child) {
+  margin-right: .25rem; }
+.platform_sh_standalone .modal-scrollbar-measure {
+  position: absolute;
+  top: -9999px;
+  width: 50px;
+  height: 50px;
+  overflow: scroll; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .modal-dialog {
+    max-width: 500px;
+    margin: 1.75rem auto; }
+  .platform_sh_standalone .modal-dialog-scrollable {
+    max-height: calc(100% - 3.5rem); }
+  .platform_sh_standalone .modal-dialog-scrollable .modal-content {
+    max-height: calc(100vh - 3.5rem); }
+  .platform_sh_standalone .modal-dialog-centered {
+    min-height: calc(100% - 3.5rem); }
+  .platform_sh_standalone .modal-dialog-centered::before {
+    height: calc(100vh - 3.5rem); }
+  .platform_sh_standalone .modal-sm {
+    max-width: 300px; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .modal-lg,
+  .platform_sh_standalone .modal-xl {
+    max-width: 800px; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .modal-xl {
+    max-width: 1140px; } }
+.platform_sh_standalone .tooltip {
+  position: absolute;
+  z-index: 1070;
+  display: block;
+  margin: 0;
+  font-family: Overpass, Arial;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-break: normal;
+  word-spacing: normal;
+  white-space: normal;
+  line-break: auto;
+  font-size: 0.875rem;
+  word-wrap: break-word;
+  opacity: 0; }
+.platform_sh_standalone .tooltip.show {
+  opacity: 0.9; }
+.platform_sh_standalone .tooltip .arrow {
+  position: absolute;
+  display: block;
+  width: 0.8rem;
+  height: 0.4rem; }
+.platform_sh_standalone .tooltip .arrow::before {
+  position: absolute;
+  content: "";
+  border-color: transparent;
+  border-style: solid; }
+.platform_sh_standalone .bs-tooltip-top, .platform_sh_standalone .bs-tooltip-auto[x-placement^="top"] {
+  padding: 0.4rem 0; }
+.platform_sh_standalone .bs-tooltip-top .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="top"] .arrow {
+  bottom: 0; }
+.platform_sh_standalone .bs-tooltip-top .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="top"] .arrow::before {
+  top: 0;
+  border-width: 0.4rem 0.4rem 0;
+  border-top-color: #000; }
+.platform_sh_standalone .bs-tooltip-right, .platform_sh_standalone .bs-tooltip-auto[x-placement^="right"] {
+  padding: 0 0.4rem; }
+.platform_sh_standalone .bs-tooltip-right .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="right"] .arrow {
+  left: 0;
+  width: 0.4rem;
+  height: 0.8rem; }
+.platform_sh_standalone .bs-tooltip-right .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="right"] .arrow::before {
+  right: 0;
+  border-width: 0.4rem 0.4rem 0.4rem 0;
+  border-right-color: #000; }
+.platform_sh_standalone .bs-tooltip-bottom, .platform_sh_standalone .bs-tooltip-auto[x-placement^="bottom"] {
+  padding: 0.4rem 0; }
+.platform_sh_standalone .bs-tooltip-bottom .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="bottom"] .arrow {
+  top: 0; }
+.platform_sh_standalone .bs-tooltip-bottom .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="bottom"] .arrow::before {
+  bottom: 0;
+  border-width: 0 0.4rem 0.4rem;
+  border-bottom-color: #000; }
+.platform_sh_standalone .bs-tooltip-left, .platform_sh_standalone .bs-tooltip-auto[x-placement^="left"] {
+  padding: 0 0.4rem; }
+.platform_sh_standalone .bs-tooltip-left .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="left"] .arrow {
+  right: 0;
+  width: 0.4rem;
+  height: 0.8rem; }
+.platform_sh_standalone .bs-tooltip-left .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="left"] .arrow::before {
+  left: 0;
+  border-width: 0.4rem 0 0.4rem 0.4rem;
+  border-left-color: #000; }
+.platform_sh_standalone .tooltip-inner {
+  max-width: 200px;
+  padding: 0.25rem 0.5rem;
+  color: #fff;
+  text-align: center;
+  background-color: #000;
+  border-radius: 0; }
+.platform_sh_standalone .popover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1060;
+  display: block;
+  max-width: 276px;
+  font-family: Overpass, Arial;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-break: normal;
+  word-spacing: normal;
+  white-space: normal;
+  line-break: auto;
+  font-size: 0.875rem;
+  word-wrap: break-word;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0; }
+.platform_sh_standalone .popover .arrow {
+  position: absolute;
+  display: block;
+  width: 1rem;
+  height: 0.5rem;
+  margin: 0 0; }
+.platform_sh_standalone .popover .arrow::before, .platform_sh_standalone .popover .arrow::after {
+  position: absolute;
+  display: block;
+  content: "";
+  border-color: transparent;
+  border-style: solid; }
+.platform_sh_standalone .bs-popover-top, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] {
+  margin-bottom: 0.5rem; }
+.platform_sh_standalone .bs-popover-top > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] > .arrow {
+  bottom: calc((0.5rem + 1px) * -1); }
+.platform_sh_standalone .bs-popover-top > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] > .arrow::before {
+  bottom: 0;
+  border-width: 0.5rem 0.5rem 0;
+  border-top-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-top > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] > .arrow::after {
+  bottom: 1px;
+  border-width: 0.5rem 0.5rem 0;
+  border-top-color: #fff; }
+.platform_sh_standalone .bs-popover-right, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] {
+  margin-left: 0.5rem; }
+.platform_sh_standalone .bs-popover-right > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] > .arrow {
+  left: calc((0.5rem + 1px) * -1);
+  width: 0.5rem;
+  height: 1rem;
+  margin: 0 0; }
+.platform_sh_standalone .bs-popover-right > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] > .arrow::before {
+  left: 0;
+  border-width: 0.5rem 0.5rem 0.5rem 0;
+  border-right-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-right > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] > .arrow::after {
+  left: 1px;
+  border-width: 0.5rem 0.5rem 0.5rem 0;
+  border-right-color: #fff; }
+.platform_sh_standalone .bs-popover-bottom, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] {
+  margin-top: 0.5rem; }
+.platform_sh_standalone .bs-popover-bottom > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] > .arrow {
+  top: calc((0.5rem + 1px) * -1); }
+.platform_sh_standalone .bs-popover-bottom > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] > .arrow::before {
+  top: 0;
+  border-width: 0 0.5rem 0.5rem 0.5rem;
+  border-bottom-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-bottom > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] > .arrow::after {
+  top: 1px;
+  border-width: 0 0.5rem 0.5rem 0.5rem;
+  border-bottom-color: #fff; }
+.platform_sh_standalone .bs-popover-bottom .popover-header::before, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] .popover-header::before {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  display: block;
+  width: 1rem;
+  margin-left: -0.5rem;
+  content: "";
+  border-bottom: 1px solid #f7f7f7; }
+.platform_sh_standalone .bs-popover-left, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] {
+  margin-right: 0.5rem; }
+.platform_sh_standalone .bs-popover-left > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] > .arrow {
+  right: calc((0.5rem + 1px) * -1);
+  width: 0.5rem;
+  height: 1rem;
+  margin: 0 0; }
+.platform_sh_standalone .bs-popover-left > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] > .arrow::before {
+  right: 0;
+  border-width: 0.5rem 0 0.5rem 0.5rem;
+  border-left-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-left > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] > .arrow::after {
+  right: 1px;
+  border-width: 0.5rem 0 0.5rem 0.5rem;
+  border-left-color: #fff; }
+.platform_sh_standalone .popover-header {
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  color: #1A182A;
+  background-color: #f7f7f7;
+  border-bottom: 1px solid #ebebeb;
+  border-top-left-radius: calc(0 - 1px);
+  border-top-right-radius: calc(0 - 1px); }
+.platform_sh_standalone .popover-header:empty {
+  display: none; }
+.platform_sh_standalone .popover-body {
+  padding: 0.5rem 0.75rem;
+  color: #49475F; }
+.platform_sh_standalone .carousel {
+  position: relative; }
+.platform_sh_standalone .carousel.pointer-event {
+  touch-action: pan-y; }
+.platform_sh_standalone .carousel-inner {
+  position: relative;
+  width: 100%;
+  overflow: hidden; }
+.platform_sh_standalone .carousel-inner::after {
+  display: block;
+  clear: both;
+  content: ""; }
+.platform_sh_standalone .carousel-item {
+  position: relative;
+  display: none;
+  float: left;
+  width: 100%;
+  margin-right: -100%;
+  backface-visibility: hidden;
+  transition: transform 0.6s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-item {
+    transition: none; } }
+.platform_sh_standalone .carousel-item.active,
+.platform_sh_standalone .carousel-item-next,
+.platform_sh_standalone .carousel-item-prev {
+  display: block; }
+.platform_sh_standalone .carousel-item-next:not(.carousel-item-left),
+.platform_sh_standalone .active.carousel-item-right {
+  transform: translateX(100%); }
+.platform_sh_standalone .carousel-item-prev:not(.carousel-item-right),
+.platform_sh_standalone .active.carousel-item-left {
+  transform: translateX(-100%); }
+.platform_sh_standalone .carousel-fade .carousel-item {
+  opacity: 0;
+  transition-property: opacity;
+  transform: none; }
+.platform_sh_standalone .carousel-fade .carousel-item.active,
+.platform_sh_standalone .carousel-fade .carousel-item-next.carousel-item-left,
+.platform_sh_standalone .carousel-fade .carousel-item-prev.carousel-item-right {
+  z-index: 1;
+  opacity: 1; }
+.platform_sh_standalone .carousel-fade .active.carousel-item-left,
+.platform_sh_standalone .carousel-fade .active.carousel-item-right {
+  z-index: 0;
+  opacity: 0;
+  transition: 0s 0.6s opacity; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-fade .active.carousel-item-left,
+  .platform_sh_standalone .carousel-fade .active.carousel-item-right {
+    transition: none; } }
+.platform_sh_standalone .carousel-control-prev,
+.platform_sh_standalone .carousel-control-next {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 15%;
+  color: #fff;
+  text-align: center;
+  opacity: 0.5;
+  transition: opacity 0.15s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-control-prev,
+  .platform_sh_standalone .carousel-control-next {
+    transition: none; } }
+.platform_sh_standalone .carousel-control-prev:hover, .platform_sh_standalone .carousel-control-prev:focus,
+.platform_sh_standalone .carousel-control-next:hover,
+.platform_sh_standalone .carousel-control-next:focus {
+  color: #fff;
+  text-decoration: none;
+  outline: 0;
+  opacity: 0.9; }
+.platform_sh_standalone .carousel-control-prev {
+  left: 0; }
+.platform_sh_standalone .carousel-control-next {
+  right: 0; }
+.platform_sh_standalone .carousel-control-prev-icon,
+.platform_sh_standalone .carousel-control-next-icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: no-repeat 50% / 100% 100%; }
+.platform_sh_standalone .carousel-control-prev-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .carousel-control-next-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .carousel-indicators {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 15;
+  display: flex;
+  justify-content: center;
+  padding-left: 0;
+  margin-right: 15%;
+  margin-left: 15%;
+  list-style: none; }
+.platform_sh_standalone .carousel-indicators li {
+  box-sizing: content-box;
+  flex: 0 1 auto;
+  width: 30px;
+  height: 3px;
+  margin-right: 3px;
+  margin-left: 3px;
+  text-indent: -999px;
+  cursor: pointer;
+  background-color: #fff;
+  background-clip: padding-box;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  opacity: .5;
+  transition: opacity 0.6s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-indicators li {
+    transition: none; } }
+.platform_sh_standalone .carousel-indicators .active {
+  opacity: 1; }
+.platform_sh_standalone .carousel-caption {
+  position: absolute;
+  right: 15%;
+  bottom: 20px;
+  left: 15%;
+  z-index: 10;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: #fff;
+  text-align: center; }
+@keyframes spinner-border {
+  to {
+    transform: rotate(360deg); } }
+.platform_sh_standalone .spinner-border {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  vertical-align: text-bottom;
+  border: 0.25em solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spinner-border .75s linear infinite; }
+.platform_sh_standalone .spinner-border-sm {
+  width: 1rem;
+  height: 1rem;
+  border-width: 0.2em; }
+@keyframes spinner-grow {
+  0% {
+    transform: scale(0); }
+  50% {
+    opacity: 1; } }
+.platform_sh_standalone .spinner-grow {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  vertical-align: text-bottom;
+  background-color: currentColor;
+  border-radius: 50%;
+  opacity: 0;
+  animation: spinner-grow .75s linear infinite; }
+.platform_sh_standalone .spinner-grow-sm {
+  width: 1rem;
+  height: 1rem; }
+.platform_sh_standalone .align-baseline {
+  vertical-align: baseline !important; }
+.platform_sh_standalone .align-top {
+  vertical-align: top !important; }
+.platform_sh_standalone .align-middle {
+  vertical-align: middle !important; }
+.platform_sh_standalone .align-bottom {
+  vertical-align: bottom !important; }
+.platform_sh_standalone .align-text-bottom {
+  vertical-align: text-bottom !important; }
+.platform_sh_standalone .align-text-top {
+  vertical-align: text-top !important; }
+.platform_sh_standalone .bg-primary {
+  background-color: #145CC6 !important; }
+.platform_sh_standalone a.bg-primary:hover, .platform_sh_standalone a.bg-primary:focus,
+.platform_sh_standalone button.bg-primary:hover,
+.platform_sh_standalone button.bg-primary:focus {
+  background-color: #0f4698 !important; }
+.platform_sh_standalone .bg-secondary {
+  background-color: #6c757d !important; }
+.platform_sh_standalone a.bg-secondary:hover, .platform_sh_standalone a.bg-secondary:focus,
+.platform_sh_standalone button.bg-secondary:hover,
+.platform_sh_standalone button.bg-secondary:focus {
+  background-color: #545b62 !important; }
+.platform_sh_standalone .bg-success {
+  background-color: #28a745 !important; }
+.platform_sh_standalone a.bg-success:hover, .platform_sh_standalone a.bg-success:focus,
+.platform_sh_standalone button.bg-success:hover,
+.platform_sh_standalone button.bg-success:focus {
+  background-color: #1e7e34 !important; }
+.platform_sh_standalone .bg-info {
+  background-color: #17a2b8 !important; }
+.platform_sh_standalone a.bg-info:hover, .platform_sh_standalone a.bg-info:focus,
+.platform_sh_standalone button.bg-info:hover,
+.platform_sh_standalone button.bg-info:focus {
+  background-color: #117a8b !important; }
+.platform_sh_standalone .bg-warning {
+  background-color: #F4BA37 !important; }
+.platform_sh_standalone a.bg-warning:hover, .platform_sh_standalone a.bg-warning:focus,
+.platform_sh_standalone button.bg-warning:hover,
+.platform_sh_standalone button.bg-warning:focus {
+  background-color: #eba70d !important; }
+.platform_sh_standalone .bg-danger {
+  background-color: #dc3545 !important; }
+.platform_sh_standalone a.bg-danger:hover, .platform_sh_standalone a.bg-danger:focus,
+.platform_sh_standalone button.bg-danger:hover,
+.platform_sh_standalone button.bg-danger:focus {
+  background-color: #bd2130 !important; }
+.platform_sh_standalone .bg-light {
+  background-color: #f8f9fa !important; }
+.platform_sh_standalone a.bg-light:hover, .platform_sh_standalone a.bg-light:focus,
+.platform_sh_standalone button.bg-light:hover,
+.platform_sh_standalone button.bg-light:focus {
+  background-color: #dae0e5 !important; }
+.platform_sh_standalone .bg-dark {
+  background-color: #343a40 !important; }
+.platform_sh_standalone a.bg-dark:hover, .platform_sh_standalone a.bg-dark:focus,
+.platform_sh_standalone button.bg-dark:hover,
+.platform_sh_standalone button.bg-dark:focus {
+  background-color: #1d2124 !important; }
+.platform_sh_standalone .bg-white {
+  background-color: #fff !important; }
+.platform_sh_standalone .bg-transparent {
+  background-color: transparent !important; }
+.platform_sh_standalone .border {
+  border: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-top {
+  border-top: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-right {
+  border-right: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-bottom {
+  border-bottom: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-left {
+  border-left: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-0 {
+  border: 0 !important; }
+.platform_sh_standalone .border-top-0 {
+  border-top: 0 !important; }
+.platform_sh_standalone .border-right-0 {
+  border-right: 0 !important; }
+.platform_sh_standalone .border-bottom-0 {
+  border-bottom: 0 !important; }
+.platform_sh_standalone .border-left-0 {
+  border-left: 0 !important; }
+.platform_sh_standalone .border-primary {
+  border-color: #145CC6 !important; }
+.platform_sh_standalone .border-secondary {
+  border-color: #6c757d !important; }
+.platform_sh_standalone .border-success {
+  border-color: #28a745 !important; }
+.platform_sh_standalone .border-info {
+  border-color: #17a2b8 !important; }
+.platform_sh_standalone .border-warning {
+  border-color: #F4BA37 !important; }
+.platform_sh_standalone .border-danger {
+  border-color: #dc3545 !important; }
+.platform_sh_standalone .border-light {
+  border-color: #f8f9fa !important; }
+.platform_sh_standalone .border-dark {
+  border-color: #343a40 !important; }
+.platform_sh_standalone .border-white {
+  border-color: #fff !important; }
+.platform_sh_standalone .rounded-sm {
+  border-radius: 0 !important; }
+.platform_sh_standalone .rounded {
+  border-radius: 0 !important; }
+.platform_sh_standalone .rounded-top {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important; }
+.platform_sh_standalone .rounded-right {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important; }
+.platform_sh_standalone .rounded-bottom {
+  border-bottom-right-radius: 0 !important;
+  border-bottom-left-radius: 0 !important; }
+.platform_sh_standalone .rounded-left {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important; }
+.platform_sh_standalone .rounded-lg {
+  border-radius: 0 !important; }
+.platform_sh_standalone .rounded-circle {
+  border-radius: 50% !important; }
+.platform_sh_standalone .rounded-pill {
+  border-radius: 50rem !important; }
+.platform_sh_standalone .rounded-0 {
+  border-radius: 0 !important; }
+.platform_sh_standalone .clearfix::after {
+  display: block;
+  clear: both;
+  content: ""; }
+.platform_sh_standalone .d-none {
+  display: none !important; }
+.platform_sh_standalone .d-inline {
+  display: inline !important; }
+.platform_sh_standalone .d-inline-block {
+  display: inline-block !important; }
+.platform_sh_standalone .d-block {
+  display: block !important; }
+.platform_sh_standalone .d-table {
+  display: table !important; }
+.platform_sh_standalone .d-table-row {
+  display: table-row !important; }
+.platform_sh_standalone .d-table-cell {
+  display: table-cell !important; }
+.platform_sh_standalone .d-flex {
+  display: flex !important; }
+.platform_sh_standalone .d-inline-flex {
+  display: inline-flex !important; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .d-sm-none {
+    display: none !important; }
+  .platform_sh_standalone .d-sm-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-sm-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-sm-block {
+    display: block !important; }
+  .platform_sh_standalone .d-sm-table {
+    display: table !important; }
+  .platform_sh_standalone .d-sm-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-sm-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-sm-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-sm-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .d-md-none {
+    display: none !important; }
+  .platform_sh_standalone .d-md-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-md-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-md-block {
+    display: block !important; }
+  .platform_sh_standalone .d-md-table {
+    display: table !important; }
+  .platform_sh_standalone .d-md-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-md-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-md-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-md-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .d-lg-none {
+    display: none !important; }
+  .platform_sh_standalone .d-lg-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-lg-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-lg-block {
+    display: block !important; }
+  .platform_sh_standalone .d-lg-table {
+    display: table !important; }
+  .platform_sh_standalone .d-lg-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-lg-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-lg-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-lg-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .d-xl-none {
+    display: none !important; }
+  .platform_sh_standalone .d-xl-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-xl-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-xl-block {
+    display: block !important; }
+  .platform_sh_standalone .d-xl-table {
+    display: table !important; }
+  .platform_sh_standalone .d-xl-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-xl-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-xl-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-xl-inline-flex {
+    display: inline-flex !important; } }
+@media print {
+  .platform_sh_standalone .d-print-none {
+    display: none !important; }
+  .platform_sh_standalone .d-print-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-print-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-print-block {
+    display: block !important; }
+  .platform_sh_standalone .d-print-table {
+    display: table !important; }
+  .platform_sh_standalone .d-print-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-print-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-print-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-print-inline-flex {
+    display: inline-flex !important; } }
+.platform_sh_standalone .embed-responsive {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden; }
+.platform_sh_standalone .embed-responsive::before {
+  display: block;
+  content: ""; }
+.platform_sh_standalone .embed-responsive .embed-responsive-item,
+.platform_sh_standalone .embed-responsive iframe,
+.platform_sh_standalone .embed-responsive embed,
+.platform_sh_standalone .embed-responsive object,
+.platform_sh_standalone .embed-responsive video {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0; }
+.platform_sh_standalone .embed-responsive-21by9::before {
+  padding-top: 42.8571428571%; }
+.platform_sh_standalone .embed-responsive-16by9::before {
+  padding-top: 56.25%; }
+.platform_sh_standalone .embed-responsive-4by3::before {
+  padding-top: 75%; }
+.platform_sh_standalone .embed-responsive-1by1::before {
+  padding-top: 100%; }
+.platform_sh_standalone .flex-row {
+  flex-direction: row !important; }
+.platform_sh_standalone .flex-column {
+  flex-direction: column !important; }
+.platform_sh_standalone .flex-row-reverse {
+  flex-direction: row-reverse !important; }
+.platform_sh_standalone .flex-column-reverse {
+  flex-direction: column-reverse !important; }
+.platform_sh_standalone .flex-wrap {
+  flex-wrap: wrap !important; }
+.platform_sh_standalone .flex-nowrap {
+  flex-wrap: nowrap !important; }
+.platform_sh_standalone .flex-wrap-reverse {
+  flex-wrap: wrap-reverse !important; }
+.platform_sh_standalone .flex-fill {
+  flex: 1 1 auto !important; }
+.platform_sh_standalone .flex-grow-0 {
+  flex-grow: 0 !important; }
+.platform_sh_standalone .flex-grow-1 {
+  flex-grow: 1 !important; }
+.platform_sh_standalone .flex-shrink-0 {
+  flex-shrink: 0 !important; }
+.platform_sh_standalone .flex-shrink-1 {
+  flex-shrink: 1 !important; }
+.platform_sh_standalone .justify-content-start {
+  justify-content: flex-start !important; }
+.platform_sh_standalone .justify-content-end {
+  justify-content: flex-end !important; }
+.platform_sh_standalone .justify-content-center {
+  justify-content: center !important; }
+.platform_sh_standalone .justify-content-between {
+  justify-content: space-between !important; }
+.platform_sh_standalone .justify-content-around {
+  justify-content: space-around !important; }
+.platform_sh_standalone .align-items-start {
+  align-items: flex-start !important; }
+.platform_sh_standalone .align-items-end {
+  align-items: flex-end !important; }
+.platform_sh_standalone .align-items-center {
+  align-items: center !important; }
+.platform_sh_standalone .align-items-baseline {
+  align-items: baseline !important; }
+.platform_sh_standalone .align-items-stretch {
+  align-items: stretch !important; }
+.platform_sh_standalone .align-content-start {
+  align-content: flex-start !important; }
+.platform_sh_standalone .align-content-end {
+  align-content: flex-end !important; }
+.platform_sh_standalone .align-content-center {
+  align-content: center !important; }
+.platform_sh_standalone .align-content-between {
+  align-content: space-between !important; }
+.platform_sh_standalone .align-content-around {
+  align-content: space-around !important; }
+.platform_sh_standalone .align-content-stretch {
+  align-content: stretch !important; }
+.platform_sh_standalone .align-self-auto {
+  align-self: auto !important; }
+.platform_sh_standalone .align-self-start {
+  align-self: flex-start !important; }
+.platform_sh_standalone .align-self-end {
+  align-self: flex-end !important; }
+.platform_sh_standalone .align-self-center {
+  align-self: center !important; }
+.platform_sh_standalone .align-self-baseline {
+  align-self: baseline !important; }
+.platform_sh_standalone .align-self-stretch {
+  align-self: stretch !important; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .flex-sm-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-sm-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-sm-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-sm-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-sm-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-sm-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-sm-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-sm-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-sm-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-sm-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-sm-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-sm-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-sm-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-sm-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-sm-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-sm-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-sm-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-sm-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-sm-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-sm-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-sm-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-sm-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-sm-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-sm-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-sm-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-sm-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-sm-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-sm-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-sm-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-sm-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-sm-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-sm-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-sm-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-sm-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .flex-md-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-md-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-md-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-md-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-md-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-md-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-md-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-md-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-md-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-md-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-md-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-md-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-md-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-md-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-md-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-md-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-md-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-md-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-md-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-md-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-md-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-md-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-md-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-md-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-md-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-md-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-md-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-md-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-md-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-md-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-md-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-md-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-md-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-md-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .flex-lg-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-lg-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-lg-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-lg-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-lg-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-lg-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-lg-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-lg-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-lg-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-lg-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-lg-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-lg-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-lg-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-lg-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-lg-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-lg-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-lg-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-lg-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-lg-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-lg-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-lg-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-lg-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-lg-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-lg-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-lg-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-lg-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-lg-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-lg-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-lg-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-lg-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-lg-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-lg-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-lg-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-lg-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .flex-xl-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-xl-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-xl-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-xl-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-xl-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-xl-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-xl-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-xl-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-xl-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-xl-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-xl-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-xl-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-xl-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-xl-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-xl-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-xl-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-xl-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-xl-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-xl-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-xl-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-xl-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-xl-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-xl-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-xl-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-xl-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-xl-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-xl-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-xl-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-xl-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-xl-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-xl-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-xl-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-xl-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-xl-stretch {
+    align-self: stretch !important; } }
+.platform_sh_standalone .float-left {
+  float: left !important; }
+.platform_sh_standalone .float-right {
+  float: right !important; }
+.platform_sh_standalone .float-none {
+  float: none !important; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .float-sm-left {
+    float: left !important; }
+  .platform_sh_standalone .float-sm-right {
+    float: right !important; }
+  .platform_sh_standalone .float-sm-none {
+    float: none !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .float-md-left {
+    float: left !important; }
+  .platform_sh_standalone .float-md-right {
+    float: right !important; }
+  .platform_sh_standalone .float-md-none {
+    float: none !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .float-lg-left {
+    float: left !important; }
+  .platform_sh_standalone .float-lg-right {
+    float: right !important; }
+  .platform_sh_standalone .float-lg-none {
+    float: none !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .float-xl-left {
+    float: left !important; }
+  .platform_sh_standalone .float-xl-right {
+    float: right !important; }
+  .platform_sh_standalone .float-xl-none {
+    float: none !important; } }
+.platform_sh_standalone .overflow-auto {
+  overflow: auto !important; }
+.platform_sh_standalone .overflow-hidden {
+  overflow: hidden !important; }
+.platform_sh_standalone .position-static {
+  position: static !important; }
+.platform_sh_standalone .position-relative {
+  position: relative !important; }
+.platform_sh_standalone .position-absolute {
+  position: absolute !important; }
+.platform_sh_standalone .position-fixed {
+  position: fixed !important; }
+.platform_sh_standalone .position-sticky {
+  position: sticky !important; }
+.platform_sh_standalone .fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1030; }
+.platform_sh_standalone .fixed-bottom {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1030; }
+@supports (position: sticky) {
+  .platform_sh_standalone .sticky-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020; } }
+.platform_sh_standalone .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0; }
+.platform_sh_standalone .sr-only-focusable:active, .platform_sh_standalone .sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
+  white-space: normal; }
+.platform_sh_standalone .shadow-sm {
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important; }
+.platform_sh_standalone .shadow {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important; }
+.platform_sh_standalone .shadow-lg {
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175) !important; }
+.platform_sh_standalone .shadow-none {
+  box-shadow: none !important; }
+.platform_sh_standalone .w-25 {
+  width: 25% !important; }
+.platform_sh_standalone .w-50 {
+  width: 50% !important; }
+.platform_sh_standalone .w-75 {
+  width: 75% !important; }
+.platform_sh_standalone .w-100 {
+  width: 100% !important; }
+.platform_sh_standalone .w-auto {
+  width: auto !important; }
+.platform_sh_standalone .h-25 {
+  height: 25% !important; }
+.platform_sh_standalone .h-50 {
+  height: 50% !important; }
+.platform_sh_standalone .h-75 {
+  height: 75% !important; }
+.platform_sh_standalone .h-100 {
+  height: 100% !important; }
+.platform_sh_standalone .h-auto {
+  height: auto !important; }
+.platform_sh_standalone .mw-100 {
+  max-width: 100% !important; }
+.platform_sh_standalone .mh-100 {
+  max-height: 100% !important; }
+.platform_sh_standalone .min-vw-100 {
+  min-width: 100vw !important; }
+.platform_sh_standalone .min-vh-100 {
+  min-height: 100vh !important; }
+.platform_sh_standalone .vw-100 {
+  width: 100vw !important; }
+.platform_sh_standalone .vh-100 {
+  height: 100vh !important; }
+.platform_sh_standalone .stretched-link::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  pointer-events: auto;
+  content: "";
+  background-color: rgba(0, 0, 0, 0); }
+.platform_sh_standalone .m-0 {
+  margin: 0 !important; }
+.platform_sh_standalone .mt-0,
+.platform_sh_standalone .my-0 {
+  margin-top: 0 !important; }
+.platform_sh_standalone .mr-0,
+.platform_sh_standalone .mx-0 {
+  margin-right: 0 !important; }
+.platform_sh_standalone .mb-0,
+.platform_sh_standalone .my-0 {
+  margin-bottom: 0 !important; }
+.platform_sh_standalone .ml-0,
+.platform_sh_standalone .mx-0 {
+  margin-left: 0 !important; }
+.platform_sh_standalone .m-1 {
+  margin: 0.25rem !important; }
+.platform_sh_standalone .mt-1,
+.platform_sh_standalone .my-1 {
+  margin-top: 0.25rem !important; }
+.platform_sh_standalone .mr-1,
+.platform_sh_standalone .mx-1 {
+  margin-right: 0.25rem !important; }
+.platform_sh_standalone .mb-1,
+.platform_sh_standalone .my-1 {
+  margin-bottom: 0.25rem !important; }
+.platform_sh_standalone .ml-1,
+.platform_sh_standalone .mx-1 {
+  margin-left: 0.25rem !important; }
+.platform_sh_standalone .m-2 {
+  margin: 0.5rem !important; }
+.platform_sh_standalone .mt-2,
+.platform_sh_standalone .my-2 {
+  margin-top: 0.5rem !important; }
+.platform_sh_standalone .mr-2,
+.platform_sh_standalone .mx-2 {
+  margin-right: 0.5rem !important; }
+.platform_sh_standalone .mb-2,
+.platform_sh_standalone .my-2 {
+  margin-bottom: 0.5rem !important; }
+.platform_sh_standalone .ml-2,
+.platform_sh_standalone .mx-2 {
+  margin-left: 0.5rem !important; }
+.platform_sh_standalone .m-3 {
+  margin: 1rem !important; }
+.platform_sh_standalone .mt-3,
+.platform_sh_standalone .my-3 {
+  margin-top: 1rem !important; }
+.platform_sh_standalone .mr-3,
+.platform_sh_standalone .mx-3 {
+  margin-right: 1rem !important; }
+.platform_sh_standalone .mb-3,
+.platform_sh_standalone .my-3 {
+  margin-bottom: 1rem !important; }
+.platform_sh_standalone .ml-3,
+.platform_sh_standalone .mx-3 {
+  margin-left: 1rem !important; }
+.platform_sh_standalone .m-4 {
+  margin: 1.5rem !important; }
+.platform_sh_standalone .mt-4,
+.platform_sh_standalone .my-4 {
+  margin-top: 1.5rem !important; }
+.platform_sh_standalone .mr-4,
+.platform_sh_standalone .mx-4 {
+  margin-right: 1.5rem !important; }
+.platform_sh_standalone .mb-4,
+.platform_sh_standalone .my-4 {
+  margin-bottom: 1.5rem !important; }
+.platform_sh_standalone .ml-4,
+.platform_sh_standalone .mx-4 {
+  margin-left: 1.5rem !important; }
+.platform_sh_standalone .m-5 {
+  margin: 3rem !important; }
+.platform_sh_standalone .mt-5,
+.platform_sh_standalone .my-5 {
+  margin-top: 3rem !important; }
+.platform_sh_standalone .mr-5,
+.platform_sh_standalone .mx-5 {
+  margin-right: 3rem !important; }
+.platform_sh_standalone .mb-5,
+.platform_sh_standalone .my-5 {
+  margin-bottom: 3rem !important; }
+.platform_sh_standalone .ml-5,
+.platform_sh_standalone .mx-5 {
+  margin-left: 3rem !important; }
+.platform_sh_standalone .p-0 {
+  padding: 0 !important; }
+.platform_sh_standalone .pt-0,
+.platform_sh_standalone .py-0 {
+  padding-top: 0 !important; }
+.platform_sh_standalone .pr-0,
+.platform_sh_standalone .px-0 {
+  padding-right: 0 !important; }
+.platform_sh_standalone .pb-0,
+.platform_sh_standalone .py-0 {
+  padding-bottom: 0 !important; }
+.platform_sh_standalone .pl-0,
+.platform_sh_standalone .px-0 {
+  padding-left: 0 !important; }
+.platform_sh_standalone .p-1 {
+  padding: 0.25rem !important; }
+.platform_sh_standalone .pt-1,
+.platform_sh_standalone .py-1 {
+  padding-top: 0.25rem !important; }
+.platform_sh_standalone .pr-1,
+.platform_sh_standalone .px-1 {
+  padding-right: 0.25rem !important; }
+.platform_sh_standalone .pb-1,
+.platform_sh_standalone .py-1 {
+  padding-bottom: 0.25rem !important; }
+.platform_sh_standalone .pl-1,
+.platform_sh_standalone .px-1 {
+  padding-left: 0.25rem !important; }
+.platform_sh_standalone .p-2 {
+  padding: 0.5rem !important; }
+.platform_sh_standalone .pt-2,
+.platform_sh_standalone .py-2 {
+  padding-top: 0.5rem !important; }
+.platform_sh_standalone .pr-2,
+.platform_sh_standalone .px-2 {
+  padding-right: 0.5rem !important; }
+.platform_sh_standalone .pb-2,
+.platform_sh_standalone .py-2 {
+  padding-bottom: 0.5rem !important; }
+.platform_sh_standalone .pl-2,
+.platform_sh_standalone .px-2 {
+  padding-left: 0.5rem !important; }
+.platform_sh_standalone .p-3 {
+  padding: 1rem !important; }
+.platform_sh_standalone .pt-3,
+.platform_sh_standalone .py-3 {
+  padding-top: 1rem !important; }
+.platform_sh_standalone .pr-3,
+.platform_sh_standalone .px-3 {
+  padding-right: 1rem !important; }
+.platform_sh_standalone .pb-3,
+.platform_sh_standalone .py-3 {
+  padding-bottom: 1rem !important; }
+.platform_sh_standalone .pl-3,
+.platform_sh_standalone .px-3 {
+  padding-left: 1rem !important; }
+.platform_sh_standalone .p-4 {
+  padding: 1.5rem !important; }
+.platform_sh_standalone .pt-4,
+.platform_sh_standalone .py-4 {
+  padding-top: 1.5rem !important; }
+.platform_sh_standalone .pr-4,
+.platform_sh_standalone .px-4 {
+  padding-right: 1.5rem !important; }
+.platform_sh_standalone .pb-4,
+.platform_sh_standalone .py-4 {
+  padding-bottom: 1.5rem !important; }
+.platform_sh_standalone .pl-4,
+.platform_sh_standalone .px-4 {
+  padding-left: 1.5rem !important; }
+.platform_sh_standalone .p-5 {
+  padding: 3rem !important; }
+.platform_sh_standalone .pt-5,
+.platform_sh_standalone .py-5 {
+  padding-top: 3rem !important; }
+.platform_sh_standalone .pr-5,
+.platform_sh_standalone .px-5 {
+  padding-right: 3rem !important; }
+.platform_sh_standalone .pb-5,
+.platform_sh_standalone .py-5 {
+  padding-bottom: 3rem !important; }
+.platform_sh_standalone .pl-5,
+.platform_sh_standalone .px-5 {
+  padding-left: 3rem !important; }
+.platform_sh_standalone .m-n1 {
+  margin: -0.25rem !important; }
+.platform_sh_standalone .mt-n1,
+.platform_sh_standalone .my-n1 {
+  margin-top: -0.25rem !important; }
+.platform_sh_standalone .mr-n1,
+.platform_sh_standalone .mx-n1 {
+  margin-right: -0.25rem !important; }
+.platform_sh_standalone .mb-n1,
+.platform_sh_standalone .my-n1 {
+  margin-bottom: -0.25rem !important; }
+.platform_sh_standalone .ml-n1,
+.platform_sh_standalone .mx-n1 {
+  margin-left: -0.25rem !important; }
+.platform_sh_standalone .m-n2 {
+  margin: -0.5rem !important; }
+.platform_sh_standalone .mt-n2,
+.platform_sh_standalone .my-n2 {
+  margin-top: -0.5rem !important; }
+.platform_sh_standalone .mr-n2,
+.platform_sh_standalone .mx-n2 {
+  margin-right: -0.5rem !important; }
+.platform_sh_standalone .mb-n2,
+.platform_sh_standalone .my-n2 {
+  margin-bottom: -0.5rem !important; }
+.platform_sh_standalone .ml-n2,
+.platform_sh_standalone .mx-n2 {
+  margin-left: -0.5rem !important; }
+.platform_sh_standalone .m-n3 {
+  margin: -1rem !important; }
+.platform_sh_standalone .mt-n3,
+.platform_sh_standalone .my-n3 {
+  margin-top: -1rem !important; }
+.platform_sh_standalone .mr-n3,
+.platform_sh_standalone .mx-n3 {
+  margin-right: -1rem !important; }
+.platform_sh_standalone .mb-n3,
+.platform_sh_standalone .my-n3 {
+  margin-bottom: -1rem !important; }
+.platform_sh_standalone .ml-n3,
+.platform_sh_standalone .mx-n3 {
+  margin-left: -1rem !important; }
+.platform_sh_standalone .m-n4 {
+  margin: -1.5rem !important; }
+.platform_sh_standalone .mt-n4,
+.platform_sh_standalone .my-n4 {
+  margin-top: -1.5rem !important; }
+.platform_sh_standalone .mr-n4,
+.platform_sh_standalone .mx-n4 {
+  margin-right: -1.5rem !important; }
+.platform_sh_standalone .mb-n4,
+.platform_sh_standalone .my-n4 {
+  margin-bottom: -1.5rem !important; }
+.platform_sh_standalone .ml-n4,
+.platform_sh_standalone .mx-n4 {
+  margin-left: -1.5rem !important; }
+.platform_sh_standalone .m-n5 {
+  margin: -3rem !important; }
+.platform_sh_standalone .mt-n5,
+.platform_sh_standalone .my-n5 {
+  margin-top: -3rem !important; }
+.platform_sh_standalone .mr-n5,
+.platform_sh_standalone .mx-n5 {
+  margin-right: -3rem !important; }
+.platform_sh_standalone .mb-n5,
+.platform_sh_standalone .my-n5 {
+  margin-bottom: -3rem !important; }
+.platform_sh_standalone .ml-n5,
+.platform_sh_standalone .mx-n5 {
+  margin-left: -3rem !important; }
+.platform_sh_standalone .m-auto {
+  margin: auto !important; }
+.platform_sh_standalone .mt-auto,
+.platform_sh_standalone .my-auto {
+  margin-top: auto !important; }
+.platform_sh_standalone .mr-auto,
+.platform_sh_standalone .mx-auto {
+  margin-right: auto !important; }
+.platform_sh_standalone .mb-auto,
+.platform_sh_standalone .my-auto {
+  margin-bottom: auto !important; }
+.platform_sh_standalone .ml-auto,
+.platform_sh_standalone .mx-auto {
+  margin-left: auto !important; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .m-sm-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-sm-0,
+  .platform_sh_standalone .my-sm-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-sm-0,
+  .platform_sh_standalone .mx-sm-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-sm-0,
+  .platform_sh_standalone .my-sm-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-sm-0,
+  .platform_sh_standalone .mx-sm-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-sm-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-sm-1,
+  .platform_sh_standalone .my-sm-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-sm-1,
+  .platform_sh_standalone .mx-sm-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-sm-1,
+  .platform_sh_standalone .my-sm-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-sm-1,
+  .platform_sh_standalone .mx-sm-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-sm-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-sm-2,
+  .platform_sh_standalone .my-sm-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-sm-2,
+  .platform_sh_standalone .mx-sm-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-sm-2,
+  .platform_sh_standalone .my-sm-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-sm-2,
+  .platform_sh_standalone .mx-sm-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-sm-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-sm-3,
+  .platform_sh_standalone .my-sm-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-sm-3,
+  .platform_sh_standalone .mx-sm-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-sm-3,
+  .platform_sh_standalone .my-sm-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-sm-3,
+  .platform_sh_standalone .mx-sm-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-sm-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-sm-4,
+  .platform_sh_standalone .my-sm-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-sm-4,
+  .platform_sh_standalone .mx-sm-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-sm-4,
+  .platform_sh_standalone .my-sm-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-sm-4,
+  .platform_sh_standalone .mx-sm-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-sm-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-sm-5,
+  .platform_sh_standalone .my-sm-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-sm-5,
+  .platform_sh_standalone .mx-sm-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-sm-5,
+  .platform_sh_standalone .my-sm-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-sm-5,
+  .platform_sh_standalone .mx-sm-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-sm-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-sm-0,
+  .platform_sh_standalone .py-sm-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-sm-0,
+  .platform_sh_standalone .px-sm-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-sm-0,
+  .platform_sh_standalone .py-sm-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-sm-0,
+  .platform_sh_standalone .px-sm-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-sm-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-sm-1,
+  .platform_sh_standalone .py-sm-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-sm-1,
+  .platform_sh_standalone .px-sm-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-sm-1,
+  .platform_sh_standalone .py-sm-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-sm-1,
+  .platform_sh_standalone .px-sm-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-sm-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-sm-2,
+  .platform_sh_standalone .py-sm-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-sm-2,
+  .platform_sh_standalone .px-sm-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-sm-2,
+  .platform_sh_standalone .py-sm-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-sm-2,
+  .platform_sh_standalone .px-sm-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-sm-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-sm-3,
+  .platform_sh_standalone .py-sm-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-sm-3,
+  .platform_sh_standalone .px-sm-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-sm-3,
+  .platform_sh_standalone .py-sm-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-sm-3,
+  .platform_sh_standalone .px-sm-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-sm-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-sm-4,
+  .platform_sh_standalone .py-sm-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-sm-4,
+  .platform_sh_standalone .px-sm-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-sm-4,
+  .platform_sh_standalone .py-sm-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-sm-4,
+  .platform_sh_standalone .px-sm-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-sm-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-sm-5,
+  .platform_sh_standalone .py-sm-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-sm-5,
+  .platform_sh_standalone .px-sm-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-sm-5,
+  .platform_sh_standalone .py-sm-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-sm-5,
+  .platform_sh_standalone .px-sm-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-sm-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-sm-n1,
+  .platform_sh_standalone .my-sm-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-sm-n1,
+  .platform_sh_standalone .mx-sm-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-sm-n1,
+  .platform_sh_standalone .my-sm-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-sm-n1,
+  .platform_sh_standalone .mx-sm-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-sm-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-sm-n2,
+  .platform_sh_standalone .my-sm-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-sm-n2,
+  .platform_sh_standalone .mx-sm-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-sm-n2,
+  .platform_sh_standalone .my-sm-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-sm-n2,
+  .platform_sh_standalone .mx-sm-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-sm-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-sm-n3,
+  .platform_sh_standalone .my-sm-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-sm-n3,
+  .platform_sh_standalone .mx-sm-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-sm-n3,
+  .platform_sh_standalone .my-sm-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-sm-n3,
+  .platform_sh_standalone .mx-sm-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-sm-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-sm-n4,
+  .platform_sh_standalone .my-sm-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-sm-n4,
+  .platform_sh_standalone .mx-sm-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-sm-n4,
+  .platform_sh_standalone .my-sm-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-sm-n4,
+  .platform_sh_standalone .mx-sm-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-sm-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-sm-n5,
+  .platform_sh_standalone .my-sm-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-sm-n5,
+  .platform_sh_standalone .mx-sm-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-sm-n5,
+  .platform_sh_standalone .my-sm-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-sm-n5,
+  .platform_sh_standalone .mx-sm-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-sm-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-sm-auto,
+  .platform_sh_standalone .my-sm-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-sm-auto,
+  .platform_sh_standalone .mx-sm-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-sm-auto,
+  .platform_sh_standalone .my-sm-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-sm-auto,
+  .platform_sh_standalone .mx-sm-auto {
+    margin-left: auto !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .m-md-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-md-0,
+  .platform_sh_standalone .my-md-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-md-0,
+  .platform_sh_standalone .mx-md-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-md-0,
+  .platform_sh_standalone .my-md-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-md-0,
+  .platform_sh_standalone .mx-md-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-md-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-md-1,
+  .platform_sh_standalone .my-md-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-md-1,
+  .platform_sh_standalone .mx-md-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-md-1,
+  .platform_sh_standalone .my-md-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-md-1,
+  .platform_sh_standalone .mx-md-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-md-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-md-2,
+  .platform_sh_standalone .my-md-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-md-2,
+  .platform_sh_standalone .mx-md-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-md-2,
+  .platform_sh_standalone .my-md-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-md-2,
+  .platform_sh_standalone .mx-md-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-md-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-md-3,
+  .platform_sh_standalone .my-md-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-md-3,
+  .platform_sh_standalone .mx-md-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-md-3,
+  .platform_sh_standalone .my-md-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-md-3,
+  .platform_sh_standalone .mx-md-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-md-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-md-4,
+  .platform_sh_standalone .my-md-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-md-4,
+  .platform_sh_standalone .mx-md-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-md-4,
+  .platform_sh_standalone .my-md-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-md-4,
+  .platform_sh_standalone .mx-md-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-md-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-md-5,
+  .platform_sh_standalone .my-md-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-md-5,
+  .platform_sh_standalone .mx-md-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-md-5,
+  .platform_sh_standalone .my-md-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-md-5,
+  .platform_sh_standalone .mx-md-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-md-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-md-0,
+  .platform_sh_standalone .py-md-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-md-0,
+  .platform_sh_standalone .px-md-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-md-0,
+  .platform_sh_standalone .py-md-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-md-0,
+  .platform_sh_standalone .px-md-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-md-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-md-1,
+  .platform_sh_standalone .py-md-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-md-1,
+  .platform_sh_standalone .px-md-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-md-1,
+  .platform_sh_standalone .py-md-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-md-1,
+  .platform_sh_standalone .px-md-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-md-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-md-2,
+  .platform_sh_standalone .py-md-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-md-2,
+  .platform_sh_standalone .px-md-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-md-2,
+  .platform_sh_standalone .py-md-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-md-2,
+  .platform_sh_standalone .px-md-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-md-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-md-3,
+  .platform_sh_standalone .py-md-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-md-3,
+  .platform_sh_standalone .px-md-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-md-3,
+  .platform_sh_standalone .py-md-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-md-3,
+  .platform_sh_standalone .px-md-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-md-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-md-4,
+  .platform_sh_standalone .py-md-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-md-4,
+  .platform_sh_standalone .px-md-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-md-4,
+  .platform_sh_standalone .py-md-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-md-4,
+  .platform_sh_standalone .px-md-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-md-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-md-5,
+  .platform_sh_standalone .py-md-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-md-5,
+  .platform_sh_standalone .px-md-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-md-5,
+  .platform_sh_standalone .py-md-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-md-5,
+  .platform_sh_standalone .px-md-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-md-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-md-n1,
+  .platform_sh_standalone .my-md-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-md-n1,
+  .platform_sh_standalone .mx-md-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-md-n1,
+  .platform_sh_standalone .my-md-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-md-n1,
+  .platform_sh_standalone .mx-md-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-md-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-md-n2,
+  .platform_sh_standalone .my-md-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-md-n2,
+  .platform_sh_standalone .mx-md-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-md-n2,
+  .platform_sh_standalone .my-md-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-md-n2,
+  .platform_sh_standalone .mx-md-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-md-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-md-n3,
+  .platform_sh_standalone .my-md-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-md-n3,
+  .platform_sh_standalone .mx-md-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-md-n3,
+  .platform_sh_standalone .my-md-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-md-n3,
+  .platform_sh_standalone .mx-md-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-md-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-md-n4,
+  .platform_sh_standalone .my-md-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-md-n4,
+  .platform_sh_standalone .mx-md-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-md-n4,
+  .platform_sh_standalone .my-md-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-md-n4,
+  .platform_sh_standalone .mx-md-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-md-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-md-n5,
+  .platform_sh_standalone .my-md-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-md-n5,
+  .platform_sh_standalone .mx-md-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-md-n5,
+  .platform_sh_standalone .my-md-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-md-n5,
+  .platform_sh_standalone .mx-md-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-md-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-md-auto,
+  .platform_sh_standalone .my-md-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-md-auto,
+  .platform_sh_standalone .mx-md-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-md-auto,
+  .platform_sh_standalone .my-md-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-md-auto,
+  .platform_sh_standalone .mx-md-auto {
+    margin-left: auto !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .m-lg-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-lg-0,
+  .platform_sh_standalone .my-lg-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-lg-0,
+  .platform_sh_standalone .mx-lg-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-lg-0,
+  .platform_sh_standalone .my-lg-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-lg-0,
+  .platform_sh_standalone .mx-lg-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-lg-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-lg-1,
+  .platform_sh_standalone .my-lg-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-lg-1,
+  .platform_sh_standalone .mx-lg-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-lg-1,
+  .platform_sh_standalone .my-lg-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-lg-1,
+  .platform_sh_standalone .mx-lg-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-lg-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-lg-2,
+  .platform_sh_standalone .my-lg-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-lg-2,
+  .platform_sh_standalone .mx-lg-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-lg-2,
+  .platform_sh_standalone .my-lg-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-lg-2,
+  .platform_sh_standalone .mx-lg-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-lg-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-lg-3,
+  .platform_sh_standalone .my-lg-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-lg-3,
+  .platform_sh_standalone .mx-lg-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-lg-3,
+  .platform_sh_standalone .my-lg-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-lg-3,
+  .platform_sh_standalone .mx-lg-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-lg-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-lg-4,
+  .platform_sh_standalone .my-lg-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-lg-4,
+  .platform_sh_standalone .mx-lg-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-lg-4,
+  .platform_sh_standalone .my-lg-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-lg-4,
+  .platform_sh_standalone .mx-lg-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-lg-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-lg-5,
+  .platform_sh_standalone .my-lg-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-lg-5,
+  .platform_sh_standalone .mx-lg-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-lg-5,
+  .platform_sh_standalone .my-lg-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-lg-5,
+  .platform_sh_standalone .mx-lg-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-lg-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-lg-0,
+  .platform_sh_standalone .py-lg-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-lg-0,
+  .platform_sh_standalone .px-lg-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-lg-0,
+  .platform_sh_standalone .py-lg-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-lg-0,
+  .platform_sh_standalone .px-lg-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-lg-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-lg-1,
+  .platform_sh_standalone .py-lg-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-lg-1,
+  .platform_sh_standalone .px-lg-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-lg-1,
+  .platform_sh_standalone .py-lg-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-lg-1,
+  .platform_sh_standalone .px-lg-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-lg-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-lg-2,
+  .platform_sh_standalone .py-lg-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-lg-2,
+  .platform_sh_standalone .px-lg-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-lg-2,
+  .platform_sh_standalone .py-lg-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-lg-2,
+  .platform_sh_standalone .px-lg-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-lg-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-lg-3,
+  .platform_sh_standalone .py-lg-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-lg-3,
+  .platform_sh_standalone .px-lg-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-lg-3,
+  .platform_sh_standalone .py-lg-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-lg-3,
+  .platform_sh_standalone .px-lg-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-lg-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-lg-4,
+  .platform_sh_standalone .py-lg-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-lg-4,
+  .platform_sh_standalone .px-lg-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-lg-4,
+  .platform_sh_standalone .py-lg-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-lg-4,
+  .platform_sh_standalone .px-lg-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-lg-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-lg-5,
+  .platform_sh_standalone .py-lg-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-lg-5,
+  .platform_sh_standalone .px-lg-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-lg-5,
+  .platform_sh_standalone .py-lg-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-lg-5,
+  .platform_sh_standalone .px-lg-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-lg-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-lg-n1,
+  .platform_sh_standalone .my-lg-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-lg-n1,
+  .platform_sh_standalone .mx-lg-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-lg-n1,
+  .platform_sh_standalone .my-lg-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-lg-n1,
+  .platform_sh_standalone .mx-lg-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-lg-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-lg-n2,
+  .platform_sh_standalone .my-lg-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-lg-n2,
+  .platform_sh_standalone .mx-lg-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-lg-n2,
+  .platform_sh_standalone .my-lg-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-lg-n2,
+  .platform_sh_standalone .mx-lg-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-lg-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-lg-n3,
+  .platform_sh_standalone .my-lg-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-lg-n3,
+  .platform_sh_standalone .mx-lg-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-lg-n3,
+  .platform_sh_standalone .my-lg-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-lg-n3,
+  .platform_sh_standalone .mx-lg-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-lg-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-lg-n4,
+  .platform_sh_standalone .my-lg-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-lg-n4,
+  .platform_sh_standalone .mx-lg-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-lg-n4,
+  .platform_sh_standalone .my-lg-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-lg-n4,
+  .platform_sh_standalone .mx-lg-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-lg-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-lg-n5,
+  .platform_sh_standalone .my-lg-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-lg-n5,
+  .platform_sh_standalone .mx-lg-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-lg-n5,
+  .platform_sh_standalone .my-lg-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-lg-n5,
+  .platform_sh_standalone .mx-lg-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-lg-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-lg-auto,
+  .platform_sh_standalone .my-lg-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-lg-auto,
+  .platform_sh_standalone .mx-lg-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-lg-auto,
+  .platform_sh_standalone .my-lg-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-lg-auto,
+  .platform_sh_standalone .mx-lg-auto {
+    margin-left: auto !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .m-xl-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-xl-0,
+  .platform_sh_standalone .my-xl-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-xl-0,
+  .platform_sh_standalone .mx-xl-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-xl-0,
+  .platform_sh_standalone .my-xl-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-xl-0,
+  .platform_sh_standalone .mx-xl-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-xl-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-xl-1,
+  .platform_sh_standalone .my-xl-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-xl-1,
+  .platform_sh_standalone .mx-xl-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-xl-1,
+  .platform_sh_standalone .my-xl-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-xl-1,
+  .platform_sh_standalone .mx-xl-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-xl-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-xl-2,
+  .platform_sh_standalone .my-xl-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-xl-2,
+  .platform_sh_standalone .mx-xl-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-xl-2,
+  .platform_sh_standalone .my-xl-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-xl-2,
+  .platform_sh_standalone .mx-xl-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-xl-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-xl-3,
+  .platform_sh_standalone .my-xl-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-xl-3,
+  .platform_sh_standalone .mx-xl-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-xl-3,
+  .platform_sh_standalone .my-xl-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-xl-3,
+  .platform_sh_standalone .mx-xl-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-xl-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-xl-4,
+  .platform_sh_standalone .my-xl-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-xl-4,
+  .platform_sh_standalone .mx-xl-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-xl-4,
+  .platform_sh_standalone .my-xl-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-xl-4,
+  .platform_sh_standalone .mx-xl-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-xl-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-xl-5,
+  .platform_sh_standalone .my-xl-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-xl-5,
+  .platform_sh_standalone .mx-xl-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-xl-5,
+  .platform_sh_standalone .my-xl-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-xl-5,
+  .platform_sh_standalone .mx-xl-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-xl-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-xl-0,
+  .platform_sh_standalone .py-xl-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-xl-0,
+  .platform_sh_standalone .px-xl-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-xl-0,
+  .platform_sh_standalone .py-xl-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-xl-0,
+  .platform_sh_standalone .px-xl-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-xl-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-xl-1,
+  .platform_sh_standalone .py-xl-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-xl-1,
+  .platform_sh_standalone .px-xl-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-xl-1,
+  .platform_sh_standalone .py-xl-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-xl-1,
+  .platform_sh_standalone .px-xl-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-xl-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-xl-2,
+  .platform_sh_standalone .py-xl-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-xl-2,
+  .platform_sh_standalone .px-xl-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-xl-2,
+  .platform_sh_standalone .py-xl-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-xl-2,
+  .platform_sh_standalone .px-xl-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-xl-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-xl-3,
+  .platform_sh_standalone .py-xl-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-xl-3,
+  .platform_sh_standalone .px-xl-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-xl-3,
+  .platform_sh_standalone .py-xl-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-xl-3,
+  .platform_sh_standalone .px-xl-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-xl-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-xl-4,
+  .platform_sh_standalone .py-xl-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-xl-4,
+  .platform_sh_standalone .px-xl-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-xl-4,
+  .platform_sh_standalone .py-xl-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-xl-4,
+  .platform_sh_standalone .px-xl-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-xl-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-xl-5,
+  .platform_sh_standalone .py-xl-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-xl-5,
+  .platform_sh_standalone .px-xl-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-xl-5,
+  .platform_sh_standalone .py-xl-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-xl-5,
+  .platform_sh_standalone .px-xl-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-xl-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-xl-n1,
+  .platform_sh_standalone .my-xl-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-xl-n1,
+  .platform_sh_standalone .mx-xl-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-xl-n1,
+  .platform_sh_standalone .my-xl-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-xl-n1,
+  .platform_sh_standalone .mx-xl-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-xl-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-xl-n2,
+  .platform_sh_standalone .my-xl-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-xl-n2,
+  .platform_sh_standalone .mx-xl-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-xl-n2,
+  .platform_sh_standalone .my-xl-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-xl-n2,
+  .platform_sh_standalone .mx-xl-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-xl-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-xl-n3,
+  .platform_sh_standalone .my-xl-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-xl-n3,
+  .platform_sh_standalone .mx-xl-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-xl-n3,
+  .platform_sh_standalone .my-xl-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-xl-n3,
+  .platform_sh_standalone .mx-xl-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-xl-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-xl-n4,
+  .platform_sh_standalone .my-xl-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-xl-n4,
+  .platform_sh_standalone .mx-xl-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-xl-n4,
+  .platform_sh_standalone .my-xl-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-xl-n4,
+  .platform_sh_standalone .mx-xl-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-xl-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-xl-n5,
+  .platform_sh_standalone .my-xl-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-xl-n5,
+  .platform_sh_standalone .mx-xl-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-xl-n5,
+  .platform_sh_standalone .my-xl-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-xl-n5,
+  .platform_sh_standalone .mx-xl-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-xl-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-xl-auto,
+  .platform_sh_standalone .my-xl-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-xl-auto,
+  .platform_sh_standalone .mx-xl-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-xl-auto,
+  .platform_sh_standalone .my-xl-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-xl-auto,
+  .platform_sh_standalone .mx-xl-auto {
+    margin-left: auto !important; } }
+.platform_sh_standalone .text-monospace {
+  font-family: "Moderat Mono", "Courier New", monospace !important; }
+.platform_sh_standalone .text-justify {
+  text-align: justify !important; }
+.platform_sh_standalone .text-wrap {
+  white-space: normal !important; }
+.platform_sh_standalone .text-nowrap {
+  white-space: nowrap !important; }
+.platform_sh_standalone .text-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap; }
+.platform_sh_standalone .text-left {
+  text-align: left !important; }
+.platform_sh_standalone .text-right {
+  text-align: right !important; }
+.platform_sh_standalone .text-center {
+  text-align: center !important; }
+@media (min-width: 576px) {
+  .platform_sh_standalone .text-sm-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-sm-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-sm-center {
+    text-align: center !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .text-md-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-md-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-md-center {
+    text-align: center !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .text-lg-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-lg-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-lg-center {
+    text-align: center !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .text-xl-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-xl-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-xl-center {
+    text-align: center !important; } }
+.platform_sh_standalone .text-lowercase {
+  text-transform: lowercase !important; }
+.platform_sh_standalone .text-uppercase {
+  text-transform: uppercase !important; }
+.platform_sh_standalone .text-capitalize {
+  text-transform: capitalize !important; }
+.platform_sh_standalone .font-weight-light {
+  font-weight: 300 !important; }
+.platform_sh_standalone .font-weight-lighter {
+  font-weight: lighter !important; }
+.platform_sh_standalone .font-weight-normal {
+  font-weight: 400 !important; }
+.platform_sh_standalone .font-weight-bold {
+  font-weight: 700 !important; }
+.platform_sh_standalone .font-weight-bolder {
+  font-weight: 900 !important; }
+.platform_sh_standalone .font-italic {
+  font-style: italic !important; }
+.platform_sh_standalone .text-white {
+  color: #fff !important; }
+.platform_sh_standalone .text-primary {
+  color: #145CC6 !important; }
+.platform_sh_standalone a.text-primary:hover, .platform_sh_standalone a.text-primary:focus {
+  color: #0d3c81 !important; }
+.platform_sh_standalone .text-secondary {
+  color: #6c757d !important; }
+.platform_sh_standalone a.text-secondary:hover, .platform_sh_standalone a.text-secondary:focus {
+  color: #494f54 !important; }
+.platform_sh_standalone .text-success {
+  color: #28a745 !important; }
+.platform_sh_standalone a.text-success:hover, .platform_sh_standalone a.text-success:focus {
+  color: #19692c !important; }
+.platform_sh_standalone .text-info {
+  color: #17a2b8 !important; }
+.platform_sh_standalone a.text-info:hover, .platform_sh_standalone a.text-info:focus {
+  color: #0f6674 !important; }
+.platform_sh_standalone .text-warning {
+  color: #F4BA37 !important; }
+.platform_sh_standalone a.text-warning:hover, .platform_sh_standalone a.text-warning:focus {
+  color: #d3960c !important; }
+.platform_sh_standalone .text-danger {
+  color: #dc3545 !important; }
+.platform_sh_standalone a.text-danger:hover, .platform_sh_standalone a.text-danger:focus {
+  color: #a71d2a !important; }
+.platform_sh_standalone .text-light {
+  color: #f8f9fa !important; }
+.platform_sh_standalone a.text-light:hover, .platform_sh_standalone a.text-light:focus {
+  color: #cbd3da !important; }
+.platform_sh_standalone .text-dark {
+  color: #343a40 !important; }
+.platform_sh_standalone a.text-dark:hover, .platform_sh_standalone a.text-dark:focus {
+  color: #121416 !important; }
+.platform_sh_standalone .text-body {
+  color: #49475F !important; }
+.platform_sh_standalone .text-muted {
+  color: #6c757d !important; }
+.platform_sh_standalone .text-black-50 {
+  color: rgba(0, 0, 0, 0.5) !important; }
+.platform_sh_standalone .text-white-50 {
+  color: rgba(255, 255, 255, 0.5) !important; }
+.platform_sh_standalone .text-hide {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0; }
+.platform_sh_standalone .text-decoration-none {
+  text-decoration: none !important; }
+.platform_sh_standalone .text-break {
+  word-break: break-word !important;
+  overflow-wrap: break-word !important; }
+.platform_sh_standalone .text-reset {
+  color: inherit !important; }
+.platform_sh_standalone .visible {
+  visibility: visible !important; }
+.platform_sh_standalone .invisible {
+  visibility: hidden !important; }
+@media print {
+  .platform_sh_standalone *,
+  .platform_sh_standalone *::before,
+  .platform_sh_standalone *::after {
+    text-shadow: none !important;
+    box-shadow: none !important; }
+  .platform_sh_standalone a:not(.btn) {
+    text-decoration: underline; }
+  .platform_sh_standalone abbr[title]::after {
+    content: " (" attr(title) ")"; }
+  .platform_sh_standalone pre {
+    white-space: pre-wrap !important; }
+  .platform_sh_standalone pre,
+  .platform_sh_standalone blockquote {
+    border: 1px solid #adb5bd;
+    page-break-inside: avoid; }
+  .platform_sh_standalone thead {
+    display: table-header-group; }
+  .platform_sh_standalone tr,
+  .platform_sh_standalone img {
+    page-break-inside: avoid; }
+  .platform_sh_standalone p,
+  .platform_sh_standalone h2,
+  .platform_sh_standalone h3 {
+    orphans: 3;
+    widows: 3; }
+  .platform_sh_standalone h2,
+  .platform_sh_standalone h3 {
+    page-break-after: avoid; }
+  @page {
+  .platform_sh_standalone {
+    size: a3; } }
+.platform_sh_standalone body {
+  min-width: 992px !important; }
+.platform_sh_standalone .container {
+  min-width: 992px !important; }
+.platform_sh_standalone .navbar {
+  display: none; }
+.platform_sh_standalone .badge {
+  border: 1px solid #000; }
+.platform_sh_standalone .table {
+  border-collapse: collapse !important; }
+.platform_sh_standalone .table td,
+.platform_sh_standalone .table th {
+  background-color: #fff !important; }
+.platform_sh_standalone .table-bordered th,
+.platform_sh_standalone .table-bordered td {
+  border: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .table-dark {
+  color: inherit; }
+.platform_sh_standalone .table-dark th,
+.platform_sh_standalone .table-dark td,
+.platform_sh_standalone .table-dark thead th,
+.platform_sh_standalone .table-dark tbody + tbody {
+  border-color: #dee2e6; }
+.platform_sh_standalone .table .thead-dark th {
+  color: inherit;
+  border-color: #dee2e6; } }
+.platform_sh_standalone :root {
+  --blue: #145CC6;
+  --indigo: #6610f2;
+  --purple: #6f42c1;
+  --pink: #FFBDBB;
+  --red: #dc3545;
+  --orange: #FB3728;
+  --yellow: #F4BA37;
+  --green: #28a745;
+  --teal: #20c997;
+  --cyan: #17a2b8;
+  --white: #fff;
+  --gray: #6c757d;
+  --gray-dark: #343a40;
+  --primary: #145CC6;
+  --secondary: #6c757d;
+  --success: #28a745;
+  --info: #17a2b8;
+  --warning: #F4BA37;
+  --danger: #dc3545;
+  --light: #f8f9fa;
+  --dark: #343a40;
+  --breakpoint-xxxs: 0;
+  --breakpoint-xxs: 320px;
+  --breakpoint-xs: 414px;
+  --breakpoint-sm: 667px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 992px;
+  --breakpoint-xl: 1200px;
+  --breakpoint-xxl: 1440px;
+  --breakpoint-xxxl: 1600px;
+  --font-family-sans-serif: Overpass, Arial;
+  --font-family-monospace: "Moderat Mono", "Courier New", monospace; }
+.platform_sh_standalone *,
+.platform_sh_standalone *::before,
+.platform_sh_standalone *::after {
+  box-sizing: border-box; }
+.platform_sh_standalone html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+.platform_sh_standalone article, .platform_sh_standalone aside, .platform_sh_standalone figcaption, .platform_sh_standalone figure, .platform_sh_standalone footer, .platform_sh_standalone header, .platform_sh_standalone hgroup, .platform_sh_standalone main, .platform_sh_standalone nav, .platform_sh_standalone section {
+  display: block; }
+.platform_sh_standalone body {
+  margin: 0;
+  font-family: Overpass, Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #49475F;
+  text-align: left;
+  background-color: #fff; }
+.platform_sh_standalone [tabindex="-1"]:focus {
+  outline: 0 !important; }
+.platform_sh_standalone hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible; }
+.platform_sh_standalone h1, .platform_sh_standalone h2, .platform_sh_standalone h3, .platform_sh_standalone h4, .platform_sh_standalone h5, .platform_sh_standalone h6 {
+  margin-top: 0;
+  margin-bottom: 0.5rem; }
+.platform_sh_standalone p {
+  margin-top: 0;
+  margin-bottom: 1rem; }
+.platform_sh_standalone abbr[title],
+.platform_sh_standalone abbr[data-original-title] {
+  text-decoration: underline;
+  text-decoration: underline dotted;
+  cursor: help;
+  border-bottom: 0;
+  text-decoration-skip-ink: none; }
+.platform_sh_standalone address {
+  margin-bottom: 1rem;
+  font-style: normal;
+  line-height: inherit; }
+.platform_sh_standalone ol,
+.platform_sh_standalone ul,
+.platform_sh_standalone dl {
+  margin-top: 0;
+  margin-bottom: 1rem; }
+.platform_sh_standalone ol ol,
+.platform_sh_standalone ul ul,
+.platform_sh_standalone ol ul,
+.platform_sh_standalone ul ol {
+  margin-bottom: 0; }
+.platform_sh_standalone dt {
+  font-weight: 700; }
+.platform_sh_standalone dd {
+  margin-bottom: .5rem;
+  margin-left: 0; }
+.platform_sh_standalone blockquote {
+  margin: 0 0 1rem; }
+.platform_sh_standalone b,
+.platform_sh_standalone strong {
+  font-weight: 900; }
+.platform_sh_standalone small {
+  font-size: 80%; }
+.platform_sh_standalone sub,
+.platform_sh_standalone sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline; }
+.platform_sh_standalone sub {
+  bottom: -.25em; }
+.platform_sh_standalone sup {
+  top: -.5em; }
+.platform_sh_standalone a {
+  color: #145CC6;
+  text-decoration: none;
+  background-color: transparent; }
+.platform_sh_standalone a:hover {
+  color: #0d3c81;
+  text-decoration: underline; }
+.platform_sh_standalone a:not([href]):not([tabindex]) {
+  color: inherit;
+  text-decoration: none; }
+.platform_sh_standalone a:not([href]):not([tabindex]):hover, .platform_sh_standalone a:not([href]):not([tabindex]):focus {
+  color: inherit;
+  text-decoration: none; }
+.platform_sh_standalone a:not([href]):not([tabindex]):focus {
+  outline: 0; }
+.platform_sh_standalone pre,
+.platform_sh_standalone code,
+.platform_sh_standalone kbd,
+.platform_sh_standalone samp {
+  font-family: "Moderat Mono", "Courier New", monospace;
+  font-size: 1em; }
+.platform_sh_standalone pre {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  overflow: auto; }
+.platform_sh_standalone figure {
+  margin: 0 0 1rem; }
+.platform_sh_standalone img {
+  vertical-align: middle;
+  border-style: none; }
+.platform_sh_standalone svg {
+  overflow: hidden;
+  vertical-align: middle; }
+.platform_sh_standalone table {
+  border-collapse: collapse; }
+.platform_sh_standalone caption {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: #6c757d;
+  text-align: left;
+  caption-side: bottom; }
+.platform_sh_standalone th {
+  text-align: inherit; }
+.platform_sh_standalone label {
+  display: inline-block;
+  margin-bottom: 0.5rem; }
+.platform_sh_standalone button {
+  border-radius: 0; }
+.platform_sh_standalone button:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color; }
+.platform_sh_standalone input,
+.platform_sh_standalone button,
+.platform_sh_standalone select,
+.platform_sh_standalone optgroup,
+.platform_sh_standalone textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit; }
+.platform_sh_standalone button,
+.platform_sh_standalone input {
+  overflow: visible; }
+.platform_sh_standalone button,
+.platform_sh_standalone select {
+  text-transform: none; }
+.platform_sh_standalone select {
+  word-wrap: normal; }
+.platform_sh_standalone button,
+.platform_sh_standalone [type="button"],
+.platform_sh_standalone [type="reset"],
+.platform_sh_standalone [type="submit"] {
+  -webkit-appearance: button; }
+.platform_sh_standalone button:not(:disabled),
+.platform_sh_standalone [type="button"]:not(:disabled),
+.platform_sh_standalone [type="reset"]:not(:disabled),
+.platform_sh_standalone [type="submit"]:not(:disabled) {
+  cursor: pointer; }
+.platform_sh_standalone button::-moz-focus-inner,
+.platform_sh_standalone [type="button"]::-moz-focus-inner,
+.platform_sh_standalone [type="reset"]::-moz-focus-inner,
+.platform_sh_standalone [type="submit"]::-moz-focus-inner {
+  padding: 0;
+  border-style: none; }
+.platform_sh_standalone input[type="radio"],
+.platform_sh_standalone input[type="checkbox"] {
+  box-sizing: border-box;
+  padding: 0; }
+.platform_sh_standalone input[type="date"],
+.platform_sh_standalone input[type="time"],
+.platform_sh_standalone input[type="datetime-local"],
+.platform_sh_standalone input[type="month"] {
+  -webkit-appearance: listbox; }
+.platform_sh_standalone textarea {
+  overflow: auto;
+  resize: vertical; }
+.platform_sh_standalone fieldset {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0; }
+.platform_sh_standalone legend {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
+  margin-bottom: .5rem;
+  font-size: 1.5rem;
+  line-height: inherit;
+  color: inherit;
+  white-space: normal; }
+.platform_sh_standalone progress {
+  vertical-align: baseline; }
+.platform_sh_standalone [type="number"]::-webkit-inner-spin-button,
+.platform_sh_standalone [type="number"]::-webkit-outer-spin-button {
+  height: auto; }
+.platform_sh_standalone [type="search"] {
+  outline-offset: -2px;
+  -webkit-appearance: none; }
+.platform_sh_standalone [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none; }
+.platform_sh_standalone ::-webkit-file-upload-button {
+  font: inherit;
+  -webkit-appearance: button; }
+.platform_sh_standalone output {
+  display: inline-block; }
+.platform_sh_standalone summary {
+  display: list-item;
+  cursor: pointer; }
+.platform_sh_standalone template {
+  display: none; }
+.platform_sh_standalone [hidden] {
+  display: none !important; }
+.platform_sh_standalone h1, .platform_sh_standalone h2, .platform_sh_standalone h3, .platform_sh_standalone h4, .platform_sh_standalone h5, .platform_sh_standalone h6,
+.platform_sh_standalone .h1, .platform_sh_standalone .h2, .platform_sh_standalone .h3, .platform_sh_standalone .h4, .platform_sh_standalone .h5, .platform_sh_standalone .h6 {
+  margin-bottom: 0.5rem;
+  font-family: "Moderat", "Helvetica Neue", Arial;
+  font-weight: 700;
+  line-height: 1.1;
+  color: #1A182A; }
+.platform_sh_standalone h1, .platform_sh_standalone .h1 {
+  font-size: 3.75rem; }
+.platform_sh_standalone h2, .platform_sh_standalone .h2 {
+  font-size: 3rem; }
+.platform_sh_standalone h3, .platform_sh_standalone .h3 {
+  font-size: 5.625rem; }
+.platform_sh_standalone h4, .platform_sh_standalone .h4 {
+  font-size: 2.125rem; }
+.platform_sh_standalone h5, .platform_sh_standalone .h5 {
+  font-size: 1.5rem; }
+.platform_sh_standalone h6, .platform_sh_standalone .h6 {
+  font-size: 1rem; }
+.platform_sh_standalone .lead {
+  font-size: 1.25rem;
+  font-weight: 300; }
+.platform_sh_standalone .display-1 {
+  font-size: 6rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone .display-2 {
+  font-size: 5.5rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone .display-3 {
+  font-size: 4.5rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone .display-4 {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.1; }
+.platform_sh_standalone hr {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  border: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1); }
+.platform_sh_standalone small,
+.platform_sh_standalone .small {
+  font-size: 80%;
+  font-weight: 400; }
+.platform_sh_standalone mark,
+.platform_sh_standalone .mark {
+  padding: 0.2em;
+  background-color: #fcf8e3; }
+.platform_sh_standalone .list-unstyled {
+  padding-left: 0;
+  list-style: none; }
+.platform_sh_standalone .list-inline {
+  padding-left: 0;
+  list-style: none; }
+.platform_sh_standalone .list-inline-item {
+  display: inline-block; }
+.platform_sh_standalone .list-inline-item:not(:last-child) {
+  margin-right: 0.5rem; }
+.platform_sh_standalone .initialism {
+  font-size: 90%;
+  text-transform: uppercase; }
+.platform_sh_standalone .blockquote {
+  margin-bottom: 1rem;
+  font-size: 1.25rem; }
+.platform_sh_standalone .blockquote-footer {
+  display: block;
+  font-size: 80%;
+  color: #6c757d; }
+.platform_sh_standalone .blockquote-footer::before {
+  content: "\2014\00A0"; }
+.platform_sh_standalone .img-fluid {
+  max-width: 100%;
+  height: auto; }
+.platform_sh_standalone .img-thumbnail {
+  padding: 0.25rem;
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 0;
+  max-width: 100%;
+  height: auto; }
+.platform_sh_standalone .figure {
+  display: inline-block; }
+.platform_sh_standalone .figure-img {
+  margin-bottom: 0.5rem;
+  line-height: 1; }
+.platform_sh_standalone .figure-caption {
+  font-size: 90%;
+  color: #6c757d; }
+.platform_sh_standalone code {
+  font-size: 87.5%;
+  color: #FFBDBB;
+  word-break: break-word; }
+a > .platform_sh_standalone code {
+  color: inherit; }
+.platform_sh_standalone kbd {
+  padding: 0.2rem 0.4rem;
+  font-size: 87.5%;
+  color: #fff;
+  background-color: #212529;
+  border-radius: 0; }
+.platform_sh_standalone kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: 700; }
+.platform_sh_standalone pre {
+  display: block;
+  font-size: 87.5%;
+  color: #212529; }
+.platform_sh_standalone pre code {
+  font-size: inherit;
+  color: inherit;
+  word-break: normal; }
+.platform_sh_standalone .pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll; }
+.platform_sh_standalone .container {
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 0; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .container {
+    max-width: 320px; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .container {
+    max-width: 414px; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .container {
+    max-width: 667px; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .container {
+    max-width: 768px; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .container {
+    max-width: 992px; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .container {
+    max-width: 1200px; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .container {
+    max-width: 1440px; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .container {
+    max-width: 1600px; } }
+.platform_sh_standalone .container-fluid {
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px;
+  margin-right: auto;
+  margin-left: auto; }
+.platform_sh_standalone .row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -20px;
+  margin-left: -20px; }
+.platform_sh_standalone .no-gutters {
+  margin-right: 0;
+  margin-left: 0; }
+.platform_sh_standalone .no-gutters > .col,
+.platform_sh_standalone .no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .col-1, .platform_sh_standalone .col-2, .platform_sh_standalone .col-3, .platform_sh_standalone .col-4, .platform_sh_standalone .col-5, .platform_sh_standalone .col-6, .platform_sh_standalone .col-7, .platform_sh_standalone .col-8, .platform_sh_standalone .col-9, .platform_sh_standalone .col-10, .platform_sh_standalone .col-11, .platform_sh_standalone .col-12, .platform_sh_standalone .col,
+.platform_sh_standalone .col-auto, .platform_sh_standalone .col-sm-1, .platform_sh_standalone .col-sm-2, .platform_sh_standalone .col-sm-3, .platform_sh_standalone .col-sm-4, .platform_sh_standalone .col-sm-5, .platform_sh_standalone .col-sm-6, .platform_sh_standalone .col-sm-7, .platform_sh_standalone .col-sm-8, .platform_sh_standalone .col-sm-9, .platform_sh_standalone .col-sm-10, .platform_sh_standalone .col-sm-11, .platform_sh_standalone .col-sm-12, .platform_sh_standalone .col-sm,
+.platform_sh_standalone .col-sm-auto, .platform_sh_standalone .col-md-1, .platform_sh_standalone .col-md-2, .platform_sh_standalone .col-md-3, .platform_sh_standalone .col-md-4, .platform_sh_standalone .col-md-5, .platform_sh_standalone .col-md-6, .platform_sh_standalone .col-md-7, .platform_sh_standalone .col-md-8, .platform_sh_standalone .col-md-9, .platform_sh_standalone .col-md-10, .platform_sh_standalone .col-md-11, .platform_sh_standalone .col-md-12, .platform_sh_standalone .col-md,
+.platform_sh_standalone .col-md-auto, .platform_sh_standalone .col-lg-1, .platform_sh_standalone .col-lg-2, .platform_sh_standalone .col-lg-3, .platform_sh_standalone .col-lg-4, .platform_sh_standalone .col-lg-5, .platform_sh_standalone .col-lg-6, .platform_sh_standalone .col-lg-7, .platform_sh_standalone .col-lg-8, .platform_sh_standalone .col-lg-9, .platform_sh_standalone .col-lg-10, .platform_sh_standalone .col-lg-11, .platform_sh_standalone .col-lg-12, .platform_sh_standalone .col-lg,
+.platform_sh_standalone .col-lg-auto, .platform_sh_standalone .col-xl-1, .platform_sh_standalone .col-xl-2, .platform_sh_standalone .col-xl-3, .platform_sh_standalone .col-xl-4, .platform_sh_standalone .col-xl-5, .platform_sh_standalone .col-xl-6, .platform_sh_standalone .col-xl-7, .platform_sh_standalone .col-xl-8, .platform_sh_standalone .col-xl-9, .platform_sh_standalone .col-xl-10, .platform_sh_standalone .col-xl-11, .platform_sh_standalone .col-xl-12, .platform_sh_standalone .col-xl,
+.platform_sh_standalone .col-xl-auto, .platform_sh_standalone .col-xxs-1, .platform_sh_standalone .col-xxs-2, .platform_sh_standalone .col-xxs-3, .platform_sh_standalone .col-xxs-4, .platform_sh_standalone .col-xxs-5, .platform_sh_standalone .col-xxs-6, .platform_sh_standalone .col-xxs-7, .platform_sh_standalone .col-xxs-8, .platform_sh_standalone .col-xxs-9, .platform_sh_standalone .col-xxs-10, .platform_sh_standalone .col-xxs-11, .platform_sh_standalone .col-xxs-12, .platform_sh_standalone .col-xxs,
+.platform_sh_standalone .col-xxs-auto, .platform_sh_standalone .col-xs-1, .platform_sh_standalone .col-xs-2, .platform_sh_standalone .col-xs-3, .platform_sh_standalone .col-xs-4, .platform_sh_standalone .col-xs-5, .platform_sh_standalone .col-xs-6, .platform_sh_standalone .col-xs-7, .platform_sh_standalone .col-xs-8, .platform_sh_standalone .col-xs-9, .platform_sh_standalone .col-xs-10, .platform_sh_standalone .col-xs-11, .platform_sh_standalone .col-xs-12, .platform_sh_standalone .col-xs,
+.platform_sh_standalone .col-xs-auto, .platform_sh_standalone .col-xxl-1, .platform_sh_standalone .col-xxl-2, .platform_sh_standalone .col-xxl-3, .platform_sh_standalone .col-xxl-4, .platform_sh_standalone .col-xxl-5, .platform_sh_standalone .col-xxl-6, .platform_sh_standalone .col-xxl-7, .platform_sh_standalone .col-xxl-8, .platform_sh_standalone .col-xxl-9, .platform_sh_standalone .col-xxl-10, .platform_sh_standalone .col-xxl-11, .platform_sh_standalone .col-xxl-12, .platform_sh_standalone .col-xxl,
+.platform_sh_standalone .col-xxl-auto, .platform_sh_standalone .col-xxxl-1, .platform_sh_standalone .col-xxxl-2, .platform_sh_standalone .col-xxxl-3, .platform_sh_standalone .col-xxxl-4, .platform_sh_standalone .col-xxxl-5, .platform_sh_standalone .col-xxxl-6, .platform_sh_standalone .col-xxxl-7, .platform_sh_standalone .col-xxxl-8, .platform_sh_standalone .col-xxxl-9, .platform_sh_standalone .col-xxxl-10, .platform_sh_standalone .col-xxxl-11, .platform_sh_standalone .col-xxxl-12, .platform_sh_standalone .col-xxxl,
+.platform_sh_standalone .col-xxxl-auto {
+  position: relative;
+  width: 100%;
+  padding-right: 20px;
+  padding-left: 20px; }
+.platform_sh_standalone .col {
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%; }
+.platform_sh_standalone .col-auto {
+  flex: 0 0 auto;
+  width: auto;
+  max-width: 100%; }
+.platform_sh_standalone .col-1 {
+  flex: 0 0 8.3333333333%;
+  max-width: 8.3333333333%; }
+.platform_sh_standalone .col-2 {
+  flex: 0 0 16.6666666667%;
+  max-width: 16.6666666667%; }
+.platform_sh_standalone .col-3 {
+  flex: 0 0 25%;
+  max-width: 25%; }
+.platform_sh_standalone .col-4 {
+  flex: 0 0 33.3333333333%;
+  max-width: 33.3333333333%; }
+.platform_sh_standalone .col-5 {
+  flex: 0 0 41.6666666667%;
+  max-width: 41.6666666667%; }
+.platform_sh_standalone .col-6 {
+  flex: 0 0 50%;
+  max-width: 50%; }
+.platform_sh_standalone .col-7 {
+  flex: 0 0 58.3333333333%;
+  max-width: 58.3333333333%; }
+.platform_sh_standalone .col-8 {
+  flex: 0 0 66.6666666667%;
+  max-width: 66.6666666667%; }
+.platform_sh_standalone .col-9 {
+  flex: 0 0 75%;
+  max-width: 75%; }
+.platform_sh_standalone .col-10 {
+  flex: 0 0 83.3333333333%;
+  max-width: 83.3333333333%; }
+.platform_sh_standalone .col-11 {
+  flex: 0 0 91.6666666667%;
+  max-width: 91.6666666667%; }
+.platform_sh_standalone .col-12 {
+  flex: 0 0 100%;
+  max-width: 100%; }
+.platform_sh_standalone .order-first {
+  order: -1; }
+.platform_sh_standalone .order-last {
+  order: 13; }
+.platform_sh_standalone .order-0 {
+  order: 0; }
+.platform_sh_standalone .order-1 {
+  order: 1; }
+.platform_sh_standalone .order-2 {
+  order: 2; }
+.platform_sh_standalone .order-3 {
+  order: 3; }
+.platform_sh_standalone .order-4 {
+  order: 4; }
+.platform_sh_standalone .order-5 {
+  order: 5; }
+.platform_sh_standalone .order-6 {
+  order: 6; }
+.platform_sh_standalone .order-7 {
+  order: 7; }
+.platform_sh_standalone .order-8 {
+  order: 8; }
+.platform_sh_standalone .order-9 {
+  order: 9; }
+.platform_sh_standalone .order-10 {
+  order: 10; }
+.platform_sh_standalone .order-11 {
+  order: 11; }
+.platform_sh_standalone .order-12 {
+  order: 12; }
+.platform_sh_standalone .offset-1 {
+  margin-left: 8.3333333333%; }
+.platform_sh_standalone .offset-2 {
+  margin-left: 16.6666666667%; }
+.platform_sh_standalone .offset-3 {
+  margin-left: 25%; }
+.platform_sh_standalone .offset-4 {
+  margin-left: 33.3333333333%; }
+.platform_sh_standalone .offset-5 {
+  margin-left: 41.6666666667%; }
+.platform_sh_standalone .offset-6 {
+  margin-left: 50%; }
+.platform_sh_standalone .offset-7 {
+  margin-left: 58.3333333333%; }
+.platform_sh_standalone .offset-8 {
+  margin-left: 66.6666666667%; }
+.platform_sh_standalone .offset-9 {
+  margin-left: 75%; }
+.platform_sh_standalone .offset-10 {
+  margin-left: 83.3333333333%; }
+.platform_sh_standalone .offset-11 {
+  margin-left: 91.6666666667%; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .col-xxs {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xxs-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xxs-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-xxs-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-xxs-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-xxs-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-xxs-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-xxs-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-xxs-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-xxs-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-xxs-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-xxs-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-xxs-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-xxs-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-xxs-first {
+    order: -1; }
+  .platform_sh_standalone .order-xxs-last {
+    order: 13; }
+  .platform_sh_standalone .order-xxs-0 {
+    order: 0; }
+  .platform_sh_standalone .order-xxs-1 {
+    order: 1; }
+  .platform_sh_standalone .order-xxs-2 {
+    order: 2; }
+  .platform_sh_standalone .order-xxs-3 {
+    order: 3; }
+  .platform_sh_standalone .order-xxs-4 {
+    order: 4; }
+  .platform_sh_standalone .order-xxs-5 {
+    order: 5; }
+  .platform_sh_standalone .order-xxs-6 {
+    order: 6; }
+  .platform_sh_standalone .order-xxs-7 {
+    order: 7; }
+  .platform_sh_standalone .order-xxs-8 {
+    order: 8; }
+  .platform_sh_standalone .order-xxs-9 {
+    order: 9; }
+  .platform_sh_standalone .order-xxs-10 {
+    order: 10; }
+  .platform_sh_standalone .order-xxs-11 {
+    order: 11; }
+  .platform_sh_standalone .order-xxs-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-xxs-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-xxs-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-xxs-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-xxs-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-xxs-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-xxs-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-xxs-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-xxs-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-xxs-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-xxs-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-xxs-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-xxs-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .col-xs {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xs-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xs-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-xs-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-xs-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-xs-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-xs-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-xs-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-xs-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-xs-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-xs-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-xs-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-xs-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-xs-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-xs-first {
+    order: -1; }
+  .platform_sh_standalone .order-xs-last {
+    order: 13; }
+  .platform_sh_standalone .order-xs-0 {
+    order: 0; }
+  .platform_sh_standalone .order-xs-1 {
+    order: 1; }
+  .platform_sh_standalone .order-xs-2 {
+    order: 2; }
+  .platform_sh_standalone .order-xs-3 {
+    order: 3; }
+  .platform_sh_standalone .order-xs-4 {
+    order: 4; }
+  .platform_sh_standalone .order-xs-5 {
+    order: 5; }
+  .platform_sh_standalone .order-xs-6 {
+    order: 6; }
+  .platform_sh_standalone .order-xs-7 {
+    order: 7; }
+  .platform_sh_standalone .order-xs-8 {
+    order: 8; }
+  .platform_sh_standalone .order-xs-9 {
+    order: 9; }
+  .platform_sh_standalone .order-xs-10 {
+    order: 10; }
+  .platform_sh_standalone .order-xs-11 {
+    order: 11; }
+  .platform_sh_standalone .order-xs-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-xs-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-xs-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-xs-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-xs-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-xs-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-xs-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-xs-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-xs-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-xs-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-xs-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-xs-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-xs-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .col-sm {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-sm-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-sm-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-sm-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-sm-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-sm-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-sm-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-sm-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-sm-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-sm-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-sm-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-sm-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-sm-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-sm-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-sm-first {
+    order: -1; }
+  .platform_sh_standalone .order-sm-last {
+    order: 13; }
+  .platform_sh_standalone .order-sm-0 {
+    order: 0; }
+  .platform_sh_standalone .order-sm-1 {
+    order: 1; }
+  .platform_sh_standalone .order-sm-2 {
+    order: 2; }
+  .platform_sh_standalone .order-sm-3 {
+    order: 3; }
+  .platform_sh_standalone .order-sm-4 {
+    order: 4; }
+  .platform_sh_standalone .order-sm-5 {
+    order: 5; }
+  .platform_sh_standalone .order-sm-6 {
+    order: 6; }
+  .platform_sh_standalone .order-sm-7 {
+    order: 7; }
+  .platform_sh_standalone .order-sm-8 {
+    order: 8; }
+  .platform_sh_standalone .order-sm-9 {
+    order: 9; }
+  .platform_sh_standalone .order-sm-10 {
+    order: 10; }
+  .platform_sh_standalone .order-sm-11 {
+    order: 11; }
+  .platform_sh_standalone .order-sm-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-sm-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-sm-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-sm-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-sm-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-sm-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-sm-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-sm-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-sm-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-sm-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-sm-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-sm-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-sm-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .col-md {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-md-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-md-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-md-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-md-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-md-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-md-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-md-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-md-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-md-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-md-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-md-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-md-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-md-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-md-first {
+    order: -1; }
+  .platform_sh_standalone .order-md-last {
+    order: 13; }
+  .platform_sh_standalone .order-md-0 {
+    order: 0; }
+  .platform_sh_standalone .order-md-1 {
+    order: 1; }
+  .platform_sh_standalone .order-md-2 {
+    order: 2; }
+  .platform_sh_standalone .order-md-3 {
+    order: 3; }
+  .platform_sh_standalone .order-md-4 {
+    order: 4; }
+  .platform_sh_standalone .order-md-5 {
+    order: 5; }
+  .platform_sh_standalone .order-md-6 {
+    order: 6; }
+  .platform_sh_standalone .order-md-7 {
+    order: 7; }
+  .platform_sh_standalone .order-md-8 {
+    order: 8; }
+  .platform_sh_standalone .order-md-9 {
+    order: 9; }
+  .platform_sh_standalone .order-md-10 {
+    order: 10; }
+  .platform_sh_standalone .order-md-11 {
+    order: 11; }
+  .platform_sh_standalone .order-md-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-md-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-md-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-md-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-md-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-md-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-md-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-md-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-md-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-md-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-md-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-md-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-md-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .col-lg {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-lg-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-lg-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-lg-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-lg-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-lg-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-lg-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-lg-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-lg-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-lg-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-lg-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-lg-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-lg-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-lg-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-lg-first {
+    order: -1; }
+  .platform_sh_standalone .order-lg-last {
+    order: 13; }
+  .platform_sh_standalone .order-lg-0 {
+    order: 0; }
+  .platform_sh_standalone .order-lg-1 {
+    order: 1; }
+  .platform_sh_standalone .order-lg-2 {
+    order: 2; }
+  .platform_sh_standalone .order-lg-3 {
+    order: 3; }
+  .platform_sh_standalone .order-lg-4 {
+    order: 4; }
+  .platform_sh_standalone .order-lg-5 {
+    order: 5; }
+  .platform_sh_standalone .order-lg-6 {
+    order: 6; }
+  .platform_sh_standalone .order-lg-7 {
+    order: 7; }
+  .platform_sh_standalone .order-lg-8 {
+    order: 8; }
+  .platform_sh_standalone .order-lg-9 {
+    order: 9; }
+  .platform_sh_standalone .order-lg-10 {
+    order: 10; }
+  .platform_sh_standalone .order-lg-11 {
+    order: 11; }
+  .platform_sh_standalone .order-lg-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-lg-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-lg-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-lg-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-lg-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-lg-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-lg-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-lg-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-lg-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-lg-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-lg-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-lg-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-lg-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .col-xl {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xl-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-xl-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-xl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-xl-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-xl-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-xl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-xl-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-xl-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-xl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-xl-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-xl-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-xl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-xl-first {
+    order: -1; }
+  .platform_sh_standalone .order-xl-last {
+    order: 13; }
+  .platform_sh_standalone .order-xl-0 {
+    order: 0; }
+  .platform_sh_standalone .order-xl-1 {
+    order: 1; }
+  .platform_sh_standalone .order-xl-2 {
+    order: 2; }
+  .platform_sh_standalone .order-xl-3 {
+    order: 3; }
+  .platform_sh_standalone .order-xl-4 {
+    order: 4; }
+  .platform_sh_standalone .order-xl-5 {
+    order: 5; }
+  .platform_sh_standalone .order-xl-6 {
+    order: 6; }
+  .platform_sh_standalone .order-xl-7 {
+    order: 7; }
+  .platform_sh_standalone .order-xl-8 {
+    order: 8; }
+  .platform_sh_standalone .order-xl-9 {
+    order: 9; }
+  .platform_sh_standalone .order-xl-10 {
+    order: 10; }
+  .platform_sh_standalone .order-xl-11 {
+    order: 11; }
+  .platform_sh_standalone .order-xl-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-xl-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-xl-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-xl-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-xl-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-xl-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-xl-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-xl-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-xl-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-xl-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-xl-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-xl-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-xl-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .col-xxl {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xxl-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-xxl-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-xxl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-xxl-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-xxl-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-xxl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-xxl-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-xxl-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-xxl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-xxl-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-xxl-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-xxl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-xxl-first {
+    order: -1; }
+  .platform_sh_standalone .order-xxl-last {
+    order: 13; }
+  .platform_sh_standalone .order-xxl-0 {
+    order: 0; }
+  .platform_sh_standalone .order-xxl-1 {
+    order: 1; }
+  .platform_sh_standalone .order-xxl-2 {
+    order: 2; }
+  .platform_sh_standalone .order-xxl-3 {
+    order: 3; }
+  .platform_sh_standalone .order-xxl-4 {
+    order: 4; }
+  .platform_sh_standalone .order-xxl-5 {
+    order: 5; }
+  .platform_sh_standalone .order-xxl-6 {
+    order: 6; }
+  .platform_sh_standalone .order-xxl-7 {
+    order: 7; }
+  .platform_sh_standalone .order-xxl-8 {
+    order: 8; }
+  .platform_sh_standalone .order-xxl-9 {
+    order: 9; }
+  .platform_sh_standalone .order-xxl-10 {
+    order: 10; }
+  .platform_sh_standalone .order-xxl-11 {
+    order: 11; }
+  .platform_sh_standalone .order-xxl-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-xxl-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-xxl-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-xxl-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-xxl-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-xxl-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-xxl-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-xxl-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-xxl-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-xxl-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-xxl-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-xxl-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-xxl-11 {
+    margin-left: 91.6666666667%; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .col-xxxl {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xxxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%; }
+  .platform_sh_standalone .col-xxxl-1 {
+    flex: 0 0 8.3333333333%;
+    max-width: 8.3333333333%; }
+  .platform_sh_standalone .col-xxxl-2 {
+    flex: 0 0 16.6666666667%;
+    max-width: 16.6666666667%; }
+  .platform_sh_standalone .col-xxxl-3 {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .platform_sh_standalone .col-xxxl-4 {
+    flex: 0 0 33.3333333333%;
+    max-width: 33.3333333333%; }
+  .platform_sh_standalone .col-xxxl-5 {
+    flex: 0 0 41.6666666667%;
+    max-width: 41.6666666667%; }
+  .platform_sh_standalone .col-xxxl-6 {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .platform_sh_standalone .col-xxxl-7 {
+    flex: 0 0 58.3333333333%;
+    max-width: 58.3333333333%; }
+  .platform_sh_standalone .col-xxxl-8 {
+    flex: 0 0 66.6666666667%;
+    max-width: 66.6666666667%; }
+  .platform_sh_standalone .col-xxxl-9 {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .platform_sh_standalone .col-xxxl-10 {
+    flex: 0 0 83.3333333333%;
+    max-width: 83.3333333333%; }
+  .platform_sh_standalone .col-xxxl-11 {
+    flex: 0 0 91.6666666667%;
+    max-width: 91.6666666667%; }
+  .platform_sh_standalone .col-xxxl-12 {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .platform_sh_standalone .order-xxxl-first {
+    order: -1; }
+  .platform_sh_standalone .order-xxxl-last {
+    order: 13; }
+  .platform_sh_standalone .order-xxxl-0 {
+    order: 0; }
+  .platform_sh_standalone .order-xxxl-1 {
+    order: 1; }
+  .platform_sh_standalone .order-xxxl-2 {
+    order: 2; }
+  .platform_sh_standalone .order-xxxl-3 {
+    order: 3; }
+  .platform_sh_standalone .order-xxxl-4 {
+    order: 4; }
+  .platform_sh_standalone .order-xxxl-5 {
+    order: 5; }
+  .platform_sh_standalone .order-xxxl-6 {
+    order: 6; }
+  .platform_sh_standalone .order-xxxl-7 {
+    order: 7; }
+  .platform_sh_standalone .order-xxxl-8 {
+    order: 8; }
+  .platform_sh_standalone .order-xxxl-9 {
+    order: 9; }
+  .platform_sh_standalone .order-xxxl-10 {
+    order: 10; }
+  .platform_sh_standalone .order-xxxl-11 {
+    order: 11; }
+  .platform_sh_standalone .order-xxxl-12 {
+    order: 12; }
+  .platform_sh_standalone .offset-xxxl-0 {
+    margin-left: 0; }
+  .platform_sh_standalone .offset-xxxl-1 {
+    margin-left: 8.3333333333%; }
+  .platform_sh_standalone .offset-xxxl-2 {
+    margin-left: 16.6666666667%; }
+  .platform_sh_standalone .offset-xxxl-3 {
+    margin-left: 25%; }
+  .platform_sh_standalone .offset-xxxl-4 {
+    margin-left: 33.3333333333%; }
+  .platform_sh_standalone .offset-xxxl-5 {
+    margin-left: 41.6666666667%; }
+  .platform_sh_standalone .offset-xxxl-6 {
+    margin-left: 50%; }
+  .platform_sh_standalone .offset-xxxl-7 {
+    margin-left: 58.3333333333%; }
+  .platform_sh_standalone .offset-xxxl-8 {
+    margin-left: 66.6666666667%; }
+  .platform_sh_standalone .offset-xxxl-9 {
+    margin-left: 75%; }
+  .platform_sh_standalone .offset-xxxl-10 {
+    margin-left: 83.3333333333%; }
+  .platform_sh_standalone .offset-xxxl-11 {
+    margin-left: 91.6666666667%; } }
+.platform_sh_standalone .table {
+  width: 100%;
+  margin-bottom: 1rem;
+  color: #49475F; }
+.platform_sh_standalone .table th,
+.platform_sh_standalone .table td {
+  padding: 0.75rem;
+  vertical-align: top;
+  border-top: 1px solid #dee2e6; }
+.platform_sh_standalone .table thead th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #dee2e6; }
+.platform_sh_standalone .table tbody + tbody {
+  border-top: 2px solid #dee2e6; }
+.platform_sh_standalone .table-sm th,
+.platform_sh_standalone .table-sm td {
+  padding: 0.3rem; }
+.platform_sh_standalone .table-bordered {
+  border: 1px solid #dee2e6; }
+.platform_sh_standalone .table-bordered th,
+.platform_sh_standalone .table-bordered td {
+  border: 1px solid #dee2e6; }
+.platform_sh_standalone .table-bordered thead th,
+.platform_sh_standalone .table-bordered thead td {
+  border-bottom-width: 2px; }
+.platform_sh_standalone .table-borderless th,
+.platform_sh_standalone .table-borderless td,
+.platform_sh_standalone .table-borderless thead th,
+.platform_sh_standalone .table-borderless tbody + tbody {
+  border: 0; }
+.platform_sh_standalone .table-striped tbody tr:nth-of-type(odd) {
+  background-color: rgba(0, 0, 0, 0.05); }
+.platform_sh_standalone .table-hover tbody tr:hover {
+  color: #49475F;
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table-primary,
+.platform_sh_standalone .table-primary > th,
+.platform_sh_standalone .table-primary > td {
+  background-color: #bdd1ef; }
+.platform_sh_standalone .table-primary th,
+.platform_sh_standalone .table-primary td,
+.platform_sh_standalone .table-primary thead th,
+.platform_sh_standalone .table-primary tbody + tbody {
+  border-color: #85aae1; }
+.platform_sh_standalone .table-hover .table-primary:hover {
+  background-color: #a8c3ea; }
+.platform_sh_standalone .table-hover .table-primary:hover > td,
+.platform_sh_standalone .table-hover .table-primary:hover > th {
+  background-color: #a8c3ea; }
+.platform_sh_standalone .table-secondary,
+.platform_sh_standalone .table-secondary > th,
+.platform_sh_standalone .table-secondary > td {
+  background-color: #d6d8db; }
+.platform_sh_standalone .table-secondary th,
+.platform_sh_standalone .table-secondary td,
+.platform_sh_standalone .table-secondary thead th,
+.platform_sh_standalone .table-secondary tbody + tbody {
+  border-color: #b3b7bb; }
+.platform_sh_standalone .table-hover .table-secondary:hover {
+  background-color: #c8cbcf; }
+.platform_sh_standalone .table-hover .table-secondary:hover > td,
+.platform_sh_standalone .table-hover .table-secondary:hover > th {
+  background-color: #c8cbcf; }
+.platform_sh_standalone .table-success,
+.platform_sh_standalone .table-success > th,
+.platform_sh_standalone .table-success > td {
+  background-color: #c3e6cb; }
+.platform_sh_standalone .table-success th,
+.platform_sh_standalone .table-success td,
+.platform_sh_standalone .table-success thead th,
+.platform_sh_standalone .table-success tbody + tbody {
+  border-color: #8fd19e; }
+.platform_sh_standalone .table-hover .table-success:hover {
+  background-color: #b1dfbb; }
+.platform_sh_standalone .table-hover .table-success:hover > td,
+.platform_sh_standalone .table-hover .table-success:hover > th {
+  background-color: #b1dfbb; }
+.platform_sh_standalone .table-info,
+.platform_sh_standalone .table-info > th,
+.platform_sh_standalone .table-info > td {
+  background-color: #bee5eb; }
+.platform_sh_standalone .table-info th,
+.platform_sh_standalone .table-info td,
+.platform_sh_standalone .table-info thead th,
+.platform_sh_standalone .table-info tbody + tbody {
+  border-color: #86cfda; }
+.platform_sh_standalone .table-hover .table-info:hover {
+  background-color: #abdde5; }
+.platform_sh_standalone .table-hover .table-info:hover > td,
+.platform_sh_standalone .table-hover .table-info:hover > th {
+  background-color: #abdde5; }
+.platform_sh_standalone .table-warning,
+.platform_sh_standalone .table-warning > th,
+.platform_sh_standalone .table-warning > td {
+  background-color: #fcecc7; }
+.platform_sh_standalone .table-warning th,
+.platform_sh_standalone .table-warning td,
+.platform_sh_standalone .table-warning thead th,
+.platform_sh_standalone .table-warning tbody + tbody {
+  border-color: #f9db97; }
+.platform_sh_standalone .table-hover .table-warning:hover {
+  background-color: #fbe4af; }
+.platform_sh_standalone .table-hover .table-warning:hover > td,
+.platform_sh_standalone .table-hover .table-warning:hover > th {
+  background-color: #fbe4af; }
+.platform_sh_standalone .table-danger,
+.platform_sh_standalone .table-danger > th,
+.platform_sh_standalone .table-danger > td {
+  background-color: #f5c6cb; }
+.platform_sh_standalone .table-danger th,
+.platform_sh_standalone .table-danger td,
+.platform_sh_standalone .table-danger thead th,
+.platform_sh_standalone .table-danger tbody + tbody {
+  border-color: #ed969e; }
+.platform_sh_standalone .table-hover .table-danger:hover {
+  background-color: #f1b0b7; }
+.platform_sh_standalone .table-hover .table-danger:hover > td,
+.platform_sh_standalone .table-hover .table-danger:hover > th {
+  background-color: #f1b0b7; }
+.platform_sh_standalone .table-light,
+.platform_sh_standalone .table-light > th,
+.platform_sh_standalone .table-light > td {
+  background-color: #fdfdfe; }
+.platform_sh_standalone .table-light th,
+.platform_sh_standalone .table-light td,
+.platform_sh_standalone .table-light thead th,
+.platform_sh_standalone .table-light tbody + tbody {
+  border-color: #fbfcfc; }
+.platform_sh_standalone .table-hover .table-light:hover {
+  background-color: #ececf6; }
+.platform_sh_standalone .table-hover .table-light:hover > td,
+.platform_sh_standalone .table-hover .table-light:hover > th {
+  background-color: #ececf6; }
+.platform_sh_standalone .table-dark,
+.platform_sh_standalone .table-dark > th,
+.platform_sh_standalone .table-dark > td {
+  background-color: #c6c8ca; }
+.platform_sh_standalone .table-dark th,
+.platform_sh_standalone .table-dark td,
+.platform_sh_standalone .table-dark thead th,
+.platform_sh_standalone .table-dark tbody + tbody {
+  border-color: #95999c; }
+.platform_sh_standalone .table-hover .table-dark:hover {
+  background-color: #b9bbbe; }
+.platform_sh_standalone .table-hover .table-dark:hover > td,
+.platform_sh_standalone .table-hover .table-dark:hover > th {
+  background-color: #b9bbbe; }
+.platform_sh_standalone .table-active,
+.platform_sh_standalone .table-active > th,
+.platform_sh_standalone .table-active > td {
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table-hover .table-active:hover {
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table-hover .table-active:hover > td,
+.platform_sh_standalone .table-hover .table-active:hover > th {
+  background-color: rgba(0, 0, 0, 0.075); }
+.platform_sh_standalone .table .thead-dark th {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #454d55; }
+.platform_sh_standalone .table .thead-light th {
+  color: #495057;
+  background-color: #e9ecef;
+  border-color: #dee2e6; }
+.platform_sh_standalone .table-dark {
+  color: #fff;
+  background-color: #343a40; }
+.platform_sh_standalone .table-dark th,
+.platform_sh_standalone .table-dark td,
+.platform_sh_standalone .table-dark thead th {
+  border-color: #454d55; }
+.platform_sh_standalone .table-dark.table-bordered {
+  border: 0; }
+.platform_sh_standalone .table-dark.table-striped tbody tr:nth-of-type(odd) {
+  background-color: rgba(255, 255, 255, 0.05); }
+.platform_sh_standalone .table-dark.table-hover tbody tr:hover {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.075); }
+@media (max-width: 319.98px) {
+  .platform_sh_standalone .table-responsive-xxs {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-xxs > .table-bordered {
+    border: 0; } }
+@media (max-width: 413.98px) {
+  .platform_sh_standalone .table-responsive-xs {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-xs > .table-bordered {
+    border: 0; } }
+@media (max-width: 666.98px) {
+  .platform_sh_standalone .table-responsive-sm {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-sm > .table-bordered {
+    border: 0; } }
+@media (max-width: 767.98px) {
+  .platform_sh_standalone .table-responsive-md {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-md > .table-bordered {
+    border: 0; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .table-responsive-lg {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-lg > .table-bordered {
+    border: 0; } }
+@media (max-width: 1199.98px) {
+  .platform_sh_standalone .table-responsive-xl {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-xl > .table-bordered {
+    border: 0; } }
+@media (max-width: 1439.98px) {
+  .platform_sh_standalone .table-responsive-xxl {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-xxl > .table-bordered {
+    border: 0; } }
+@media (max-width: 1599.98px) {
+  .platform_sh_standalone .table-responsive-xxxl {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; }
+  .platform_sh_standalone .table-responsive-xxxl > .table-bordered {
+    border: 0; } }
+.platform_sh_standalone .table-responsive {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch; }
+.platform_sh_standalone .table-responsive > .table-bordered {
+  border: 0; }
+.platform_sh_standalone .form-control {
+  display: block;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid #ced4da;
+  border-radius: 0;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .form-control {
+    transition: none; } }
+.platform_sh_standalone .form-control::-ms-expand {
+  background-color: transparent;
+  border: 0; }
+.platform_sh_standalone .form-control:focus {
+  color: #495057;
+  background-color: #fff;
+  border-color: #6aa0f0;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .form-control::placeholder {
+  color: #6c757d;
+  opacity: 1; }
+.platform_sh_standalone .form-control:disabled, .platform_sh_standalone .form-control[readonly] {
+  background-color: #e9ecef;
+  opacity: 1; }
+.platform_sh_standalone select.form-control:focus::-ms-value {
+  color: #495057;
+  background-color: #fff; }
+.platform_sh_standalone .form-control-file,
+.platform_sh_standalone .form-control-range {
+  display: block;
+  width: 100%; }
+.platform_sh_standalone .col-form-label {
+  padding-top: calc(0.375rem + 1px);
+  padding-bottom: calc(0.375rem + 1px);
+  margin-bottom: 0;
+  font-size: inherit;
+  line-height: 1; }
+.platform_sh_standalone .col-form-label-lg {
+  padding-top: calc(0.5rem + 1px);
+  padding-bottom: calc(0.5rem + 1px);
+  font-size: 1.25rem;
+  line-height: 1.5; }
+.platform_sh_standalone .col-form-label-sm {
+  padding-top: calc(0.25rem + 1px);
+  padding-bottom: calc(0.25rem + 1px);
+  font-size: 0.875rem;
+  line-height: 1.5; }
+.platform_sh_standalone .form-control-plaintext {
+  display: block;
+  width: 100%;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  margin-bottom: 0;
+  line-height: 1;
+  color: #49475F;
+  background-color: transparent;
+  border: solid transparent;
+  border-width: 1px 0; }
+.platform_sh_standalone .form-control-plaintext.form-control-sm, .platform_sh_standalone .form-control-plaintext.form-control-lg {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .form-control-sm {
+  height: calc(1.5em + 0.5rem + 2px);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .form-control-lg {
+  height: calc(1.5em + 1rem + 2px);
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone select.form-control[size], .platform_sh_standalone select.form-control[multiple] {
+  height: auto; }
+.platform_sh_standalone textarea.form-control {
+  height: auto; }
+.platform_sh_standalone .form-group {
+  margin-bottom: 1rem; }
+.platform_sh_standalone .form-text {
+  display: block;
+  margin-top: 0.25rem; }
+.platform_sh_standalone .form-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -5px;
+  margin-left: -5px; }
+.platform_sh_standalone .form-row > .col,
+.platform_sh_standalone .form-row > [class*="col-"] {
+  padding-right: 5px;
+  padding-left: 5px; }
+.platform_sh_standalone .form-check {
+  position: relative;
+  display: block;
+  padding-left: 1.25rem; }
+.platform_sh_standalone .form-check-input {
+  position: absolute;
+  margin-top: 0.3rem;
+  margin-left: -1.25rem; }
+.platform_sh_standalone .form-check-input:disabled ~ .form-check-label {
+  color: #6c757d; }
+.platform_sh_standalone .form-check-label {
+  margin-bottom: 0; }
+.platform_sh_standalone .form-check-inline {
+  display: inline-flex;
+  align-items: center;
+  padding-left: 0;
+  margin-right: 0.75rem; }
+.platform_sh_standalone .form-check-inline .form-check-input {
+  position: static;
+  margin-top: 0;
+  margin-right: 0.3125rem;
+  margin-left: 0; }
+.platform_sh_standalone .valid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #28a745; }
+.platform_sh_standalone .valid-tooltip {
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+  display: none;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin-top: .1rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: #fff;
+  background-color: rgba(40, 167, 69, 0.9);
+  border-radius: 0; }
+.was-validated .platform_sh_standalone .form-control:valid, .platform_sh_standalone .form-control.is-valid {
+  border-color: #28a745;
+  padding-right: calc(1em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: center right calc(0.25em + 0.1875rem);
+  background-size: calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .form-control:valid:focus, .platform_sh_standalone .form-control.is-valid:focus {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.was-validated .platform_sh_standalone .form-control:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .form-control:valid ~ .valid-tooltip, .platform_sh_standalone .form-control.is-valid ~ .valid-feedback,
+.platform_sh_standalone .form-control.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone textarea.form-control:valid, .platform_sh_standalone textarea.form-control.is-valid {
+  padding-right: calc(1em + 0.75rem);
+  background-position: top calc(0.25em + 0.1875rem) right calc(0.25em + 0.1875rem); }
+.was-validated .platform_sh_standalone .custom-select:valid, .platform_sh_standalone .custom-select.is-valid {
+  border-color: #28a745;
+  padding-right: calc((1em + 0.75rem) * 3 / 4 + 1.75rem);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") #fff no-repeat center right 1.75rem/calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .custom-select:valid:focus, .platform_sh_standalone .custom-select.is-valid:focus {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-select:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .custom-select:valid ~ .valid-tooltip, .platform_sh_standalone .custom-select.is-valid ~ .valid-feedback,
+.platform_sh_standalone .custom-select.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-control-file:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .form-control-file:valid ~ .valid-tooltip, .platform_sh_standalone .form-control-file.is-valid ~ .valid-feedback,
+.platform_sh_standalone .form-control-file.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-check-input:valid ~ .form-check-label, .platform_sh_standalone .form-check-input.is-valid ~ .form-check-label {
+  color: #28a745; }
+.was-validated .platform_sh_standalone .form-check-input:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .form-check-input:valid ~ .valid-tooltip, .platform_sh_standalone .form-check-input.is-valid ~ .valid-feedback,
+.platform_sh_standalone .form-check-input.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .custom-control-label, .platform_sh_standalone .custom-control-input.is-valid ~ .custom-control-label {
+  color: #28a745; }
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid ~ .custom-control-label::before {
+  border-color: #28a745; }
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .custom-control-input:valid ~ .valid-tooltip, .platform_sh_standalone .custom-control-input.is-valid ~ .valid-feedback,
+.platform_sh_standalone .custom-control-input.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:valid:checked ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid:checked ~ .custom-control-label::before {
+  border-color: #34ce57;
+  background-color: #34ce57; }
+.was-validated .platform_sh_standalone .custom-control-input:valid:focus ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-control-input:valid:focus:not(:checked) ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-valid:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #28a745; }
+.was-validated .platform_sh_standalone .custom-file-input:valid ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-valid ~ .custom-file-label {
+  border-color: #28a745; }
+.was-validated .platform_sh_standalone .custom-file-input:valid ~ .valid-feedback,
+.was-validated .platform_sh_standalone .custom-file-input:valid ~ .valid-tooltip, .platform_sh_standalone .custom-file-input.is-valid ~ .valid-feedback,
+.platform_sh_standalone .custom-file-input.is-valid ~ .valid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-file-input:valid:focus ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-valid:focus ~ .custom-file-label {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+.platform_sh_standalone .invalid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #dc3545; }
+.platform_sh_standalone .invalid-tooltip {
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+  display: none;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin-top: .1rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: #fff;
+  background-color: rgba(220, 53, 69, 0.9);
+  border-radius: 0; }
+.was-validated .platform_sh_standalone .form-control:invalid, .platform_sh_standalone .form-control.is-invalid {
+  border-color: #dc3545;
+  padding-right: calc(1em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23dc3545' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23dc3545' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center right calc(0.25em + 0.1875rem);
+  background-size: calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .form-control:invalid:focus, .platform_sh_standalone .form-control.is-invalid:focus {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.was-validated .platform_sh_standalone .form-control:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .form-control:invalid ~ .invalid-tooltip, .platform_sh_standalone .form-control.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .form-control.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone textarea.form-control:invalid, .platform_sh_standalone textarea.form-control.is-invalid {
+  padding-right: calc(1em + 0.75rem);
+  background-position: top calc(0.25em + 0.1875rem) right calc(0.25em + 0.1875rem); }
+.was-validated .platform_sh_standalone .custom-select:invalid, .platform_sh_standalone .custom-select.is-invalid {
+  border-color: #dc3545;
+  padding-right: calc((1em + 0.75rem) * 3 / 4 + 1.75rem);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px, url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23dc3545' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23dc3545' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E") #fff no-repeat center right 1.75rem/calc(0.5em + 0.375rem) calc(0.5em + 0.375rem); }
+.was-validated .platform_sh_standalone .custom-select:invalid:focus, .platform_sh_standalone .custom-select.is-invalid:focus {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-select:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .custom-select:invalid ~ .invalid-tooltip, .platform_sh_standalone .custom-select.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .custom-select.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-control-file:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .form-control-file:invalid ~ .invalid-tooltip, .platform_sh_standalone .form-control-file.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .form-control-file.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .form-check-input:invalid ~ .form-check-label, .platform_sh_standalone .form-check-input.is-invalid ~ .form-check-label {
+  color: #dc3545; }
+.was-validated .platform_sh_standalone .form-check-input:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .form-check-input:invalid ~ .invalid-tooltip, .platform_sh_standalone .form-check-input.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .form-check-input.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .custom-control-label, .platform_sh_standalone .custom-control-input.is-invalid ~ .custom-control-label {
+  color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid ~ .custom-control-label::before {
+  border-color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .custom-control-input:invalid ~ .invalid-tooltip, .platform_sh_standalone .custom-control-input.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .custom-control-input.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid:checked ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid:checked ~ .custom-control-label::before {
+  border-color: #e4606d;
+  background-color: #e4606d; }
+.was-validated .platform_sh_standalone .custom-control-input:invalid:focus ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.was-validated .platform_sh_standalone .custom-control-input:invalid:focus:not(:checked) ~ .custom-control-label::before, .platform_sh_standalone .custom-control-input.is-invalid:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-file-input:invalid ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-invalid ~ .custom-file-label {
+  border-color: #dc3545; }
+.was-validated .platform_sh_standalone .custom-file-input:invalid ~ .invalid-feedback,
+.was-validated .platform_sh_standalone .custom-file-input:invalid ~ .invalid-tooltip, .platform_sh_standalone .custom-file-input.is-invalid ~ .invalid-feedback,
+.platform_sh_standalone .custom-file-input.is-invalid ~ .invalid-tooltip {
+  display: block; }
+.was-validated .platform_sh_standalone .custom-file-input:invalid:focus ~ .custom-file-label, .platform_sh_standalone .custom-file-input.is-invalid:focus ~ .custom-file-label {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+.platform_sh_standalone .form-inline {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center; }
+.platform_sh_standalone .form-inline .form-check {
+  width: 100%; }
+@media (min-width: 667px) {
+  .platform_sh_standalone .form-inline label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 0; }
+  .platform_sh_standalone .form-inline .form-group {
+    display: flex;
+    flex: 0 0 auto;
+    flex-flow: row wrap;
+    align-items: center;
+    margin-bottom: 0; }
+  .platform_sh_standalone .form-inline .form-control {
+    display: inline-block;
+    width: auto;
+    vertical-align: middle; }
+  .platform_sh_standalone .form-inline .form-control-plaintext {
+    display: inline-block; }
+  .platform_sh_standalone .form-inline .input-group,
+  .platform_sh_standalone .form-inline .custom-select {
+    width: auto; }
+  .platform_sh_standalone .form-inline .form-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: auto;
+    padding-left: 0; }
+  .platform_sh_standalone .form-inline .form-check-input {
+    position: relative;
+    flex-shrink: 0;
+    margin-top: 0;
+    margin-right: 0.25rem;
+    margin-left: 0; }
+  .platform_sh_standalone .form-inline .custom-control {
+    align-items: center;
+    justify-content: center; }
+  .platform_sh_standalone .form-inline .custom-control-label {
+    margin-bottom: 0; } }
+.platform_sh_standalone .btn, .platform_sh_standalone #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .user-widget__free-trial {
+  display: inline-block;
+  font-weight: 400;
+  color: #49475F;
+  text-align: center;
+  vertical-align: middle;
+  user-select: none;
+  background-color: transparent;
+  border: 0 solid transparent;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  line-height: 1;
+  border-radius: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .btn, .platform_sh_standalone #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .user-widget__free-trial {
+    transition: none; } }
+.platform_sh_standalone .btn:hover, .platform_sh_standalone #user-widget .user-widget__log-in:hover, .platform_sh_standalone #user-widget .user-widget__free-trial:hover {
+  color: #49475F;
+  text-decoration: none; }
+.platform_sh_standalone .btn:focus, .platform_sh_standalone #user-widget .user-widget__log-in:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:focus, .platform_sh_standalone .btn.focus, .platform_sh_standalone #user-widget .focus.user-widget__log-in, .platform_sh_standalone #user-widget .focus.user-widget__free-trial {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .btn.disabled, .platform_sh_standalone #user-widget .disabled.user-widget__log-in, .platform_sh_standalone #user-widget .disabled.user-widget__free-trial, .platform_sh_standalone .btn:disabled, .platform_sh_standalone #user-widget .user-widget__log-in:disabled, .platform_sh_standalone #user-widget .user-widget__free-trial:disabled {
+  opacity: 0.65; }
+.platform_sh_standalone a.btn.disabled, .platform_sh_standalone #user-widget a.disabled.user-widget__log-in, .platform_sh_standalone #user-widget a.disabled.user-widget__free-trial,
+.platform_sh_standalone fieldset:disabled a.btn,
+.platform_sh_standalone fieldset:disabled #user-widget a.user-widget__log-in,
+.platform_sh_standalone #user-widget fieldset:disabled a.user-widget__log-in,
+.platform_sh_standalone fieldset:disabled #user-widget a.user-widget__free-trial,
+.platform_sh_standalone #user-widget fieldset:disabled a.user-widget__free-trial {
+  pointer-events: none; }
+.platform_sh_standalone .btn-primary, .platform_sh_standalone #user-widget .user-widget__free-trial {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-primary:hover, .platform_sh_standalone #user-widget .user-widget__free-trial:hover {
+  color: #fff;
+  background-color: #104ca3;
+  border-color: #0f4698; }
+.platform_sh_standalone .btn-primary:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:focus, .platform_sh_standalone .btn-primary.focus, .platform_sh_standalone #user-widget .focus.user-widget__free-trial {
+  box-shadow: 0 0 0 0.2rem rgba(55, 116, 207, 0.5); }
+.platform_sh_standalone .btn-primary.disabled, .platform_sh_standalone #user-widget .disabled.user-widget__free-trial, .platform_sh_standalone .btn-primary:disabled, .platform_sh_standalone #user-widget .user-widget__free-trial:disabled {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-primary:not(:disabled):not(.disabled):active, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-primary:not(:disabled):not(.disabled).active, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-primary.dropdown-toggle, .show > .platform_sh_standalone #user-widget .dropdown-toggle.user-widget__free-trial {
+  color: #fff;
+  background-color: #0f4698;
+  border-color: #0e418c; }
+.platform_sh_standalone .btn-primary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-primary:not(:disabled):not(.disabled).active:focus, .platform_sh_standalone #user-widget .user-widget__free-trial:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-primary.dropdown-toggle:focus, .show > .platform_sh_standalone #user-widget .dropdown-toggle.user-widget__free-trial:focus {
+  box-shadow: 0 0 0 0.2rem rgba(55, 116, 207, 0.5); }
+.platform_sh_standalone .btn-secondary {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-secondary:hover {
+  color: #fff;
+  background-color: #5a6268;
+  border-color: #545b62; }
+.platform_sh_standalone .btn-secondary:focus, .platform_sh_standalone .btn-secondary.focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5); }
+.platform_sh_standalone .btn-secondary.disabled, .platform_sh_standalone .btn-secondary:disabled {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-secondary.dropdown-toggle {
+  color: #fff;
+  background-color: #545b62;
+  border-color: #4e555b; }
+.platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-secondary:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-secondary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5); }
+.platform_sh_standalone .btn-success {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-success:hover {
+  color: #fff;
+  background-color: #218838;
+  border-color: #1e7e34; }
+.platform_sh_standalone .btn-success:focus, .platform_sh_standalone .btn-success.focus {
+  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5); }
+.platform_sh_standalone .btn-success.disabled, .platform_sh_standalone .btn-success:disabled {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-success:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-success:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-success.dropdown-toggle {
+  color: #fff;
+  background-color: #1e7e34;
+  border-color: #1c7430; }
+.platform_sh_standalone .btn-success:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-success:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-success.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5); }
+.platform_sh_standalone .btn-info {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-info:hover {
+  color: #fff;
+  background-color: #138496;
+  border-color: #117a8b; }
+.platform_sh_standalone .btn-info:focus, .platform_sh_standalone .btn-info.focus {
+  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5); }
+.platform_sh_standalone .btn-info.disabled, .platform_sh_standalone .btn-info:disabled {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-info:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-info:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-info.dropdown-toggle {
+  color: #fff;
+  background-color: #117a8b;
+  border-color: #10707f; }
+.platform_sh_standalone .btn-info:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-info:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-info.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5); }
+.platform_sh_standalone .btn-warning {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-warning:hover {
+  color: #212529;
+  background-color: #f2ad13;
+  border-color: #eba70d; }
+.platform_sh_standalone .btn-warning:focus, .platform_sh_standalone .btn-warning.focus {
+  box-shadow: 0 0 0 0.2rem rgba(212, 164, 53, 0.5); }
+.platform_sh_standalone .btn-warning.disabled, .platform_sh_standalone .btn-warning:disabled {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-warning:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-warning:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-warning.dropdown-toggle {
+  color: #212529;
+  background-color: #eba70d;
+  border-color: #df9e0c; }
+.platform_sh_standalone .btn-warning:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-warning:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-warning.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(212, 164, 53, 0.5); }
+.platform_sh_standalone .btn-danger {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-danger:hover {
+  color: #fff;
+  background-color: #c82333;
+  border-color: #bd2130; }
+.platform_sh_standalone .btn-danger:focus, .platform_sh_standalone .btn-danger.focus {
+  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5); }
+.platform_sh_standalone .btn-danger.disabled, .platform_sh_standalone .btn-danger:disabled {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-danger:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-danger:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-danger.dropdown-toggle {
+  color: #fff;
+  background-color: #bd2130;
+  border-color: #b21f2d; }
+.platform_sh_standalone .btn-danger:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-danger:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-danger.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5); }
+.platform_sh_standalone .btn-light {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-light:hover {
+  color: #212529;
+  background-color: #e2e6ea;
+  border-color: #dae0e5; }
+.platform_sh_standalone .btn-light:focus, .platform_sh_standalone .btn-light.focus {
+  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5); }
+.platform_sh_standalone .btn-light.disabled, .platform_sh_standalone .btn-light:disabled {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-light:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-light:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-light.dropdown-toggle {
+  color: #212529;
+  background-color: #dae0e5;
+  border-color: #d3d9df; }
+.platform_sh_standalone .btn-light:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-light:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-light.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5); }
+.platform_sh_standalone .btn-dark {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-dark:hover {
+  color: #fff;
+  background-color: #23272b;
+  border-color: #1d2124; }
+.platform_sh_standalone .btn-dark:focus, .platform_sh_standalone .btn-dark.focus {
+  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5); }
+.platform_sh_standalone .btn-dark.disabled, .platform_sh_standalone .btn-dark:disabled {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-dark:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-dark:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-dark.dropdown-toggle {
+  color: #fff;
+  background-color: #1d2124;
+  border-color: #171a1d; }
+.platform_sh_standalone .btn-dark:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-dark:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-dark.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5); }
+.platform_sh_standalone .btn-outline-primary {
+  color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-outline-primary:hover {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-outline-primary:focus, .platform_sh_standalone .btn-outline-primary.focus {
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .btn-outline-primary.disabled, .platform_sh_standalone .btn-outline-primary:disabled {
+  color: #145CC6;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-primary.dropdown-toggle {
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-primary:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-primary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .btn-outline-secondary {
+  color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-outline-secondary:hover {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-outline-secondary:focus, .platform_sh_standalone .btn-outline-secondary.focus {
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
+.platform_sh_standalone .btn-outline-secondary.disabled, .platform_sh_standalone .btn-outline-secondary:disabled {
+  color: #6c757d;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-secondary.dropdown-toggle {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d; }
+.platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-secondary:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-secondary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
+.platform_sh_standalone .btn-outline-success {
+  color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-outline-success:hover {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-outline-success:focus, .platform_sh_standalone .btn-outline-success.focus {
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
+.platform_sh_standalone .btn-outline-success.disabled, .platform_sh_standalone .btn-outline-success:disabled {
+  color: #28a745;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-success.dropdown-toggle {
+  color: #fff;
+  background-color: #28a745;
+  border-color: #28a745; }
+.platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-success:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-success.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
+.platform_sh_standalone .btn-outline-info {
+  color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-outline-info:hover {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-outline-info:focus, .platform_sh_standalone .btn-outline-info.focus {
+  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
+.platform_sh_standalone .btn-outline-info.disabled, .platform_sh_standalone .btn-outline-info:disabled {
+  color: #17a2b8;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-info.dropdown-toggle {
+  color: #fff;
+  background-color: #17a2b8;
+  border-color: #17a2b8; }
+.platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-info:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-info.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
+.platform_sh_standalone .btn-outline-warning {
+  color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-outline-warning:hover {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-outline-warning:focus, .platform_sh_standalone .btn-outline-warning.focus {
+  box-shadow: 0 0 0 0.2rem rgba(244, 186, 55, 0.5); }
+.platform_sh_standalone .btn-outline-warning.disabled, .platform_sh_standalone .btn-outline-warning:disabled {
+  color: #F4BA37;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-warning.dropdown-toggle {
+  color: #212529;
+  background-color: #F4BA37;
+  border-color: #F4BA37; }
+.platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-warning:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-warning.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(244, 186, 55, 0.5); }
+.platform_sh_standalone .btn-outline-danger {
+  color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-outline-danger:hover {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-outline-danger:focus, .platform_sh_standalone .btn-outline-danger.focus {
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
+.platform_sh_standalone .btn-outline-danger.disabled, .platform_sh_standalone .btn-outline-danger:disabled {
+  color: #dc3545;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-danger.dropdown-toggle {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545; }
+.platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-danger:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-danger.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
+.platform_sh_standalone .btn-outline-light {
+  color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-outline-light:hover {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-outline-light:focus, .platform_sh_standalone .btn-outline-light.focus {
+  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
+.platform_sh_standalone .btn-outline-light.disabled, .platform_sh_standalone .btn-outline-light:disabled {
+  color: #f8f9fa;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-light.dropdown-toggle {
+  color: #212529;
+  background-color: #f8f9fa;
+  border-color: #f8f9fa; }
+.platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-light:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-light.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
+.platform_sh_standalone .btn-outline-dark {
+  color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-outline-dark:hover {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-outline-dark:focus, .platform_sh_standalone .btn-outline-dark.focus {
+  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
+.platform_sh_standalone .btn-outline-dark.disabled, .platform_sh_standalone .btn-outline-dark:disabled {
+  color: #343a40;
+  background-color: transparent; }
+.platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled):active, .platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled).active, .show > .platform_sh_standalone .btn-outline-dark.dropdown-toggle {
+  color: #fff;
+  background-color: #343a40;
+  border-color: #343a40; }
+.platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled):active:focus, .platform_sh_standalone .btn-outline-dark:not(:disabled):not(.disabled).active:focus, .show > .platform_sh_standalone .btn-outline-dark.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
+.platform_sh_standalone .btn-link {
+  font-weight: 400;
+  color: #145CC6;
+  text-decoration: none; }
+.platform_sh_standalone .btn-link:hover {
+  color: #0d3c81;
+  text-decoration: underline; }
+.platform_sh_standalone .btn-link:focus, .platform_sh_standalone .btn-link.focus {
+  text-decoration: underline;
+  box-shadow: none; }
+.platform_sh_standalone .btn-link:disabled, .platform_sh_standalone .btn-link.disabled {
+  color: #6c757d;
+  pointer-events: none; }
+.platform_sh_standalone .btn-lg, .platform_sh_standalone .btn-group-lg > .btn, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__free-trial {
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .btn-sm, .platform_sh_standalone .btn-group-sm > .btn, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__free-trial {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .btn-block {
+  display: block;
+  width: 100%; }
+.platform_sh_standalone .btn-block + .btn-block {
+  margin-top: 0.5rem; }
+.platform_sh_standalone input[type="submit"].btn-block,
+.platform_sh_standalone input[type="reset"].btn-block,
+.platform_sh_standalone input[type="button"].btn-block {
+  width: 100%; }
+.platform_sh_standalone .fade {
+  transition: opacity 0.15s linear; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .fade {
+    transition: none; } }
+.platform_sh_standalone .fade:not(.show) {
+  opacity: 0; }
+.platform_sh_standalone .collapse:not(.show) {
+  display: none; }
+.platform_sh_standalone .collapsing {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  transition: height 0.35s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .collapsing {
+    transition: none; } }
+.platform_sh_standalone .dropup,
+.platform_sh_standalone .dropright,
+.platform_sh_standalone .dropdown,
+.platform_sh_standalone .dropleft {
+  position: relative; }
+.platform_sh_standalone .dropdown-toggle {
+  white-space: nowrap; }
+.platform_sh_standalone .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0;
+  border-left: 0.3em solid transparent; }
+.platform_sh_standalone .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 10rem;
+  padding: 0.5rem 0;
+  margin: 0.125rem 0 0;
+  font-size: 1rem;
+  color: #49475F;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0; }
+.platform_sh_standalone .dropdown-menu-left {
+  right: auto;
+  left: 0; }
+.platform_sh_standalone .dropdown-menu-right {
+  right: 0;
+  left: auto; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .dropdown-menu-xxs-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-xxs-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .dropdown-menu-xs-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-xs-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .dropdown-menu-sm-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-sm-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .dropdown-menu-md-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-md-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .dropdown-menu-lg-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-lg-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .dropdown-menu-xl-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-xl-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .dropdown-menu-xxl-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-xxl-right {
+    right: 0;
+    left: auto; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .dropdown-menu-xxxl-left {
+    right: auto;
+    left: 0; }
+  .platform_sh_standalone .dropdown-menu-xxxl-right {
+    right: 0;
+    left: auto; } }
+.platform_sh_standalone .dropup .dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 0.125rem; }
+.platform_sh_standalone .dropup .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0.3em solid;
+  border-left: 0.3em solid transparent; }
+.platform_sh_standalone .dropup .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropright .dropdown-menu {
+  top: 0;
+  right: auto;
+  left: 100%;
+  margin-top: 0;
+  margin-left: 0.125rem; }
+.platform_sh_standalone .dropright .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0;
+  border-bottom: 0.3em solid transparent;
+  border-left: 0.3em solid; }
+.platform_sh_standalone .dropright .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropright .dropdown-toggle::after {
+  vertical-align: 0; }
+.platform_sh_standalone .dropleft .dropdown-menu {
+  top: 0;
+  right: 100%;
+  left: auto;
+  margin-top: 0;
+  margin-right: 0.125rem; }
+.platform_sh_standalone .dropleft .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: ""; }
+.platform_sh_standalone .dropleft .dropdown-toggle::after {
+  display: none; }
+.platform_sh_standalone .dropleft .dropdown-toggle::before {
+  display: inline-block;
+  margin-right: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0.3em solid;
+  border-bottom: 0.3em solid transparent; }
+.platform_sh_standalone .dropleft .dropdown-toggle:empty::after {
+  margin-left: 0; }
+.platform_sh_standalone .dropleft .dropdown-toggle::before {
+  vertical-align: 0; }
+.platform_sh_standalone .dropdown-menu[x-placement^="top"], .platform_sh_standalone .dropdown-menu[x-placement^="right"], .platform_sh_standalone .dropdown-menu[x-placement^="bottom"], .platform_sh_standalone .dropdown-menu[x-placement^="left"] {
+  right: auto;
+  bottom: auto; }
+.platform_sh_standalone .dropdown-divider {
+  height: 0;
+  margin: 0.5rem 0;
+  overflow: hidden;
+  border-top: 1px solid #e9ecef; }
+.platform_sh_standalone .dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 1.5rem;
+  clear: both;
+  font-weight: 400;
+  color: #212529;
+  text-align: inherit;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0; }
+.platform_sh_standalone .dropdown-item:hover, .platform_sh_standalone .dropdown-item:focus {
+  color: #16181b;
+  text-decoration: none;
+  background-color: #f8f9fa; }
+.platform_sh_standalone .dropdown-item.active, .platform_sh_standalone .dropdown-item:active {
+  color: #fff;
+  text-decoration: none;
+  background-color: #145CC6; }
+.platform_sh_standalone .dropdown-item.disabled, .platform_sh_standalone .dropdown-item:disabled {
+  color: #6c757d;
+  pointer-events: none;
+  background-color: transparent; }
+.platform_sh_standalone .dropdown-menu.show {
+  display: block; }
+.platform_sh_standalone .dropdown-header {
+  display: block;
+  padding: 0.5rem 1.5rem;
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  color: #6c757d;
+  white-space: nowrap; }
+.platform_sh_standalone .dropdown-item-text {
+  display: block;
+  padding: 0.25rem 1.5rem;
+  color: #212529; }
+.platform_sh_standalone .btn-group,
+.platform_sh_standalone .btn-group-vertical {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle; }
+.platform_sh_standalone .btn-group > .btn, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial,
+.platform_sh_standalone .btn-group-vertical > .btn,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial {
+  position: relative;
+  flex: 1 1 auto; }
+.platform_sh_standalone .btn-group > .btn:hover, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:hover, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:hover,
+.platform_sh_standalone .btn-group-vertical > .btn:hover,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:hover,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:hover {
+  z-index: 1; }
+.platform_sh_standalone .btn-group > .btn:focus, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:focus, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:focus, .platform_sh_standalone .btn-group > .btn:active, .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:active, .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:active, .platform_sh_standalone .btn-group > .btn.active, .platform_sh_standalone #user-widget .btn-group > .active.user-widget__log-in, .platform_sh_standalone #user-widget .btn-group > .active.user-widget__free-trial,
+.platform_sh_standalone .btn-group-vertical > .btn:focus,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:focus,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:focus,
+.platform_sh_standalone .btn-group-vertical > .btn:active,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:active,
+.platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:active,
+.platform_sh_standalone .btn-group-vertical > .btn.active,
+.platform_sh_standalone #user-widget .btn-group-vertical > .active.user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .active.user-widget__free-trial {
+  z-index: 1; }
+.platform_sh_standalone .btn-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start; }
+.platform_sh_standalone .btn-toolbar .input-group {
+  width: auto; }
+.platform_sh_standalone .btn-group > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group > .btn-group:not(:first-child) {
+  margin-left: 0; }
+.platform_sh_standalone .btn-group > .btn:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone .btn-group > .btn-group:not(:last-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:last-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:last-child) > .user-widget__free-trial {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .btn-group > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group > .btn-group:not(:first-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:first-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group > .btn-group:not(:first-child) > .user-widget__free-trial {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .dropdown-toggle-split {
+  padding-right: 0.9375rem;
+  padding-left: 0.9375rem; }
+.platform_sh_standalone .dropdown-toggle-split::after, .dropup .platform_sh_standalone .dropdown-toggle-split::after, .dropright .platform_sh_standalone .dropdown-toggle-split::after {
+  margin-left: 0; }
+.dropleft .platform_sh_standalone .dropdown-toggle-split::before {
+  margin-right: 0; }
+.platform_sh_standalone .btn-sm + .dropdown-toggle-split, .platform_sh_standalone .btn-group-sm > .btn + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__log-in + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__free-trial + .dropdown-toggle-split {
+  padding-right: 0.375rem;
+  padding-left: 0.375rem; }
+.platform_sh_standalone .btn-lg + .dropdown-toggle-split, .platform_sh_standalone .btn-group-lg > .btn + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__log-in + .dropdown-toggle-split, .platform_sh_standalone #user-widget .btn-group-lg > .user-widget__free-trial + .dropdown-toggle-split {
+  padding-right: 0.75rem;
+  padding-left: 0.75rem; }
+.platform_sh_standalone .btn-group-vertical {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center; }
+.platform_sh_standalone .btn-group-vertical > .btn, .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial,
+.platform_sh_standalone .btn-group-vertical > .btn-group {
+  width: 100%; }
+.platform_sh_standalone .btn-group-vertical > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group-vertical > .btn-group:not(:first-child) {
+  margin-top: 0; }
+.platform_sh_standalone .btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:not(:last-child):not(.dropdown-toggle), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone .btn-group-vertical > .btn-group:not(:last-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:last-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:last-child) > .user-widget__free-trial {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .btn-group-vertical > .btn:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__log-in:not(:first-child), .platform_sh_standalone #user-widget .btn-group-vertical > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .btn-group-vertical > .btn-group:not(:first-child) > .btn,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:first-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-vertical > .btn-group:not(:first-child) > .user-widget__free-trial {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .btn-group-toggle > .btn, .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__free-trial,
+.platform_sh_standalone .btn-group-toggle > .btn-group > .btn,
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__log-in,
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__free-trial {
+  margin-bottom: 0; }
+.platform_sh_standalone .btn-group-toggle > .btn input[type="radio"], .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__log-in input[type="radio"], .platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__free-trial input[type="radio"],
+.platform_sh_standalone .btn-group-toggle > .btn input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__log-in input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .user-widget__free-trial input[type="checkbox"],
+.platform_sh_standalone .btn-group-toggle > .btn-group > .btn input[type="radio"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__log-in input[type="radio"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__free-trial input[type="radio"],
+.platform_sh_standalone .btn-group-toggle > .btn-group > .btn input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__log-in input[type="checkbox"],
+.platform_sh_standalone #user-widget .btn-group-toggle > .btn-group > .user-widget__free-trial input[type="checkbox"] {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+  pointer-events: none; }
+.platform_sh_standalone .input-group {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  width: 100%; }
+.platform_sh_standalone .input-group > .form-control,
+.platform_sh_standalone .input-group > .form-control-plaintext,
+.platform_sh_standalone .input-group > .custom-select,
+.platform_sh_standalone .input-group > .custom-file {
+  position: relative;
+  flex: 1 1 auto;
+  width: 1%;
+  margin-bottom: 0; }
+.platform_sh_standalone .input-group > .form-control + .form-control,
+.platform_sh_standalone .input-group > .form-control + .custom-select,
+.platform_sh_standalone .input-group > .form-control + .custom-file,
+.platform_sh_standalone .input-group > .form-control-plaintext + .form-control,
+.platform_sh_standalone .input-group > .form-control-plaintext + .custom-select,
+.platform_sh_standalone .input-group > .form-control-plaintext + .custom-file,
+.platform_sh_standalone .input-group > .custom-select + .form-control,
+.platform_sh_standalone .input-group > .custom-select + .custom-select,
+.platform_sh_standalone .input-group > .custom-select + .custom-file,
+.platform_sh_standalone .input-group > .custom-file + .form-control,
+.platform_sh_standalone .input-group > .custom-file + .custom-select,
+.platform_sh_standalone .input-group > .custom-file + .custom-file {
+  margin-left: -1px; }
+.platform_sh_standalone .input-group > .form-control:focus,
+.platform_sh_standalone .input-group > .custom-select:focus,
+.platform_sh_standalone .input-group > .custom-file .custom-file-input:focus ~ .custom-file-label {
+  z-index: 3; }
+.platform_sh_standalone .input-group > .custom-file .custom-file-input:focus {
+  z-index: 4; }
+.platform_sh_standalone .input-group > .form-control:not(:last-child),
+.platform_sh_standalone .input-group > .custom-select:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .input-group > .form-control:not(:first-child),
+.platform_sh_standalone .input-group > .custom-select:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .input-group > .custom-file {
+  display: flex;
+  align-items: center; }
+.platform_sh_standalone .input-group > .custom-file:not(:last-child) .custom-file-label, .platform_sh_standalone .input-group > .custom-file:not(:last-child) .custom-file-label::after {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .input-group > .custom-file:not(:first-child) .custom-file-label {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .input-group-prepend,
+.platform_sh_standalone .input-group-append {
+  display: flex; }
+.platform_sh_standalone .input-group-prepend .btn, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial,
+.platform_sh_standalone .input-group-append .btn,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial {
+  position: relative;
+  z-index: 2; }
+.platform_sh_standalone .input-group-prepend .btn:focus, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in:focus, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in:focus, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial:focus, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial:focus,
+.platform_sh_standalone .input-group-append .btn:focus,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in:focus,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in:focus,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial:focus,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial:focus {
+  z-index: 3; }
+.platform_sh_standalone .input-group-prepend .btn + .btn, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .btn, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .btn, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .btn, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .btn, .platform_sh_standalone .input-group-prepend #user-widget .btn + .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .btn + .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .user-widget__log-in, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .user-widget__log-in, .platform_sh_standalone .input-group-prepend #user-widget .btn + .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .btn + .user-widget__free-trial, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .user-widget__free-trial, .platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .user-widget__free-trial, .platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .user-widget__free-trial,
+.platform_sh_standalone .input-group-prepend .btn + .input-group-text,
+.platform_sh_standalone .input-group-prepend #user-widget .user-widget__log-in + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-prepend .user-widget__log-in + .input-group-text,
+.platform_sh_standalone .input-group-prepend #user-widget .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-prepend .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone .input-group-prepend .input-group-text + .input-group-text,
+.platform_sh_standalone .input-group-prepend .input-group-text + .btn,
+.platform_sh_standalone .input-group-prepend #user-widget .input-group-text + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-prepend .input-group-text + .user-widget__log-in,
+.platform_sh_standalone .input-group-prepend #user-widget .input-group-text + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-prepend .input-group-text + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append .btn + .btn,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .btn,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .btn,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .btn,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .btn,
+.platform_sh_standalone .input-group-append #user-widget .btn + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .btn + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .btn + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .btn + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .user-widget__free-trial,
+.platform_sh_standalone .input-group-append .btn + .input-group-text,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__log-in + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__log-in + .input-group-text,
+.platform_sh_standalone .input-group-append #user-widget .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone #user-widget .input-group-append .user-widget__free-trial + .input-group-text,
+.platform_sh_standalone .input-group-append .input-group-text + .input-group-text,
+.platform_sh_standalone .input-group-append .input-group-text + .btn,
+.platform_sh_standalone .input-group-append #user-widget .input-group-text + .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-append .input-group-text + .user-widget__log-in,
+.platform_sh_standalone .input-group-append #user-widget .input-group-text + .user-widget__free-trial,
+.platform_sh_standalone #user-widget .input-group-append .input-group-text + .user-widget__free-trial {
+  margin-left: -1px; }
+.platform_sh_standalone .input-group-prepend {
+  margin-right: -1px; }
+.platform_sh_standalone .input-group-append {
+  margin-left: -1px; }
+.platform_sh_standalone .input-group-text {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #e9ecef;
+  border: 1px solid #ced4da;
+  border-radius: 0; }
+.platform_sh_standalone .input-group-text input[type="radio"],
+.platform_sh_standalone .input-group-text input[type="checkbox"] {
+  margin-top: 0; }
+.platform_sh_standalone .input-group-lg > .form-control:not(textarea),
+.platform_sh_standalone .input-group-lg > .custom-select {
+  height: calc(1.5em + 1rem + 2px); }
+.platform_sh_standalone .input-group-lg > .form-control,
+.platform_sh_standalone .input-group-lg > .custom-select,
+.platform_sh_standalone .input-group-lg > .input-group-prepend > .input-group-text,
+.platform_sh_standalone .input-group-lg > .input-group-append > .input-group-text,
+.platform_sh_standalone .input-group-lg > .input-group-prepend > .btn,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-prepend > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-prepend > .user-widget__free-trial,
+.platform_sh_standalone .input-group-lg > .input-group-append > .btn,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-append > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-lg > .input-group-append > .user-widget__free-trial {
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .input-group-sm > .form-control:not(textarea),
+.platform_sh_standalone .input-group-sm > .custom-select {
+  height: calc(1.5em + 0.5rem + 2px); }
+.platform_sh_standalone .input-group-sm > .form-control,
+.platform_sh_standalone .input-group-sm > .custom-select,
+.platform_sh_standalone .input-group-sm > .input-group-prepend > .input-group-text,
+.platform_sh_standalone .input-group-sm > .input-group-append > .input-group-text,
+.platform_sh_standalone .input-group-sm > .input-group-prepend > .btn,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-prepend > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-prepend > .user-widget__free-trial,
+.platform_sh_standalone .input-group-sm > .input-group-append > .btn,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-append > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group-sm > .input-group-append > .user-widget__free-trial {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0; }
+.platform_sh_standalone .input-group-lg > .custom-select,
+.platform_sh_standalone .input-group-sm > .custom-select {
+  padding-right: 1.75rem; }
+.platform_sh_standalone .input-group > .input-group-prepend > .btn, .platform_sh_standalone #user-widget .input-group > .input-group-prepend > .user-widget__log-in, .platform_sh_standalone #user-widget .input-group > .input-group-prepend > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-prepend > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-append:not(:last-child) > .btn,
+.platform_sh_standalone #user-widget .input-group > .input-group-append:not(:last-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group > .input-group-append:not(:last-child) > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-append:not(:last-child) > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone #user-widget .input-group > .input-group-append:last-child > .user-widget__log-in:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone #user-widget .input-group > .input-group-append:last-child > .user-widget__free-trial:not(:last-child):not(.dropdown-toggle),
+.platform_sh_standalone .input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .input-group > .input-group-append > .btn, .platform_sh_standalone #user-widget .input-group > .input-group-append > .user-widget__log-in, .platform_sh_standalone #user-widget .input-group > .input-group-append > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-append > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-prepend:not(:first-child) > .btn,
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:not(:first-child) > .user-widget__log-in,
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:not(:first-child) > .user-widget__free-trial,
+.platform_sh_standalone .input-group > .input-group-prepend:not(:first-child) > .input-group-text,
+.platform_sh_standalone .input-group > .input-group-prepend:first-child > .btn:not(:first-child),
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:first-child > .user-widget__log-in:not(:first-child),
+.platform_sh_standalone #user-widget .input-group > .input-group-prepend:first-child > .user-widget__free-trial:not(:first-child),
+.platform_sh_standalone .input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .custom-control {
+  position: relative;
+  display: block;
+  min-height: 1rem;
+  padding-left: 1.5rem; }
+.platform_sh_standalone .custom-control-inline {
+  display: inline-flex;
+  margin-right: 1rem; }
+.platform_sh_standalone .custom-control-input {
+  position: absolute;
+  z-index: -1;
+  opacity: 0; }
+.platform_sh_standalone .custom-control-input:checked ~ .custom-control-label::before {
+  color: #fff;
+  border-color: #145CC6;
+  background-color: #145CC6; }
+.platform_sh_standalone .custom-control-input:focus ~ .custom-control-label::before {
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
+  border-color: #6aa0f0; }
+.platform_sh_standalone .custom-control-input:not(:disabled):active ~ .custom-control-label::before {
+  color: #fff;
+  background-color: #98bdf5;
+  border-color: #98bdf5; }
+.platform_sh_standalone .custom-control-input:disabled ~ .custom-control-label {
+  color: #6c757d; }
+.platform_sh_standalone .custom-control-input:disabled ~ .custom-control-label::before {
+  background-color: #e9ecef; }
+.platform_sh_standalone .custom-control-label {
+  position: relative;
+  margin-bottom: 0;
+  vertical-align: top; }
+.platform_sh_standalone .custom-control-label::before {
+  position: absolute;
+  top: 0rem;
+  left: -1.5rem;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  pointer-events: none;
+  content: "";
+  background-color: #fff;
+  border: #adb5bd solid 1px; }
+.platform_sh_standalone .custom-control-label::after {
+  position: absolute;
+  top: 0rem;
+  left: -1.5rem;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  content: "";
+  background: no-repeat 50% / 50% 50%; }
+.platform_sh_standalone .custom-checkbox .custom-control-label::before {
+  border-radius: 0; }
+.platform_sh_standalone .custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
+  border-color: #145CC6;
+  background-color: #145CC6; }
+.platform_sh_standalone .custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='%23fff' d='M0 2h4'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-checkbox .custom-control-input:disabled:indeterminate ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-radio .custom-control-label::before {
+  border-radius: 50%; }
+.platform_sh_standalone .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-switch {
+  padding-left: 2.25rem; }
+.platform_sh_standalone .custom-switch .custom-control-label::before {
+  left: -2.25rem;
+  width: 1.75rem;
+  pointer-events: all;
+  border-radius: 0.5rem; }
+.platform_sh_standalone .custom-switch .custom-control-label::after {
+  top: calc(0rem + 2px);
+  left: calc(-2.25rem + 2px);
+  width: calc(1rem - 4px);
+  height: calc(1rem - 4px);
+  background-color: #adb5bd;
+  border-radius: 0.5rem;
+  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-switch .custom-control-label::after {
+    transition: none; } }
+.platform_sh_standalone .custom-switch .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fff;
+  transform: translateX(0.75rem); }
+.platform_sh_standalone .custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .custom-select {
+  display: inline-block;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  padding: 0.375rem 1.75rem 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  vertical-align: middle;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0;
+  appearance: none; }
+.platform_sh_standalone .custom-select:focus {
+  border-color: #6aa0f0;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-select:focus::-ms-value {
+  color: #495057;
+  background-color: #fff; }
+.platform_sh_standalone .custom-select[multiple], .platform_sh_standalone .custom-select[size]:not([size="1"]) {
+  height: auto;
+  padding-right: 0.75rem;
+  background-image: none; }
+.platform_sh_standalone .custom-select:disabled {
+  color: #6c757d;
+  background-color: #e9ecef; }
+.platform_sh_standalone .custom-select::-ms-expand {
+  display: none; }
+.platform_sh_standalone .custom-select-sm {
+  height: calc(1.5em + 0.5rem + 2px);
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  font-size: 0.875rem; }
+.platform_sh_standalone .custom-select-lg {
+  height: calc(1.5em + 1rem + 2px);
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  font-size: 1.25rem; }
+.platform_sh_standalone .custom-file {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  margin-bottom: 0; }
+.platform_sh_standalone .custom-file-input {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  height: calc(1em + 0.75rem + 2px);
+  margin: 0;
+  opacity: 0; }
+.platform_sh_standalone .custom-file-input:focus ~ .custom-file-label {
+  border-color: #6aa0f0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-file-input:disabled ~ .custom-file-label {
+  background-color: #e9ecef; }
+.platform_sh_standalone .custom-file-input:lang(en) ~ .custom-file-label::after {
+  content: "Browse"; }
+.platform_sh_standalone .custom-file-input ~ .custom-file-label[data-browse]::after {
+  content: attr(data-browse); }
+.platform_sh_standalone .custom-file-label {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1;
+  height: calc(1em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  font-weight: 400;
+  line-height: 1;
+  color: #495057;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0; }
+.platform_sh_standalone .custom-file-label::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 3;
+  display: block;
+  height: calc(1em + 0.75rem);
+  padding: 0.375rem 0.75rem;
+  line-height: 1;
+  color: #495057;
+  content: "Browse";
+  background-color: #e9ecef;
+  border-left: inherit;
+  border-radius: 0 0 0 0; }
+.platform_sh_standalone .custom-range {
+  width: 100%;
+  height: calc(1rem + 0.4rem);
+  padding: 0;
+  background-color: transparent;
+  appearance: none; }
+.platform_sh_standalone .custom-range:focus {
+  outline: none; }
+.platform_sh_standalone .custom-range:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-range:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-range:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .custom-range::-moz-focus-outer {
+  border: 0; }
+.platform_sh_standalone .custom-range::-webkit-slider-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: -0.25rem;
+  background-color: #145CC6;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  appearance: none; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-range::-webkit-slider-thumb {
+    transition: none; } }
+.platform_sh_standalone .custom-range::-webkit-slider-thumb:active {
+  background-color: #98bdf5; }
+.platform_sh_standalone .custom-range::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: #dee2e6;
+  border-color: transparent;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  background-color: #145CC6;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  appearance: none; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-range::-moz-range-thumb {
+    transition: none; } }
+.platform_sh_standalone .custom-range::-moz-range-thumb:active {
+  background-color: #98bdf5; }
+.platform_sh_standalone .custom-range::-moz-range-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: #dee2e6;
+  border-color: transparent;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range::-ms-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0;
+  margin-right: 0.2rem;
+  margin-left: 0.2rem;
+  background-color: #145CC6;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  appearance: none; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-range::-ms-thumb {
+    transition: none; } }
+.platform_sh_standalone .custom-range::-ms-thumb:active {
+  background-color: #98bdf5; }
+.platform_sh_standalone .custom-range::-ms-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: transparent;
+  border-color: transparent;
+  border-width: 0.5rem; }
+.platform_sh_standalone .custom-range::-ms-fill-lower {
+  background-color: #dee2e6;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range::-ms-fill-upper {
+  margin-right: 15px;
+  background-color: #dee2e6;
+  border-radius: 1rem; }
+.platform_sh_standalone .custom-range:disabled::-webkit-slider-thumb {
+  background-color: #adb5bd; }
+.platform_sh_standalone .custom-range:disabled::-webkit-slider-runnable-track {
+  cursor: default; }
+.platform_sh_standalone .custom-range:disabled::-moz-range-thumb {
+  background-color: #adb5bd; }
+.platform_sh_standalone .custom-range:disabled::-moz-range-track {
+  cursor: default; }
+.platform_sh_standalone .custom-range:disabled::-ms-thumb {
+  background-color: #adb5bd; }
+.platform_sh_standalone .custom-control-label::before,
+.platform_sh_standalone .custom-file-label,
+.platform_sh_standalone .custom-select {
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .custom-control-label::before,
+  .platform_sh_standalone .custom-file-label,
+  .platform_sh_standalone .custom-select {
+    transition: none; } }
+.platform_sh_standalone .nav {
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none; }
+.platform_sh_standalone .nav-link {
+  display: block;
+  padding: 0.5rem 1rem; }
+.platform_sh_standalone .nav-link:hover, .platform_sh_standalone .nav-link:focus {
+  text-decoration: none; }
+.platform_sh_standalone .nav-link.disabled {
+  color: #6c757d;
+  pointer-events: none;
+  cursor: default; }
+.platform_sh_standalone .nav-tabs {
+  border-bottom: 1px solid #dee2e6; }
+.platform_sh_standalone .nav-tabs .nav-item {
+  margin-bottom: -1px; }
+.platform_sh_standalone .nav-tabs .nav-link {
+  border: 1px solid transparent;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .nav-tabs .nav-link:hover, .platform_sh_standalone .nav-tabs .nav-link:focus {
+  border-color: #e9ecef #e9ecef #dee2e6; }
+.platform_sh_standalone .nav-tabs .nav-link.disabled {
+  color: #6c757d;
+  background-color: transparent;
+  border-color: transparent; }
+.platform_sh_standalone .nav-tabs .nav-link.active,
+.platform_sh_standalone .nav-tabs .nav-item.show .nav-link {
+  color: #495057;
+  background-color: #fff;
+  border-color: #dee2e6 #dee2e6 #fff; }
+.platform_sh_standalone .nav-tabs .dropdown-menu {
+  margin-top: -1px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .nav-pills .nav-link {
+  border-radius: 0; }
+.platform_sh_standalone .nav-pills .nav-link.active,
+.platform_sh_standalone .nav-pills .show > .nav-link {
+  color: #fff;
+  background-color: #145CC6; }
+.platform_sh_standalone .nav-fill .nav-item {
+  flex: 1 1 auto;
+  text-align: center; }
+.platform_sh_standalone .nav-justified .nav-item {
+  flex-basis: 0;
+  flex-grow: 1;
+  text-align: center; }
+.platform_sh_standalone .tab-content > .tab-pane {
+  display: none; }
+.platform_sh_standalone .tab-content > .active {
+  display: block; }
+.platform_sh_standalone .navbar {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem; }
+.platform_sh_standalone .navbar > .container,
+.platform_sh_standalone .navbar > .container-fluid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between; }
+.platform_sh_standalone .navbar-brand {
+  display: inline-block;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  margin-right: 1rem;
+  font-size: 1.25rem;
+  line-height: inherit;
+  white-space: nowrap; }
+.platform_sh_standalone .navbar-brand:hover, .platform_sh_standalone .navbar-brand:focus {
+  text-decoration: none; }
+.platform_sh_standalone .navbar-nav {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none; }
+.platform_sh_standalone .navbar-nav .nav-link {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .navbar-nav .dropdown-menu {
+  position: static;
+  float: none; }
+.platform_sh_standalone .navbar-text {
+  display: inline-block;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem; }
+.platform_sh_standalone .navbar-collapse {
+  flex-basis: 100%;
+  flex-grow: 1;
+  align-items: center; }
+.platform_sh_standalone .navbar-toggler {
+  padding: 0.25rem 0.75rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0; }
+.platform_sh_standalone .navbar-toggler:hover, .platform_sh_standalone .navbar-toggler:focus {
+  text-decoration: none; }
+.platform_sh_standalone .navbar-toggler-icon {
+  display: inline-block;
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: middle;
+  content: "";
+  background: no-repeat center center;
+  background-size: 100% 100%; }
+@media (max-width: 319.98px) {
+  .platform_sh_standalone .navbar-expand-xxs > .container,
+  .platform_sh_standalone .navbar-expand-xxs > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 320px) {
+  .platform_sh_standalone .navbar-expand-xxs {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-xxs .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-xxs .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-xxs .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-xxs > .container,
+  .platform_sh_standalone .navbar-expand-xxs > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-xxs .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-xxs .navbar-toggler {
+    display: none; } }
+@media (max-width: 413.98px) {
+  .platform_sh_standalone .navbar-expand-xs > .container,
+  .platform_sh_standalone .navbar-expand-xs > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .navbar-expand-xs {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-xs .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-xs .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-xs .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-xs > .container,
+  .platform_sh_standalone .navbar-expand-xs > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-xs .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-xs .navbar-toggler {
+    display: none; } }
+@media (max-width: 666.98px) {
+  .platform_sh_standalone .navbar-expand-sm > .container,
+  .platform_sh_standalone .navbar-expand-sm > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .navbar-expand-sm {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-sm > .container,
+  .platform_sh_standalone .navbar-expand-sm > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-sm .navbar-toggler {
+    display: none; } }
+@media (max-width: 767.98px) {
+  .platform_sh_standalone .navbar-expand-md > .container,
+  .platform_sh_standalone .navbar-expand-md > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .navbar-expand-md {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-md .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-md .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-md .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-md > .container,
+  .platform_sh_standalone .navbar-expand-md > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-md .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-md .navbar-toggler {
+    display: none; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .navbar-expand-lg > .container,
+  .platform_sh_standalone .navbar-expand-lg > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-expand-lg {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-lg > .container,
+  .platform_sh_standalone .navbar-expand-lg > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-lg .navbar-toggler {
+    display: none; } }
+@media (max-width: 1199.98px) {
+  .platform_sh_standalone .navbar-expand-xl > .container,
+  .platform_sh_standalone .navbar-expand-xl > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .navbar-expand-xl {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-xl > .container,
+  .platform_sh_standalone .navbar-expand-xl > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-xl .navbar-toggler {
+    display: none; } }
+@media (max-width: 1439.98px) {
+  .platform_sh_standalone .navbar-expand-xxl > .container,
+  .platform_sh_standalone .navbar-expand-xxl > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .navbar-expand-xxl {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-xxl .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-xxl .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-xxl .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-xxl > .container,
+  .platform_sh_standalone .navbar-expand-xxl > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-xxl .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-xxl .navbar-toggler {
+    display: none; } }
+@media (max-width: 1599.98px) {
+  .platform_sh_standalone .navbar-expand-xxxl > .container,
+  .platform_sh_standalone .navbar-expand-xxxl > .container-fluid {
+    padding-right: 0;
+    padding-left: 0; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .navbar-expand-xxxl {
+    flex-flow: row nowrap;
+    justify-content: flex-start; }
+  .platform_sh_standalone .navbar-expand-xxxl .navbar-nav {
+    flex-direction: row; }
+  .platform_sh_standalone .navbar-expand-xxxl .navbar-nav .dropdown-menu {
+    position: absolute; }
+  .platform_sh_standalone .navbar-expand-xxxl .navbar-nav .nav-link {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem; }
+  .platform_sh_standalone .navbar-expand-xxxl > .container,
+  .platform_sh_standalone .navbar-expand-xxxl > .container-fluid {
+    flex-wrap: nowrap; }
+  .platform_sh_standalone .navbar-expand-xxxl .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto; }
+  .platform_sh_standalone .navbar-expand-xxxl .navbar-toggler {
+    display: none; } }
+.platform_sh_standalone .navbar-expand {
+  flex-flow: row nowrap;
+  justify-content: flex-start; }
+.platform_sh_standalone .navbar-expand > .container,
+.platform_sh_standalone .navbar-expand > .container-fluid {
+  padding-right: 0;
+  padding-left: 0; }
+.platform_sh_standalone .navbar-expand .navbar-nav {
+  flex-direction: row; }
+.platform_sh_standalone .navbar-expand .navbar-nav .dropdown-menu {
+  position: absolute; }
+.platform_sh_standalone .navbar-expand .navbar-nav .nav-link {
+  padding-right: 0.5rem;
+  padding-left: 0.5rem; }
+.platform_sh_standalone .navbar-expand > .container,
+.platform_sh_standalone .navbar-expand > .container-fluid {
+  flex-wrap: nowrap; }
+.platform_sh_standalone .navbar-expand .navbar-collapse {
+  display: flex !important;
+  flex-basis: auto; }
+.platform_sh_standalone .navbar-expand .navbar-toggler {
+  display: none; }
+.platform_sh_standalone .navbar-light .navbar-brand {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-brand:hover, .platform_sh_standalone .navbar-light .navbar-brand:focus {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link {
+  color: rgba(0, 0, 0, 0.5); }
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link:hover, .platform_sh_standalone .navbar-light .navbar-nav .nav-link:focus {
+  color: rgba(0, 0, 0, 0.7); }
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link.disabled {
+  color: rgba(0, 0, 0, 0.3); }
+.platform_sh_standalone .navbar-light .navbar-nav .show > .nav-link,
+.platform_sh_standalone .navbar-light .navbar-nav .active > .nav-link,
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link.show,
+.platform_sh_standalone .navbar-light .navbar-nav .nav-link.active {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-toggler {
+  color: rgba(0, 0, 0, 0.5);
+  border-color: rgba(0, 0, 0, 0.1); }
+.platform_sh_standalone .navbar-light .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(0, 0, 0, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .navbar-light .navbar-text {
+  color: rgba(0, 0, 0, 0.5); }
+.platform_sh_standalone .navbar-light .navbar-text a {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-light .navbar-text a:hover, .platform_sh_standalone .navbar-light .navbar-text a:focus {
+  color: rgba(0, 0, 0, 0.9); }
+.platform_sh_standalone .navbar-dark .navbar-brand {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-brand:hover, .platform_sh_standalone .navbar-dark .navbar-brand:focus {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link {
+  color: rgba(255, 255, 255, 0.5); }
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link:hover, .platform_sh_standalone .navbar-dark .navbar-nav .nav-link:focus {
+  color: rgba(255, 255, 255, 0.75); }
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link.disabled {
+  color: rgba(255, 255, 255, 0.25); }
+.platform_sh_standalone .navbar-dark .navbar-nav .show > .nav-link,
+.platform_sh_standalone .navbar-dark .navbar-nav .active > .nav-link,
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link.show,
+.platform_sh_standalone .navbar-dark .navbar-nav .nav-link.active {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-toggler {
+  color: rgba(255, 255, 255, 0.5);
+  border-color: rgba(255, 255, 255, 0.1); }
+.platform_sh_standalone .navbar-dark .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .navbar-dark .navbar-text {
+  color: rgba(255, 255, 255, 0.5); }
+.platform_sh_standalone .navbar-dark .navbar-text a {
+  color: #fff; }
+.platform_sh_standalone .navbar-dark .navbar-text a:hover, .platform_sh_standalone .navbar-dark .navbar-text a:focus {
+  color: #fff; }
+.platform_sh_standalone .card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  word-wrap: break-word;
+  background-color: #fff;
+  background-clip: border-box;
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-radius: 0; }
+.platform_sh_standalone .card > hr {
+  margin-right: 0;
+  margin-left: 0; }
+.platform_sh_standalone .card > .list-group:first-child .list-group-item:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .card > .list-group:last-child .list-group-item:last-child {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .card-body {
+  flex: 1 1 auto;
+  padding: 1.25rem; }
+.platform_sh_standalone .card-title {
+  margin-bottom: 0.75rem; }
+.platform_sh_standalone .card-subtitle {
+  margin-top: -0.375rem;
+  margin-bottom: 0; }
+.platform_sh_standalone .card-text:last-child {
+  margin-bottom: 0; }
+.platform_sh_standalone .card-link:hover {
+  text-decoration: none; }
+.platform_sh_standalone .card-link + .card-link {
+  margin-left: 1.25rem; }
+.platform_sh_standalone .card-header {
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 0;
+  background-color: rgba(0, 0, 0, 0.03);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125); }
+.platform_sh_standalone .card-header:first-child {
+  border-radius: calc(0 - 1px) calc(0 - 1px) 0 0; }
+.platform_sh_standalone .card-header + .list-group .list-group-item:first-child {
+  border-top: 0; }
+.platform_sh_standalone .card-footer {
+  padding: 0.75rem 1.25rem;
+  background-color: rgba(0, 0, 0, 0.03);
+  border-top: 1px solid rgba(0, 0, 0, 0.125); }
+.platform_sh_standalone .card-footer:last-child {
+  border-radius: 0 0 calc(0 - 1px) calc(0 - 1px); }
+.platform_sh_standalone .card-header-tabs {
+  margin-right: -0.625rem;
+  margin-bottom: -0.75rem;
+  margin-left: -0.625rem;
+  border-bottom: 0; }
+.platform_sh_standalone .card-header-pills {
+  margin-right: -0.625rem;
+  margin-left: -0.625rem; }
+.platform_sh_standalone .card-img-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 1.25rem; }
+.platform_sh_standalone .card-img {
+  width: 100%;
+  border-radius: calc(0 - 1px); }
+.platform_sh_standalone .card-img-top {
+  width: 100%;
+  border-top-left-radius: calc(0 - 1px);
+  border-top-right-radius: calc(0 - 1px); }
+.platform_sh_standalone .card-img-bottom {
+  width: 100%;
+  border-bottom-right-radius: calc(0 - 1px);
+  border-bottom-left-radius: calc(0 - 1px); }
+.platform_sh_standalone .card-deck {
+  display: flex;
+  flex-direction: column; }
+.platform_sh_standalone .card-deck .card {
+  margin-bottom: 20px; }
+@media (min-width: 667px) {
+  .platform_sh_standalone .card-deck {
+    flex-flow: row wrap;
+    margin-right: -20px;
+    margin-left: -20px; }
+  .platform_sh_standalone .card-deck .card {
+    display: flex;
+    flex: 1 0 0%;
+    flex-direction: column;
+    margin-right: 20px;
+    margin-bottom: 0;
+    margin-left: 20px; } }
+.platform_sh_standalone .card-group {
+  display: flex;
+  flex-direction: column; }
+.platform_sh_standalone .card-group > .card {
+  margin-bottom: 20px; }
+@media (min-width: 667px) {
+  .platform_sh_standalone .card-group {
+    flex-flow: row wrap; }
+  .platform_sh_standalone .card-group > .card {
+    flex: 1 0 0%;
+    margin-bottom: 0; }
+  .platform_sh_standalone .card-group > .card + .card {
+    margin-left: 0;
+    border-left: 0; }
+  .platform_sh_standalone .card-group > .card:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-img-top,
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-header {
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-img-bottom,
+  .platform_sh_standalone .card-group > .card:not(:last-child) .card-footer {
+    border-bottom-right-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-img-top,
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-header {
+    border-top-left-radius: 0; }
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-img-bottom,
+  .platform_sh_standalone .card-group > .card:not(:first-child) .card-footer {
+    border-bottom-left-radius: 0; } }
+.platform_sh_standalone .card-columns .card {
+  margin-bottom: 0.75rem; }
+@media (min-width: 667px) {
+  .platform_sh_standalone .card-columns {
+    column-count: 3;
+    column-gap: 1.25rem;
+    orphans: 1;
+    widows: 1; }
+  .platform_sh_standalone .card-columns .card {
+    display: inline-block;
+    width: 100%; } }
+.platform_sh_standalone .accordion > .card {
+  overflow: hidden; }
+.platform_sh_standalone .accordion > .card:not(:first-of-type) .card-header:first-child {
+  border-radius: 0; }
+.platform_sh_standalone .accordion > .card:not(:first-of-type):not(:last-of-type) {
+  border-bottom: 0;
+  border-radius: 0; }
+.platform_sh_standalone .accordion > .card:first-of-type {
+  border-bottom: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .accordion > .card:last-of-type {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .accordion > .card .card-header {
+  margin-bottom: -1px; }
+.platform_sh_standalone .breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  list-style: none;
+  background-color: #e9ecef;
+  border-radius: 0; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item {
+  padding-left: 0.5rem; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item::before {
+  display: inline-block;
+  padding-right: 0.5rem;
+  color: #6c757d;
+  content: "/"; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item:hover::before {
+  text-decoration: underline; }
+.platform_sh_standalone .breadcrumb-item + .breadcrumb-item:hover::before {
+  text-decoration: none; }
+.platform_sh_standalone .breadcrumb-item.active {
+  color: #6c757d; }
+.platform_sh_standalone .pagination {
+  display: flex;
+  padding-left: 0;
+  list-style: none;
+  border-radius: 0; }
+.platform_sh_standalone .page-link {
+  position: relative;
+  display: block;
+  padding: 0.5rem 0.75rem;
+  margin-left: -1px;
+  line-height: 1.25;
+  color: #145CC6;
+  background-color: #fff;
+  border: 1px solid #dee2e6; }
+.platform_sh_standalone .page-link:hover {
+  z-index: 2;
+  color: #0d3c81;
+  text-decoration: none;
+  background-color: #e9ecef;
+  border-color: #dee2e6; }
+.platform_sh_standalone .page-link:focus {
+  z-index: 2;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.25); }
+.platform_sh_standalone .page-item:first-child .page-link {
+  margin-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .page-item:last-child .page-link {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .page-item.active .page-link {
+  z-index: 1;
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .page-item.disabled .page-link {
+  color: #6c757d;
+  pointer-events: none;
+  cursor: auto;
+  background-color: #fff;
+  border-color: #dee2e6; }
+.platform_sh_standalone .pagination-lg .page-link {
+  padding: 0.75rem 1.5rem;
+  font-size: 1.25rem;
+  line-height: 1.5; }
+.platform_sh_standalone .pagination-lg .page-item:first-child .page-link {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .pagination-lg .page-item:last-child .page-link {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .pagination-sm .page-link {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5; }
+.platform_sh_standalone .pagination-sm .page-item:first-child .page-link {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .pagination-sm .page-item:last-child .page-link {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+.platform_sh_standalone .badge {
+  display: inline-block;
+  padding: 0.25em 0.4em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .badge {
+    transition: none; } }
+a.platform_sh_standalone .badge:hover, a.platform_sh_standalone .badge:focus {
+  text-decoration: none; }
+.platform_sh_standalone .badge:empty {
+  display: none; }
+.platform_sh_standalone .btn .badge, .platform_sh_standalone #user-widget .user-widget__log-in .badge, .platform_sh_standalone #user-widget .user-widget__free-trial .badge {
+  position: relative;
+  top: -1px; }
+.platform_sh_standalone .badge-pill {
+  padding-right: 0.6em;
+  padding-left: 0.6em;
+  border-radius: 10rem; }
+.platform_sh_standalone .badge-primary {
+  color: #fff;
+  background-color: #145CC6; }
+a.platform_sh_standalone .badge-primary:hover, a.platform_sh_standalone .badge-primary:focus {
+  color: #fff;
+  background-color: #0f4698; }
+a.platform_sh_standalone .badge-primary:focus, a.platform_sh_standalone .badge-primary.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(20, 92, 198, 0.5); }
+.platform_sh_standalone .badge-secondary {
+  color: #fff;
+  background-color: #6c757d; }
+a.platform_sh_standalone .badge-secondary:hover, a.platform_sh_standalone .badge-secondary:focus {
+  color: #fff;
+  background-color: #545b62; }
+a.platform_sh_standalone .badge-secondary:focus, a.platform_sh_standalone .badge-secondary.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
+.platform_sh_standalone .badge-success {
+  color: #fff;
+  background-color: #28a745; }
+a.platform_sh_standalone .badge-success:hover, a.platform_sh_standalone .badge-success:focus {
+  color: #fff;
+  background-color: #1e7e34; }
+a.platform_sh_standalone .badge-success:focus, a.platform_sh_standalone .badge-success.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
+.platform_sh_standalone .badge-info {
+  color: #fff;
+  background-color: #17a2b8; }
+a.platform_sh_standalone .badge-info:hover, a.platform_sh_standalone .badge-info:focus {
+  color: #fff;
+  background-color: #117a8b; }
+a.platform_sh_standalone .badge-info:focus, a.platform_sh_standalone .badge-info.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
+.platform_sh_standalone .badge-warning {
+  color: #212529;
+  background-color: #F4BA37; }
+a.platform_sh_standalone .badge-warning:hover, a.platform_sh_standalone .badge-warning:focus {
+  color: #212529;
+  background-color: #eba70d; }
+a.platform_sh_standalone .badge-warning:focus, a.platform_sh_standalone .badge-warning.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(244, 186, 55, 0.5); }
+.platform_sh_standalone .badge-danger {
+  color: #fff;
+  background-color: #dc3545; }
+a.platform_sh_standalone .badge-danger:hover, a.platform_sh_standalone .badge-danger:focus {
+  color: #fff;
+  background-color: #bd2130; }
+a.platform_sh_standalone .badge-danger:focus, a.platform_sh_standalone .badge-danger.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
+.platform_sh_standalone .badge-light {
+  color: #212529;
+  background-color: #f8f9fa; }
+a.platform_sh_standalone .badge-light:hover, a.platform_sh_standalone .badge-light:focus {
+  color: #212529;
+  background-color: #dae0e5; }
+a.platform_sh_standalone .badge-light:focus, a.platform_sh_standalone .badge-light.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
+.platform_sh_standalone .badge-dark {
+  color: #fff;
+  background-color: #343a40; }
+a.platform_sh_standalone .badge-dark:hover, a.platform_sh_standalone .badge-dark:focus {
+  color: #fff;
+  background-color: #1d2124; }
+a.platform_sh_standalone .badge-dark:focus, a.platform_sh_standalone .badge-dark.focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
+.platform_sh_standalone .jumbotron {
+  padding: 2rem 1rem;
+  margin-bottom: 2rem;
+  background-color: #e9ecef;
+  border-radius: 0; }
+@media (min-width: 667px) {
+  .platform_sh_standalone .jumbotron {
+    padding: 4rem 2rem; } }
+.platform_sh_standalone .jumbotron-fluid {
+  padding-right: 0;
+  padding-left: 0;
+  border-radius: 0; }
+.platform_sh_standalone .alert {
+  position: relative;
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: 0; }
+.platform_sh_standalone .alert-heading {
+  color: inherit; }
+.platform_sh_standalone .alert-link {
+  font-weight: 700; }
+.platform_sh_standalone .alert-dismissible {
+  padding-right: 4rem; }
+.platform_sh_standalone .alert-dismissible .close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.75rem 1.25rem;
+  color: inherit; }
+.platform_sh_standalone .alert-primary {
+  color: #0a3067;
+  background-color: #d0def4;
+  border-color: #bdd1ef; }
+.platform_sh_standalone .alert-primary hr {
+  border-top-color: #a8c3ea; }
+.platform_sh_standalone .alert-primary .alert-link {
+  color: #051a39; }
+.platform_sh_standalone .alert-secondary {
+  color: #383d41;
+  background-color: #e2e3e5;
+  border-color: #d6d8db; }
+.platform_sh_standalone .alert-secondary hr {
+  border-top-color: #c8cbcf; }
+.platform_sh_standalone .alert-secondary .alert-link {
+  color: #202326; }
+.platform_sh_standalone .alert-success {
+  color: #155724;
+  background-color: #d4edda;
+  border-color: #c3e6cb; }
+.platform_sh_standalone .alert-success hr {
+  border-top-color: #b1dfbb; }
+.platform_sh_standalone .alert-success .alert-link {
+  color: #0b2e13; }
+.platform_sh_standalone .alert-info {
+  color: #0c5460;
+  background-color: #d1ecf1;
+  border-color: #bee5eb; }
+.platform_sh_standalone .alert-info hr {
+  border-top-color: #abdde5; }
+.platform_sh_standalone .alert-info .alert-link {
+  color: #062c33; }
+.platform_sh_standalone .alert-warning {
+  color: #7f611d;
+  background-color: #fdf1d7;
+  border-color: #fcecc7; }
+.platform_sh_standalone .alert-warning hr {
+  border-top-color: #fbe4af; }
+.platform_sh_standalone .alert-warning .alert-link {
+  color: #554114; }
+.platform_sh_standalone .alert-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb; }
+.platform_sh_standalone .alert-danger hr {
+  border-top-color: #f1b0b7; }
+.platform_sh_standalone .alert-danger .alert-link {
+  color: #491217; }
+.platform_sh_standalone .alert-light {
+  color: #818182;
+  background-color: #fefefe;
+  border-color: #fdfdfe; }
+.platform_sh_standalone .alert-light hr {
+  border-top-color: #ececf6; }
+.platform_sh_standalone .alert-light .alert-link {
+  color: #686868; }
+.platform_sh_standalone .alert-dark {
+  color: #1b1e21;
+  background-color: #d6d8d9;
+  border-color: #c6c8ca; }
+.platform_sh_standalone .alert-dark hr {
+  border-top-color: #b9bbbe; }
+.platform_sh_standalone .alert-dark .alert-link {
+  color: #040505; }
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 1rem 0; }
+  to {
+    background-position: 0 0; } }
+.platform_sh_standalone .progress {
+  display: flex;
+  height: 1rem;
+  overflow: hidden;
+  font-size: 0.75rem;
+  background-color: #e9ecef;
+  border-radius: 0; }
+.platform_sh_standalone .progress-bar {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #145CC6;
+  transition: width 0.6s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .progress-bar {
+    transition: none; } }
+.platform_sh_standalone .progress-bar-striped {
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-size: 1rem 1rem; }
+.platform_sh_standalone .progress-bar-animated {
+  animation: progress-bar-stripes 1s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .progress-bar-animated {
+    animation: none; } }
+.platform_sh_standalone .media {
+  display: flex;
+  align-items: flex-start; }
+.platform_sh_standalone .media-body {
+  flex: 1; }
+.platform_sh_standalone .list-group {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0; }
+.platform_sh_standalone .list-group-item-action {
+  width: 100%;
+  color: #495057;
+  text-align: inherit; }
+.platform_sh_standalone .list-group-item-action:hover, .platform_sh_standalone .list-group-item-action:focus {
+  z-index: 1;
+  color: #495057;
+  text-decoration: none;
+  background-color: #f8f9fa; }
+.platform_sh_standalone .list-group-item-action:active {
+  color: #49475F;
+  background-color: #e9ecef; }
+.platform_sh_standalone .list-group-item {
+  position: relative;
+  display: block;
+  padding: 0.75rem 1.25rem;
+  margin-bottom: -1px;
+  background-color: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.125); }
+.platform_sh_standalone .list-group-item:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .list-group-item:last-child {
+  margin-bottom: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .list-group-item.disabled, .platform_sh_standalone .list-group-item:disabled {
+  color: #6c757d;
+  pointer-events: none;
+  background-color: #fff; }
+.platform_sh_standalone .list-group-item.active {
+  z-index: 2;
+  color: #fff;
+  background-color: #145CC6;
+  border-color: #145CC6; }
+.platform_sh_standalone .list-group-horizontal {
+  flex-direction: row; }
+.platform_sh_standalone .list-group-horizontal .list-group-item {
+  margin-right: -1px;
+  margin-bottom: 0; }
+.platform_sh_standalone .list-group-horizontal .list-group-item:first-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .list-group-horizontal .list-group-item:last-child {
+  margin-right: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .list-group-horizontal-xxs {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-xxs .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-xxs .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-xxs .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .list-group-horizontal-xs {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-xs .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-xs .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-xs .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .list-group-horizontal-sm {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-sm .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-sm .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-sm .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .list-group-horizontal-md {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-md .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-md .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-md .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .list-group-horizontal-lg {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-lg .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-lg .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-lg .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .list-group-horizontal-xl {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-xl .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-xl .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-xl .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .list-group-horizontal-xxl {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-xxl .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-xxl .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-xxl .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .list-group-horizontal-xxxl {
+    flex-direction: row; }
+  .platform_sh_standalone .list-group-horizontal-xxxl .list-group-item {
+    margin-right: -1px;
+    margin-bottom: 0; }
+  .platform_sh_standalone .list-group-horizontal-xxxl .list-group-item:first-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 0; }
+  .platform_sh_standalone .list-group-horizontal-xxxl .list-group-item:last-child {
+    margin-right: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0; } }
+.platform_sh_standalone .list-group-flush .list-group-item {
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0; }
+.platform_sh_standalone .list-group-flush .list-group-item:last-child {
+  margin-bottom: -1px; }
+.platform_sh_standalone .list-group-flush:first-child .list-group-item:first-child {
+  border-top: 0; }
+.platform_sh_standalone .list-group-flush:last-child .list-group-item:last-child {
+  margin-bottom: 0;
+  border-bottom: 0; }
+.platform_sh_standalone .list-group-item-primary {
+  color: #0a3067;
+  background-color: #bdd1ef; }
+.platform_sh_standalone .list-group-item-primary.list-group-item-action:hover, .platform_sh_standalone .list-group-item-primary.list-group-item-action:focus {
+  color: #0a3067;
+  background-color: #a8c3ea; }
+.platform_sh_standalone .list-group-item-primary.list-group-item-action.active {
+  color: #fff;
+  background-color: #0a3067;
+  border-color: #0a3067; }
+.platform_sh_standalone .list-group-item-secondary {
+  color: #383d41;
+  background-color: #d6d8db; }
+.platform_sh_standalone .list-group-item-secondary.list-group-item-action:hover, .platform_sh_standalone .list-group-item-secondary.list-group-item-action:focus {
+  color: #383d41;
+  background-color: #c8cbcf; }
+.platform_sh_standalone .list-group-item-secondary.list-group-item-action.active {
+  color: #fff;
+  background-color: #383d41;
+  border-color: #383d41; }
+.platform_sh_standalone .list-group-item-success {
+  color: #155724;
+  background-color: #c3e6cb; }
+.platform_sh_standalone .list-group-item-success.list-group-item-action:hover, .platform_sh_standalone .list-group-item-success.list-group-item-action:focus {
+  color: #155724;
+  background-color: #b1dfbb; }
+.platform_sh_standalone .list-group-item-success.list-group-item-action.active {
+  color: #fff;
+  background-color: #155724;
+  border-color: #155724; }
+.platform_sh_standalone .list-group-item-info {
+  color: #0c5460;
+  background-color: #bee5eb; }
+.platform_sh_standalone .list-group-item-info.list-group-item-action:hover, .platform_sh_standalone .list-group-item-info.list-group-item-action:focus {
+  color: #0c5460;
+  background-color: #abdde5; }
+.platform_sh_standalone .list-group-item-info.list-group-item-action.active {
+  color: #fff;
+  background-color: #0c5460;
+  border-color: #0c5460; }
+.platform_sh_standalone .list-group-item-warning {
+  color: #7f611d;
+  background-color: #fcecc7; }
+.platform_sh_standalone .list-group-item-warning.list-group-item-action:hover, .platform_sh_standalone .list-group-item-warning.list-group-item-action:focus {
+  color: #7f611d;
+  background-color: #fbe4af; }
+.platform_sh_standalone .list-group-item-warning.list-group-item-action.active {
+  color: #fff;
+  background-color: #7f611d;
+  border-color: #7f611d; }
+.platform_sh_standalone .list-group-item-danger {
+  color: #721c24;
+  background-color: #f5c6cb; }
+.platform_sh_standalone .list-group-item-danger.list-group-item-action:hover, .platform_sh_standalone .list-group-item-danger.list-group-item-action:focus {
+  color: #721c24;
+  background-color: #f1b0b7; }
+.platform_sh_standalone .list-group-item-danger.list-group-item-action.active {
+  color: #fff;
+  background-color: #721c24;
+  border-color: #721c24; }
+.platform_sh_standalone .list-group-item-light {
+  color: #818182;
+  background-color: #fdfdfe; }
+.platform_sh_standalone .list-group-item-light.list-group-item-action:hover, .platform_sh_standalone .list-group-item-light.list-group-item-action:focus {
+  color: #818182;
+  background-color: #ececf6; }
+.platform_sh_standalone .list-group-item-light.list-group-item-action.active {
+  color: #fff;
+  background-color: #818182;
+  border-color: #818182; }
+.platform_sh_standalone .list-group-item-dark {
+  color: #1b1e21;
+  background-color: #c6c8ca; }
+.platform_sh_standalone .list-group-item-dark.list-group-item-action:hover, .platform_sh_standalone .list-group-item-dark.list-group-item-action:focus {
+  color: #1b1e21;
+  background-color: #b9bbbe; }
+.platform_sh_standalone .list-group-item-dark.list-group-item-action.active {
+  color: #fff;
+  background-color: #1b1e21;
+  border-color: #1b1e21; }
+.platform_sh_standalone .close {
+  float: right;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #000;
+  text-shadow: 0 1px 0 #fff;
+  opacity: .5; }
+.platform_sh_standalone .close:hover {
+  color: #000;
+  text-decoration: none; }
+.platform_sh_standalone .close:not(:disabled):not(.disabled):hover, .platform_sh_standalone .close:not(:disabled):not(.disabled):focus {
+  opacity: .75; }
+.platform_sh_standalone button.close {
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  appearance: none; }
+.platform_sh_standalone a.close.disabled {
+  pointer-events: none; }
+.platform_sh_standalone .toast {
+  max-width: 350px;
+  overflow: hidden;
+  font-size: 0.875rem;
+  background-color: rgba(255, 255, 255, 0.85);
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  opacity: 0;
+  border-radius: 0.25rem; }
+.platform_sh_standalone .toast:not(:last-child) {
+  margin-bottom: 0.75rem; }
+.platform_sh_standalone .toast.showing {
+  opacity: 1; }
+.platform_sh_standalone .toast.show {
+  display: block;
+  opacity: 1; }
+.platform_sh_standalone .toast.hide {
+  display: none; }
+.platform_sh_standalone .toast-header {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  color: #6c757d;
+  background-color: rgba(255, 255, 255, 0.85);
+  background-clip: padding-box;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05); }
+.platform_sh_standalone .toast-body {
+  padding: 0.75rem; }
+.platform_sh_standalone .modal-open {
+  overflow: hidden; }
+.platform_sh_standalone .modal-open .modal {
+  overflow-x: hidden;
+  overflow-y: auto; }
+.platform_sh_standalone .modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1050;
+  display: none;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  outline: 0; }
+.platform_sh_standalone .modal-dialog {
+  position: relative;
+  width: auto;
+  margin: 0.5rem;
+  pointer-events: none; }
+.modal.fade .platform_sh_standalone .modal-dialog {
+  transition: transform 0.3s ease-out;
+  transform: translate(0, -50px); }
+@media (prefers-reduced-motion: reduce) {
+  .modal.fade .platform_sh_standalone .modal-dialog {
+    transition: none; } }
+.modal.show .platform_sh_standalone .modal-dialog {
+  transform: none; }
+.platform_sh_standalone .modal-dialog-scrollable {
+  display: flex;
+  max-height: calc(100% - 1rem); }
+.platform_sh_standalone .modal-dialog-scrollable .modal-content {
+  max-height: calc(100vh - 1rem);
+  overflow: hidden; }
+.platform_sh_standalone .modal-dialog-scrollable .modal-header,
+.platform_sh_standalone .modal-dialog-scrollable .modal-footer {
+  flex-shrink: 0; }
+.platform_sh_standalone .modal-dialog-scrollable .modal-body {
+  overflow-y: auto; }
+.platform_sh_standalone .modal-dialog-centered {
+  display: flex;
+  align-items: center;
+  min-height: calc(100% - 1rem); }
+.platform_sh_standalone .modal-dialog-centered::before {
+  display: block;
+  height: calc(100vh - 1rem);
+  content: ""; }
+.platform_sh_standalone .modal-dialog-centered.modal-dialog-scrollable {
+  flex-direction: column;
+  justify-content: center;
+  height: 100%; }
+.platform_sh_standalone .modal-dialog-centered.modal-dialog-scrollable .modal-content {
+  max-height: none; }
+.platform_sh_standalone .modal-dialog-centered.modal-dialog-scrollable::before {
+  content: none; }
+.platform_sh_standalone .modal-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  pointer-events: auto;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0;
+  outline: 0; }
+.platform_sh_standalone .modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1040;
+  width: 100vw;
+  height: 100vh;
+  background-color: #000; }
+.platform_sh_standalone .modal-backdrop.fade {
+  opacity: 0; }
+.platform_sh_standalone .modal-backdrop.show {
+  opacity: 0.5; }
+.platform_sh_standalone .modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1rem 1rem;
+  border-bottom: 1px solid #dee2e6;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+.platform_sh_standalone .modal-header .close {
+  padding: 1rem 1rem;
+  margin: -1rem -1rem -1rem auto; }
+.platform_sh_standalone .modal-title {
+  margin-bottom: 0;
+  line-height: 1; }
+.platform_sh_standalone .modal-body {
+  position: relative;
+  flex: 1 1 auto;
+  padding: 1rem; }
+.platform_sh_standalone .modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 1rem;
+  border-top: 1px solid #dee2e6;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0; }
+.platform_sh_standalone .modal-footer > :not(:first-child) {
+  margin-left: .25rem; }
+.platform_sh_standalone .modal-footer > :not(:last-child) {
+  margin-right: .25rem; }
+.platform_sh_standalone .modal-scrollbar-measure {
+  position: absolute;
+  top: -9999px;
+  width: 50px;
+  height: 50px;
+  overflow: scroll; }
+@media (min-width: 667px) {
+  .platform_sh_standalone .modal-dialog {
+    max-width: 500px;
+    margin: 1.75rem auto; }
+  .platform_sh_standalone .modal-dialog-scrollable {
+    max-height: calc(100% - 3.5rem); }
+  .platform_sh_standalone .modal-dialog-scrollable .modal-content {
+    max-height: calc(100vh - 3.5rem); }
+  .platform_sh_standalone .modal-dialog-centered {
+    min-height: calc(100% - 3.5rem); }
+  .platform_sh_standalone .modal-dialog-centered::before {
+    height: calc(100vh - 3.5rem); }
+  .platform_sh_standalone .modal-sm {
+    max-width: 300px; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .modal-lg,
+  .platform_sh_standalone .modal-xl {
+    max-width: 800px; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .modal-xl {
+    max-width: 1140px; } }
+.platform_sh_standalone .tooltip {
+  position: absolute;
+  z-index: 1070;
+  display: block;
+  margin: 0;
+  font-family: Overpass, Arial;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-break: normal;
+  word-spacing: normal;
+  white-space: normal;
+  line-break: auto;
+  font-size: 0.875rem;
+  word-wrap: break-word;
+  opacity: 0; }
+.platform_sh_standalone .tooltip.show {
+  opacity: 0.9; }
+.platform_sh_standalone .tooltip .arrow {
+  position: absolute;
+  display: block;
+  width: 0.8rem;
+  height: 0.4rem; }
+.platform_sh_standalone .tooltip .arrow::before {
+  position: absolute;
+  content: "";
+  border-color: transparent;
+  border-style: solid; }
+.platform_sh_standalone .bs-tooltip-top, .platform_sh_standalone .bs-tooltip-auto[x-placement^="top"] {
+  padding: 0.4rem 0; }
+.platform_sh_standalone .bs-tooltip-top .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="top"] .arrow {
+  bottom: 0; }
+.platform_sh_standalone .bs-tooltip-top .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="top"] .arrow::before {
+  top: 0;
+  border-width: 0.4rem 0.4rem 0;
+  border-top-color: #000; }
+.platform_sh_standalone .bs-tooltip-right, .platform_sh_standalone .bs-tooltip-auto[x-placement^="right"] {
+  padding: 0 0.4rem; }
+.platform_sh_standalone .bs-tooltip-right .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="right"] .arrow {
+  left: 0;
+  width: 0.4rem;
+  height: 0.8rem; }
+.platform_sh_standalone .bs-tooltip-right .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="right"] .arrow::before {
+  right: 0;
+  border-width: 0.4rem 0.4rem 0.4rem 0;
+  border-right-color: #000; }
+.platform_sh_standalone .bs-tooltip-bottom, .platform_sh_standalone .bs-tooltip-auto[x-placement^="bottom"] {
+  padding: 0.4rem 0; }
+.platform_sh_standalone .bs-tooltip-bottom .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="bottom"] .arrow {
+  top: 0; }
+.platform_sh_standalone .bs-tooltip-bottom .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="bottom"] .arrow::before {
+  bottom: 0;
+  border-width: 0 0.4rem 0.4rem;
+  border-bottom-color: #000; }
+.platform_sh_standalone .bs-tooltip-left, .platform_sh_standalone .bs-tooltip-auto[x-placement^="left"] {
+  padding: 0 0.4rem; }
+.platform_sh_standalone .bs-tooltip-left .arrow, .platform_sh_standalone .bs-tooltip-auto[x-placement^="left"] .arrow {
+  right: 0;
+  width: 0.4rem;
+  height: 0.8rem; }
+.platform_sh_standalone .bs-tooltip-left .arrow::before, .platform_sh_standalone .bs-tooltip-auto[x-placement^="left"] .arrow::before {
+  left: 0;
+  border-width: 0.4rem 0 0.4rem 0.4rem;
+  border-left-color: #000; }
+.platform_sh_standalone .tooltip-inner {
+  max-width: 200px;
+  padding: 0.25rem 0.5rem;
+  color: #fff;
+  text-align: center;
+  background-color: #000;
+  border-radius: 0; }
+.platform_sh_standalone .popover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1060;
+  display: block;
+  max-width: 276px;
+  font-family: Overpass, Arial;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-break: normal;
+  word-spacing: normal;
+  white-space: normal;
+  line-break: auto;
+  font-size: 0.875rem;
+  word-wrap: break-word;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0; }
+.platform_sh_standalone .popover .arrow {
+  position: absolute;
+  display: block;
+  width: 1rem;
+  height: 0.5rem;
+  margin: 0 0; }
+.platform_sh_standalone .popover .arrow::before, .platform_sh_standalone .popover .arrow::after {
+  position: absolute;
+  display: block;
+  content: "";
+  border-color: transparent;
+  border-style: solid; }
+.platform_sh_standalone .bs-popover-top, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] {
+  margin-bottom: 0.5rem; }
+.platform_sh_standalone .bs-popover-top > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] > .arrow {
+  bottom: calc((0.5rem + 1px) * -1); }
+.platform_sh_standalone .bs-popover-top > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] > .arrow::before {
+  bottom: 0;
+  border-width: 0.5rem 0.5rem 0;
+  border-top-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-top > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="top"] > .arrow::after {
+  bottom: 1px;
+  border-width: 0.5rem 0.5rem 0;
+  border-top-color: #fff; }
+.platform_sh_standalone .bs-popover-right, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] {
+  margin-left: 0.5rem; }
+.platform_sh_standalone .bs-popover-right > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] > .arrow {
+  left: calc((0.5rem + 1px) * -1);
+  width: 0.5rem;
+  height: 1rem;
+  margin: 0 0; }
+.platform_sh_standalone .bs-popover-right > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] > .arrow::before {
+  left: 0;
+  border-width: 0.5rem 0.5rem 0.5rem 0;
+  border-right-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-right > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="right"] > .arrow::after {
+  left: 1px;
+  border-width: 0.5rem 0.5rem 0.5rem 0;
+  border-right-color: #fff; }
+.platform_sh_standalone .bs-popover-bottom, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] {
+  margin-top: 0.5rem; }
+.platform_sh_standalone .bs-popover-bottom > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] > .arrow {
+  top: calc((0.5rem + 1px) * -1); }
+.platform_sh_standalone .bs-popover-bottom > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] > .arrow::before {
+  top: 0;
+  border-width: 0 0.5rem 0.5rem 0.5rem;
+  border-bottom-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-bottom > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] > .arrow::after {
+  top: 1px;
+  border-width: 0 0.5rem 0.5rem 0.5rem;
+  border-bottom-color: #fff; }
+.platform_sh_standalone .bs-popover-bottom .popover-header::before, .platform_sh_standalone .bs-popover-auto[x-placement^="bottom"] .popover-header::before {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  display: block;
+  width: 1rem;
+  margin-left: -0.5rem;
+  content: "";
+  border-bottom: 1px solid #f7f7f7; }
+.platform_sh_standalone .bs-popover-left, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] {
+  margin-right: 0.5rem; }
+.platform_sh_standalone .bs-popover-left > .arrow, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] > .arrow {
+  right: calc((0.5rem + 1px) * -1);
+  width: 0.5rem;
+  height: 1rem;
+  margin: 0 0; }
+.platform_sh_standalone .bs-popover-left > .arrow::before, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] > .arrow::before {
+  right: 0;
+  border-width: 0.5rem 0 0.5rem 0.5rem;
+  border-left-color: rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .bs-popover-left > .arrow::after, .platform_sh_standalone .bs-popover-auto[x-placement^="left"] > .arrow::after {
+  right: 1px;
+  border-width: 0.5rem 0 0.5rem 0.5rem;
+  border-left-color: #fff; }
+.platform_sh_standalone .popover-header {
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  color: #1A182A;
+  background-color: #f7f7f7;
+  border-bottom: 1px solid #ebebeb;
+  border-top-left-radius: calc(0 - 1px);
+  border-top-right-radius: calc(0 - 1px); }
+.platform_sh_standalone .popover-header:empty {
+  display: none; }
+.platform_sh_standalone .popover-body {
+  padding: 0.5rem 0.75rem;
+  color: #49475F; }
+.platform_sh_standalone .carousel {
+  position: relative; }
+.platform_sh_standalone .carousel.pointer-event {
+  touch-action: pan-y; }
+.platform_sh_standalone .carousel-inner {
+  position: relative;
+  width: 100%;
+  overflow: hidden; }
+.platform_sh_standalone .carousel-inner::after {
+  display: block;
+  clear: both;
+  content: ""; }
+.platform_sh_standalone .carousel-item {
+  position: relative;
+  display: none;
+  float: left;
+  width: 100%;
+  margin-right: -100%;
+  backface-visibility: hidden;
+  transition: transform 0.6s ease-in-out; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-item {
+    transition: none; } }
+.platform_sh_standalone .carousel-item.active,
+.platform_sh_standalone .carousel-item-next,
+.platform_sh_standalone .carousel-item-prev {
+  display: block; }
+.platform_sh_standalone .carousel-item-next:not(.carousel-item-left),
+.platform_sh_standalone .active.carousel-item-right {
+  transform: translateX(100%); }
+.platform_sh_standalone .carousel-item-prev:not(.carousel-item-right),
+.platform_sh_standalone .active.carousel-item-left {
+  transform: translateX(-100%); }
+.platform_sh_standalone .carousel-fade .carousel-item {
+  opacity: 0;
+  transition-property: opacity;
+  transform: none; }
+.platform_sh_standalone .carousel-fade .carousel-item.active,
+.platform_sh_standalone .carousel-fade .carousel-item-next.carousel-item-left,
+.platform_sh_standalone .carousel-fade .carousel-item-prev.carousel-item-right {
+  z-index: 1;
+  opacity: 1; }
+.platform_sh_standalone .carousel-fade .active.carousel-item-left,
+.platform_sh_standalone .carousel-fade .active.carousel-item-right {
+  z-index: 0;
+  opacity: 0;
+  transition: 0s 0.6s opacity; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-fade .active.carousel-item-left,
+  .platform_sh_standalone .carousel-fade .active.carousel-item-right {
+    transition: none; } }
+.platform_sh_standalone .carousel-control-prev,
+.platform_sh_standalone .carousel-control-next {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 15%;
+  color: #fff;
+  text-align: center;
+  opacity: 0.5;
+  transition: opacity 0.15s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-control-prev,
+  .platform_sh_standalone .carousel-control-next {
+    transition: none; } }
+.platform_sh_standalone .carousel-control-prev:hover, .platform_sh_standalone .carousel-control-prev:focus,
+.platform_sh_standalone .carousel-control-next:hover,
+.platform_sh_standalone .carousel-control-next:focus {
+  color: #fff;
+  text-decoration: none;
+  outline: 0;
+  opacity: 0.9; }
+.platform_sh_standalone .carousel-control-prev {
+  left: 0; }
+.platform_sh_standalone .carousel-control-next {
+  right: 0; }
+.platform_sh_standalone .carousel-control-prev-icon,
+.platform_sh_standalone .carousel-control-next-icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: no-repeat 50% / 100% 100%; }
+.platform_sh_standalone .carousel-control-prev-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5-2.5-2.5 2.5-2.5-1.5-1.5z'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .carousel-control-next-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/%3e%3c/svg%3e"); }
+.platform_sh_standalone .carousel-indicators {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 15;
+  display: flex;
+  justify-content: center;
+  padding-left: 0;
+  margin-right: 15%;
+  margin-left: 15%;
+  list-style: none; }
+.platform_sh_standalone .carousel-indicators li {
+  box-sizing: content-box;
+  flex: 0 1 auto;
+  width: 30px;
+  height: 3px;
+  margin-right: 3px;
+  margin-left: 3px;
+  text-indent: -999px;
+  cursor: pointer;
+  background-color: #fff;
+  background-clip: padding-box;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  opacity: .5;
+  transition: opacity 0.6s ease; }
+@media (prefers-reduced-motion: reduce) {
+  .platform_sh_standalone .carousel-indicators li {
+    transition: none; } }
+.platform_sh_standalone .carousel-indicators .active {
+  opacity: 1; }
+.platform_sh_standalone .carousel-caption {
+  position: absolute;
+  right: 15%;
+  bottom: 20px;
+  left: 15%;
+  z-index: 10;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: #fff;
+  text-align: center; }
+@keyframes spinner-border {
+  to {
+    transform: rotate(360deg); } }
+.platform_sh_standalone .spinner-border {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  vertical-align: text-bottom;
+  border: 0.25em solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spinner-border .75s linear infinite; }
+.platform_sh_standalone .spinner-border-sm {
+  width: 1rem;
+  height: 1rem;
+  border-width: 0.2em; }
+@keyframes spinner-grow {
+  0% {
+    transform: scale(0); }
+  50% {
+    opacity: 1; } }
+.platform_sh_standalone .spinner-grow {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  vertical-align: text-bottom;
+  background-color: currentColor;
+  border-radius: 50%;
+  opacity: 0;
+  animation: spinner-grow .75s linear infinite; }
+.platform_sh_standalone .spinner-grow-sm {
+  width: 1rem;
+  height: 1rem; }
+.platform_sh_standalone .align-baseline {
+  vertical-align: baseline !important; }
+.platform_sh_standalone .align-top {
+  vertical-align: top !important; }
+.platform_sh_standalone .align-middle {
+  vertical-align: middle !important; }
+.platform_sh_standalone .align-bottom {
+  vertical-align: bottom !important; }
+.platform_sh_standalone .align-text-bottom {
+  vertical-align: text-bottom !important; }
+.platform_sh_standalone .align-text-top {
+  vertical-align: text-top !important; }
+.platform_sh_standalone .bg-primary {
+  background-color: #145CC6 !important; }
+.platform_sh_standalone a.bg-primary:hover, .platform_sh_standalone a.bg-primary:focus,
+.platform_sh_standalone button.bg-primary:hover,
+.platform_sh_standalone button.bg-primary:focus {
+  background-color: #0f4698 !important; }
+.platform_sh_standalone .bg-secondary {
+  background-color: #6c757d !important; }
+.platform_sh_standalone a.bg-secondary:hover, .platform_sh_standalone a.bg-secondary:focus,
+.platform_sh_standalone button.bg-secondary:hover,
+.platform_sh_standalone button.bg-secondary:focus {
+  background-color: #545b62 !important; }
+.platform_sh_standalone .bg-success {
+  background-color: #28a745 !important; }
+.platform_sh_standalone a.bg-success:hover, .platform_sh_standalone a.bg-success:focus,
+.platform_sh_standalone button.bg-success:hover,
+.platform_sh_standalone button.bg-success:focus {
+  background-color: #1e7e34 !important; }
+.platform_sh_standalone .bg-info {
+  background-color: #17a2b8 !important; }
+.platform_sh_standalone a.bg-info:hover, .platform_sh_standalone a.bg-info:focus,
+.platform_sh_standalone button.bg-info:hover,
+.platform_sh_standalone button.bg-info:focus {
+  background-color: #117a8b !important; }
+.platform_sh_standalone .bg-warning {
+  background-color: #F4BA37 !important; }
+.platform_sh_standalone a.bg-warning:hover, .platform_sh_standalone a.bg-warning:focus,
+.platform_sh_standalone button.bg-warning:hover,
+.platform_sh_standalone button.bg-warning:focus {
+  background-color: #eba70d !important; }
+.platform_sh_standalone .bg-danger {
+  background-color: #dc3545 !important; }
+.platform_sh_standalone a.bg-danger:hover, .platform_sh_standalone a.bg-danger:focus,
+.platform_sh_standalone button.bg-danger:hover,
+.platform_sh_standalone button.bg-danger:focus {
+  background-color: #bd2130 !important; }
+.platform_sh_standalone .bg-light {
+  background-color: #f8f9fa !important; }
+.platform_sh_standalone a.bg-light:hover, .platform_sh_standalone a.bg-light:focus,
+.platform_sh_standalone button.bg-light:hover,
+.platform_sh_standalone button.bg-light:focus {
+  background-color: #dae0e5 !important; }
+.platform_sh_standalone .bg-dark {
+  background-color: #343a40 !important; }
+.platform_sh_standalone a.bg-dark:hover, .platform_sh_standalone a.bg-dark:focus,
+.platform_sh_standalone button.bg-dark:hover,
+.platform_sh_standalone button.bg-dark:focus {
+  background-color: #1d2124 !important; }
+.platform_sh_standalone .bg-white {
+  background-color: #fff !important; }
+.platform_sh_standalone .bg-transparent {
+  background-color: transparent !important; }
+.platform_sh_standalone .border {
+  border: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-top {
+  border-top: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-right {
+  border-right: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-bottom {
+  border-bottom: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-left {
+  border-left: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .border-0 {
+  border: 0 !important; }
+.platform_sh_standalone .border-top-0 {
+  border-top: 0 !important; }
+.platform_sh_standalone .border-right-0 {
+  border-right: 0 !important; }
+.platform_sh_standalone .border-bottom-0 {
+  border-bottom: 0 !important; }
+.platform_sh_standalone .border-left-0 {
+  border-left: 0 !important; }
+.platform_sh_standalone .border-primary {
+  border-color: #145CC6 !important; }
+.platform_sh_standalone .border-secondary {
+  border-color: #6c757d !important; }
+.platform_sh_standalone .border-success {
+  border-color: #28a745 !important; }
+.platform_sh_standalone .border-info {
+  border-color: #17a2b8 !important; }
+.platform_sh_standalone .border-warning {
+  border-color: #F4BA37 !important; }
+.platform_sh_standalone .border-danger {
+  border-color: #dc3545 !important; }
+.platform_sh_standalone .border-light {
+  border-color: #f8f9fa !important; }
+.platform_sh_standalone .border-dark {
+  border-color: #343a40 !important; }
+.platform_sh_standalone .border-white {
+  border-color: #fff !important; }
+.platform_sh_standalone .rounded-sm {
+  border-radius: 0 !important; }
+.platform_sh_standalone .rounded {
+  border-radius: 0 !important; }
+.platform_sh_standalone .rounded-top {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important; }
+.platform_sh_standalone .rounded-right {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important; }
+.platform_sh_standalone .rounded-bottom {
+  border-bottom-right-radius: 0 !important;
+  border-bottom-left-radius: 0 !important; }
+.platform_sh_standalone .rounded-left {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important; }
+.platform_sh_standalone .rounded-lg {
+  border-radius: 0 !important; }
+.platform_sh_standalone .rounded-circle {
+  border-radius: 50% !important; }
+.platform_sh_standalone .rounded-pill {
+  border-radius: 50rem !important; }
+.platform_sh_standalone .rounded-0 {
+  border-radius: 0 !important; }
+.platform_sh_standalone .clearfix::after {
+  display: block;
+  clear: both;
+  content: ""; }
+.platform_sh_standalone .d-none {
+  display: none !important; }
+.platform_sh_standalone .d-inline {
+  display: inline !important; }
+.platform_sh_standalone .d-inline-block {
+  display: inline-block !important; }
+.platform_sh_standalone .d-block {
+  display: block !important; }
+.platform_sh_standalone .d-table {
+  display: table !important; }
+.platform_sh_standalone .d-table-row {
+  display: table-row !important; }
+.platform_sh_standalone .d-table-cell {
+  display: table-cell !important; }
+.platform_sh_standalone .d-flex {
+  display: flex !important; }
+.platform_sh_standalone .d-inline-flex {
+  display: inline-flex !important; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .d-xxs-none {
+    display: none !important; }
+  .platform_sh_standalone .d-xxs-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-xxs-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-xxs-block {
+    display: block !important; }
+  .platform_sh_standalone .d-xxs-table {
+    display: table !important; }
+  .platform_sh_standalone .d-xxs-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-xxs-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-xxs-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-xxs-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .d-xs-none {
+    display: none !important; }
+  .platform_sh_standalone .d-xs-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-xs-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-xs-block {
+    display: block !important; }
+  .platform_sh_standalone .d-xs-table {
+    display: table !important; }
+  .platform_sh_standalone .d-xs-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-xs-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-xs-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-xs-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .d-sm-none {
+    display: none !important; }
+  .platform_sh_standalone .d-sm-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-sm-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-sm-block {
+    display: block !important; }
+  .platform_sh_standalone .d-sm-table {
+    display: table !important; }
+  .platform_sh_standalone .d-sm-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-sm-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-sm-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-sm-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .d-md-none {
+    display: none !important; }
+  .platform_sh_standalone .d-md-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-md-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-md-block {
+    display: block !important; }
+  .platform_sh_standalone .d-md-table {
+    display: table !important; }
+  .platform_sh_standalone .d-md-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-md-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-md-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-md-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .d-lg-none {
+    display: none !important; }
+  .platform_sh_standalone .d-lg-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-lg-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-lg-block {
+    display: block !important; }
+  .platform_sh_standalone .d-lg-table {
+    display: table !important; }
+  .platform_sh_standalone .d-lg-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-lg-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-lg-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-lg-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .d-xl-none {
+    display: none !important; }
+  .platform_sh_standalone .d-xl-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-xl-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-xl-block {
+    display: block !important; }
+  .platform_sh_standalone .d-xl-table {
+    display: table !important; }
+  .platform_sh_standalone .d-xl-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-xl-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-xl-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-xl-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .d-xxl-none {
+    display: none !important; }
+  .platform_sh_standalone .d-xxl-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-xxl-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-xxl-block {
+    display: block !important; }
+  .platform_sh_standalone .d-xxl-table {
+    display: table !important; }
+  .platform_sh_standalone .d-xxl-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-xxl-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-xxl-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-xxl-inline-flex {
+    display: inline-flex !important; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .d-xxxl-none {
+    display: none !important; }
+  .platform_sh_standalone .d-xxxl-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-xxxl-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-xxxl-block {
+    display: block !important; }
+  .platform_sh_standalone .d-xxxl-table {
+    display: table !important; }
+  .platform_sh_standalone .d-xxxl-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-xxxl-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-xxxl-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-xxxl-inline-flex {
+    display: inline-flex !important; } }
+@media print {
+  .platform_sh_standalone .d-print-none {
+    display: none !important; }
+  .platform_sh_standalone .d-print-inline {
+    display: inline !important; }
+  .platform_sh_standalone .d-print-inline-block {
+    display: inline-block !important; }
+  .platform_sh_standalone .d-print-block {
+    display: block !important; }
+  .platform_sh_standalone .d-print-table {
+    display: table !important; }
+  .platform_sh_standalone .d-print-table-row {
+    display: table-row !important; }
+  .platform_sh_standalone .d-print-table-cell {
+    display: table-cell !important; }
+  .platform_sh_standalone .d-print-flex {
+    display: flex !important; }
+  .platform_sh_standalone .d-print-inline-flex {
+    display: inline-flex !important; } }
+.platform_sh_standalone .embed-responsive {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden; }
+.platform_sh_standalone .embed-responsive::before {
+  display: block;
+  content: ""; }
+.platform_sh_standalone .embed-responsive .embed-responsive-item,
+.platform_sh_standalone .embed-responsive iframe,
+.platform_sh_standalone .embed-responsive embed,
+.platform_sh_standalone .embed-responsive object,
+.platform_sh_standalone .embed-responsive video {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0; }
+.platform_sh_standalone .embed-responsive-21by9::before {
+  padding-top: 42.8571428571%; }
+.platform_sh_standalone .embed-responsive-16by9::before {
+  padding-top: 56.25%; }
+.platform_sh_standalone .embed-responsive-4by3::before {
+  padding-top: 75%; }
+.platform_sh_standalone .embed-responsive-1by1::before {
+  padding-top: 100%; }
+.platform_sh_standalone .embed-responsive-21by9::before {
+  padding-top: 42.8571428571%; }
+.platform_sh_standalone .embed-responsive-16by9::before {
+  padding-top: 56.25%; }
+.platform_sh_standalone .embed-responsive-4by3::before {
+  padding-top: 75%; }
+.platform_sh_standalone .embed-responsive-1by1::before {
+  padding-top: 100%; }
+.platform_sh_standalone .embed-responsive-21by9::before {
+  padding-top: 42.8571428571%; }
+.platform_sh_standalone .embed-responsive-16by9::before {
+  padding-top: 56.25%; }
+.platform_sh_standalone .embed-responsive-4by3::before {
+  padding-top: 75%; }
+.platform_sh_standalone .embed-responsive-1by1::before {
+  padding-top: 100%; }
+.platform_sh_standalone .flex-row {
+  flex-direction: row !important; }
+.platform_sh_standalone .flex-column {
+  flex-direction: column !important; }
+.platform_sh_standalone .flex-row-reverse {
+  flex-direction: row-reverse !important; }
+.platform_sh_standalone .flex-column-reverse {
+  flex-direction: column-reverse !important; }
+.platform_sh_standalone .flex-wrap {
+  flex-wrap: wrap !important; }
+.platform_sh_standalone .flex-nowrap {
+  flex-wrap: nowrap !important; }
+.platform_sh_standalone .flex-wrap-reverse {
+  flex-wrap: wrap-reverse !important; }
+.platform_sh_standalone .flex-fill {
+  flex: 1 1 auto !important; }
+.platform_sh_standalone .flex-grow-0 {
+  flex-grow: 0 !important; }
+.platform_sh_standalone .flex-grow-1 {
+  flex-grow: 1 !important; }
+.platform_sh_standalone .flex-shrink-0 {
+  flex-shrink: 0 !important; }
+.platform_sh_standalone .flex-shrink-1 {
+  flex-shrink: 1 !important; }
+.platform_sh_standalone .justify-content-start {
+  justify-content: flex-start !important; }
+.platform_sh_standalone .justify-content-end {
+  justify-content: flex-end !important; }
+.platform_sh_standalone .justify-content-center {
+  justify-content: center !important; }
+.platform_sh_standalone .justify-content-between {
+  justify-content: space-between !important; }
+.platform_sh_standalone .justify-content-around {
+  justify-content: space-around !important; }
+.platform_sh_standalone .align-items-start {
+  align-items: flex-start !important; }
+.platform_sh_standalone .align-items-end {
+  align-items: flex-end !important; }
+.platform_sh_standalone .align-items-center {
+  align-items: center !important; }
+.platform_sh_standalone .align-items-baseline {
+  align-items: baseline !important; }
+.platform_sh_standalone .align-items-stretch {
+  align-items: stretch !important; }
+.platform_sh_standalone .align-content-start {
+  align-content: flex-start !important; }
+.platform_sh_standalone .align-content-end {
+  align-content: flex-end !important; }
+.platform_sh_standalone .align-content-center {
+  align-content: center !important; }
+.platform_sh_standalone .align-content-between {
+  align-content: space-between !important; }
+.platform_sh_standalone .align-content-around {
+  align-content: space-around !important; }
+.platform_sh_standalone .align-content-stretch {
+  align-content: stretch !important; }
+.platform_sh_standalone .align-self-auto {
+  align-self: auto !important; }
+.platform_sh_standalone .align-self-start {
+  align-self: flex-start !important; }
+.platform_sh_standalone .align-self-end {
+  align-self: flex-end !important; }
+.platform_sh_standalone .align-self-center {
+  align-self: center !important; }
+.platform_sh_standalone .align-self-baseline {
+  align-self: baseline !important; }
+.platform_sh_standalone .align-self-stretch {
+  align-self: stretch !important; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .flex-xxs-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-xxs-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-xxs-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-xxs-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-xxs-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-xxs-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-xxs-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-xxs-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-xxs-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-xxs-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-xxs-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-xxs-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-xxs-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-xxs-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-xxs-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-xxs-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-xxs-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-xxs-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-xxs-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-xxs-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-xxs-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-xxs-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-xxs-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-xxs-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-xxs-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-xxs-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-xxs-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-xxs-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-xxs-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-xxs-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-xxs-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-xxs-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-xxs-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-xxs-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .flex-xs-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-xs-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-xs-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-xs-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-xs-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-xs-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-xs-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-xs-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-xs-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-xs-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-xs-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-xs-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-xs-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-xs-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-xs-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-xs-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-xs-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-xs-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-xs-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-xs-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-xs-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-xs-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-xs-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-xs-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-xs-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-xs-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-xs-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-xs-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-xs-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-xs-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-xs-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-xs-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-xs-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-xs-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .flex-sm-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-sm-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-sm-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-sm-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-sm-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-sm-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-sm-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-sm-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-sm-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-sm-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-sm-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-sm-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-sm-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-sm-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-sm-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-sm-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-sm-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-sm-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-sm-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-sm-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-sm-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-sm-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-sm-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-sm-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-sm-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-sm-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-sm-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-sm-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-sm-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-sm-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-sm-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-sm-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-sm-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-sm-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .flex-md-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-md-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-md-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-md-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-md-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-md-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-md-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-md-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-md-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-md-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-md-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-md-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-md-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-md-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-md-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-md-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-md-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-md-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-md-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-md-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-md-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-md-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-md-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-md-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-md-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-md-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-md-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-md-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-md-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-md-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-md-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-md-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-md-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-md-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .flex-lg-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-lg-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-lg-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-lg-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-lg-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-lg-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-lg-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-lg-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-lg-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-lg-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-lg-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-lg-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-lg-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-lg-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-lg-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-lg-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-lg-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-lg-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-lg-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-lg-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-lg-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-lg-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-lg-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-lg-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-lg-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-lg-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-lg-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-lg-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-lg-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-lg-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-lg-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-lg-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-lg-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-lg-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .flex-xl-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-xl-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-xl-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-xl-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-xl-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-xl-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-xl-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-xl-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-xl-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-xl-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-xl-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-xl-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-xl-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-xl-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-xl-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-xl-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-xl-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-xl-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-xl-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-xl-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-xl-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-xl-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-xl-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-xl-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-xl-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-xl-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-xl-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-xl-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-xl-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-xl-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-xl-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-xl-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-xl-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-xl-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .flex-xxl-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-xxl-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-xxl-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-xxl-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-xxl-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-xxl-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-xxl-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-xxl-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-xxl-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-xxl-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-xxl-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-xxl-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-xxl-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-xxl-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-xxl-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-xxl-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-xxl-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-xxl-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-xxl-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-xxl-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-xxl-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-xxl-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-xxl-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-xxl-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-xxl-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-xxl-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-xxl-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-xxl-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-xxl-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-xxl-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-xxl-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-xxl-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-xxl-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-xxl-stretch {
+    align-self: stretch !important; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .flex-xxxl-row {
+    flex-direction: row !important; }
+  .platform_sh_standalone .flex-xxxl-column {
+    flex-direction: column !important; }
+  .platform_sh_standalone .flex-xxxl-row-reverse {
+    flex-direction: row-reverse !important; }
+  .platform_sh_standalone .flex-xxxl-column-reverse {
+    flex-direction: column-reverse !important; }
+  .platform_sh_standalone .flex-xxxl-wrap {
+    flex-wrap: wrap !important; }
+  .platform_sh_standalone .flex-xxxl-nowrap {
+    flex-wrap: nowrap !important; }
+  .platform_sh_standalone .flex-xxxl-wrap-reverse {
+    flex-wrap: wrap-reverse !important; }
+  .platform_sh_standalone .flex-xxxl-fill {
+    flex: 1 1 auto !important; }
+  .platform_sh_standalone .flex-xxxl-grow-0 {
+    flex-grow: 0 !important; }
+  .platform_sh_standalone .flex-xxxl-grow-1 {
+    flex-grow: 1 !important; }
+  .platform_sh_standalone .flex-xxxl-shrink-0 {
+    flex-shrink: 0 !important; }
+  .platform_sh_standalone .flex-xxxl-shrink-1 {
+    flex-shrink: 1 !important; }
+  .platform_sh_standalone .justify-content-xxxl-start {
+    justify-content: flex-start !important; }
+  .platform_sh_standalone .justify-content-xxxl-end {
+    justify-content: flex-end !important; }
+  .platform_sh_standalone .justify-content-xxxl-center {
+    justify-content: center !important; }
+  .platform_sh_standalone .justify-content-xxxl-between {
+    justify-content: space-between !important; }
+  .platform_sh_standalone .justify-content-xxxl-around {
+    justify-content: space-around !important; }
+  .platform_sh_standalone .align-items-xxxl-start {
+    align-items: flex-start !important; }
+  .platform_sh_standalone .align-items-xxxl-end {
+    align-items: flex-end !important; }
+  .platform_sh_standalone .align-items-xxxl-center {
+    align-items: center !important; }
+  .platform_sh_standalone .align-items-xxxl-baseline {
+    align-items: baseline !important; }
+  .platform_sh_standalone .align-items-xxxl-stretch {
+    align-items: stretch !important; }
+  .platform_sh_standalone .align-content-xxxl-start {
+    align-content: flex-start !important; }
+  .platform_sh_standalone .align-content-xxxl-end {
+    align-content: flex-end !important; }
+  .platform_sh_standalone .align-content-xxxl-center {
+    align-content: center !important; }
+  .platform_sh_standalone .align-content-xxxl-between {
+    align-content: space-between !important; }
+  .platform_sh_standalone .align-content-xxxl-around {
+    align-content: space-around !important; }
+  .platform_sh_standalone .align-content-xxxl-stretch {
+    align-content: stretch !important; }
+  .platform_sh_standalone .align-self-xxxl-auto {
+    align-self: auto !important; }
+  .platform_sh_standalone .align-self-xxxl-start {
+    align-self: flex-start !important; }
+  .platform_sh_standalone .align-self-xxxl-end {
+    align-self: flex-end !important; }
+  .platform_sh_standalone .align-self-xxxl-center {
+    align-self: center !important; }
+  .platform_sh_standalone .align-self-xxxl-baseline {
+    align-self: baseline !important; }
+  .platform_sh_standalone .align-self-xxxl-stretch {
+    align-self: stretch !important; } }
+.platform_sh_standalone .float-left {
+  float: left !important; }
+.platform_sh_standalone .float-right {
+  float: right !important; }
+.platform_sh_standalone .float-none {
+  float: none !important; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .float-xxs-left {
+    float: left !important; }
+  .platform_sh_standalone .float-xxs-right {
+    float: right !important; }
+  .platform_sh_standalone .float-xxs-none {
+    float: none !important; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .float-xs-left {
+    float: left !important; }
+  .platform_sh_standalone .float-xs-right {
+    float: right !important; }
+  .platform_sh_standalone .float-xs-none {
+    float: none !important; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .float-sm-left {
+    float: left !important; }
+  .platform_sh_standalone .float-sm-right {
+    float: right !important; }
+  .platform_sh_standalone .float-sm-none {
+    float: none !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .float-md-left {
+    float: left !important; }
+  .platform_sh_standalone .float-md-right {
+    float: right !important; }
+  .platform_sh_standalone .float-md-none {
+    float: none !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .float-lg-left {
+    float: left !important; }
+  .platform_sh_standalone .float-lg-right {
+    float: right !important; }
+  .platform_sh_standalone .float-lg-none {
+    float: none !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .float-xl-left {
+    float: left !important; }
+  .platform_sh_standalone .float-xl-right {
+    float: right !important; }
+  .platform_sh_standalone .float-xl-none {
+    float: none !important; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .float-xxl-left {
+    float: left !important; }
+  .platform_sh_standalone .float-xxl-right {
+    float: right !important; }
+  .platform_sh_standalone .float-xxl-none {
+    float: none !important; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .float-xxxl-left {
+    float: left !important; }
+  .platform_sh_standalone .float-xxxl-right {
+    float: right !important; }
+  .platform_sh_standalone .float-xxxl-none {
+    float: none !important; } }
+.platform_sh_standalone .overflow-auto {
+  overflow: auto !important; }
+.platform_sh_standalone .overflow-hidden {
+  overflow: hidden !important; }
+.platform_sh_standalone .position-static {
+  position: static !important; }
+.platform_sh_standalone .position-relative {
+  position: relative !important; }
+.platform_sh_standalone .position-absolute {
+  position: absolute !important; }
+.platform_sh_standalone .position-fixed {
+  position: fixed !important; }
+.platform_sh_standalone .position-sticky {
+  position: sticky !important; }
+.platform_sh_standalone .fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1030; }
+.platform_sh_standalone .fixed-bottom {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1030; }
+@supports (position: sticky) {
+  .platform_sh_standalone .sticky-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020; } }
+.platform_sh_standalone .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0; }
+.platform_sh_standalone .sr-only-focusable:active, .platform_sh_standalone .sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
+  white-space: normal; }
+.platform_sh_standalone .shadow-sm {
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important; }
+.platform_sh_standalone .shadow {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important; }
+.platform_sh_standalone .shadow-lg {
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175) !important; }
+.platform_sh_standalone .shadow-none {
+  box-shadow: none !important; }
+.platform_sh_standalone .w-25 {
+  width: 25% !important; }
+.platform_sh_standalone .w-50 {
+  width: 50% !important; }
+.platform_sh_standalone .w-75 {
+  width: 75% !important; }
+.platform_sh_standalone .w-100 {
+  width: 100% !important; }
+.platform_sh_standalone .w-auto {
+  width: auto !important; }
+.platform_sh_standalone .h-25 {
+  height: 25% !important; }
+.platform_sh_standalone .h-50 {
+  height: 50% !important; }
+.platform_sh_standalone .h-75 {
+  height: 75% !important; }
+.platform_sh_standalone .h-100 {
+  height: 100% !important; }
+.platform_sh_standalone .h-auto {
+  height: auto !important; }
+.platform_sh_standalone .mw-100 {
+  max-width: 100% !important; }
+.platform_sh_standalone .mh-100 {
+  max-height: 100% !important; }
+.platform_sh_standalone .min-vw-100 {
+  min-width: 100vw !important; }
+.platform_sh_standalone .min-vh-100 {
+  min-height: 100vh !important; }
+.platform_sh_standalone .vw-100 {
+  width: 100vw !important; }
+.platform_sh_standalone .vh-100 {
+  height: 100vh !important; }
+.platform_sh_standalone .stretched-link::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  pointer-events: auto;
+  content: "";
+  background-color: rgba(0, 0, 0, 0); }
+.platform_sh_standalone .m-0 {
+  margin: 0 !important; }
+.platform_sh_standalone .mt-0,
+.platform_sh_standalone .my-0 {
+  margin-top: 0 !important; }
+.platform_sh_standalone .mr-0,
+.platform_sh_standalone .mx-0 {
+  margin-right: 0 !important; }
+.platform_sh_standalone .mb-0,
+.platform_sh_standalone .my-0 {
+  margin-bottom: 0 !important; }
+.platform_sh_standalone .ml-0,
+.platform_sh_standalone .mx-0 {
+  margin-left: 0 !important; }
+.platform_sh_standalone .m-1 {
+  margin: 0.25rem !important; }
+.platform_sh_standalone .mt-1,
+.platform_sh_standalone .my-1 {
+  margin-top: 0.25rem !important; }
+.platform_sh_standalone .mr-1,
+.platform_sh_standalone .mx-1 {
+  margin-right: 0.25rem !important; }
+.platform_sh_standalone .mb-1,
+.platform_sh_standalone .my-1 {
+  margin-bottom: 0.25rem !important; }
+.platform_sh_standalone .ml-1,
+.platform_sh_standalone .mx-1 {
+  margin-left: 0.25rem !important; }
+.platform_sh_standalone .m-2 {
+  margin: 0.5rem !important; }
+.platform_sh_standalone .mt-2,
+.platform_sh_standalone .my-2 {
+  margin-top: 0.5rem !important; }
+.platform_sh_standalone .mr-2,
+.platform_sh_standalone .mx-2 {
+  margin-right: 0.5rem !important; }
+.platform_sh_standalone .mb-2,
+.platform_sh_standalone .my-2 {
+  margin-bottom: 0.5rem !important; }
+.platform_sh_standalone .ml-2,
+.platform_sh_standalone .mx-2 {
+  margin-left: 0.5rem !important; }
+.platform_sh_standalone .m-3 {
+  margin: 1rem !important; }
+.platform_sh_standalone .mt-3,
+.platform_sh_standalone .my-3 {
+  margin-top: 1rem !important; }
+.platform_sh_standalone .mr-3,
+.platform_sh_standalone .mx-3 {
+  margin-right: 1rem !important; }
+.platform_sh_standalone .mb-3,
+.platform_sh_standalone .my-3 {
+  margin-bottom: 1rem !important; }
+.platform_sh_standalone .ml-3,
+.platform_sh_standalone .mx-3 {
+  margin-left: 1rem !important; }
+.platform_sh_standalone .m-4 {
+  margin: 1.5rem !important; }
+.platform_sh_standalone .mt-4,
+.platform_sh_standalone .my-4 {
+  margin-top: 1.5rem !important; }
+.platform_sh_standalone .mr-4,
+.platform_sh_standalone .mx-4 {
+  margin-right: 1.5rem !important; }
+.platform_sh_standalone .mb-4,
+.platform_sh_standalone .my-4 {
+  margin-bottom: 1.5rem !important; }
+.platform_sh_standalone .ml-4,
+.platform_sh_standalone .mx-4 {
+  margin-left: 1.5rem !important; }
+.platform_sh_standalone .m-5 {
+  margin: 3rem !important; }
+.platform_sh_standalone .mt-5,
+.platform_sh_standalone .my-5 {
+  margin-top: 3rem !important; }
+.platform_sh_standalone .mr-5,
+.platform_sh_standalone .mx-5 {
+  margin-right: 3rem !important; }
+.platform_sh_standalone .mb-5,
+.platform_sh_standalone .my-5 {
+  margin-bottom: 3rem !important; }
+.platform_sh_standalone .ml-5,
+.platform_sh_standalone .mx-5 {
+  margin-left: 3rem !important; }
+.platform_sh_standalone .p-0 {
+  padding: 0 !important; }
+.platform_sh_standalone .pt-0,
+.platform_sh_standalone .py-0 {
+  padding-top: 0 !important; }
+.platform_sh_standalone .pr-0,
+.platform_sh_standalone .px-0 {
+  padding-right: 0 !important; }
+.platform_sh_standalone .pb-0,
+.platform_sh_standalone .py-0 {
+  padding-bottom: 0 !important; }
+.platform_sh_standalone .pl-0,
+.platform_sh_standalone .px-0 {
+  padding-left: 0 !important; }
+.platform_sh_standalone .p-1 {
+  padding: 0.25rem !important; }
+.platform_sh_standalone .pt-1,
+.platform_sh_standalone .py-1 {
+  padding-top: 0.25rem !important; }
+.platform_sh_standalone .pr-1,
+.platform_sh_standalone .px-1 {
+  padding-right: 0.25rem !important; }
+.platform_sh_standalone .pb-1,
+.platform_sh_standalone .py-1 {
+  padding-bottom: 0.25rem !important; }
+.platform_sh_standalone .pl-1,
+.platform_sh_standalone .px-1 {
+  padding-left: 0.25rem !important; }
+.platform_sh_standalone .p-2 {
+  padding: 0.5rem !important; }
+.platform_sh_standalone .pt-2,
+.platform_sh_standalone .py-2 {
+  padding-top: 0.5rem !important; }
+.platform_sh_standalone .pr-2,
+.platform_sh_standalone .px-2 {
+  padding-right: 0.5rem !important; }
+.platform_sh_standalone .pb-2,
+.platform_sh_standalone .py-2 {
+  padding-bottom: 0.5rem !important; }
+.platform_sh_standalone .pl-2,
+.platform_sh_standalone .px-2 {
+  padding-left: 0.5rem !important; }
+.platform_sh_standalone .p-3 {
+  padding: 1rem !important; }
+.platform_sh_standalone .pt-3,
+.platform_sh_standalone .py-3 {
+  padding-top: 1rem !important; }
+.platform_sh_standalone .pr-3,
+.platform_sh_standalone .px-3 {
+  padding-right: 1rem !important; }
+.platform_sh_standalone .pb-3,
+.platform_sh_standalone .py-3 {
+  padding-bottom: 1rem !important; }
+.platform_sh_standalone .pl-3,
+.platform_sh_standalone .px-3 {
+  padding-left: 1rem !important; }
+.platform_sh_standalone .p-4 {
+  padding: 1.5rem !important; }
+.platform_sh_standalone .pt-4,
+.platform_sh_standalone .py-4 {
+  padding-top: 1.5rem !important; }
+.platform_sh_standalone .pr-4,
+.platform_sh_standalone .px-4 {
+  padding-right: 1.5rem !important; }
+.platform_sh_standalone .pb-4,
+.platform_sh_standalone .py-4 {
+  padding-bottom: 1.5rem !important; }
+.platform_sh_standalone .pl-4,
+.platform_sh_standalone .px-4 {
+  padding-left: 1.5rem !important; }
+.platform_sh_standalone .p-5 {
+  padding: 3rem !important; }
+.platform_sh_standalone .pt-5,
+.platform_sh_standalone .py-5 {
+  padding-top: 3rem !important; }
+.platform_sh_standalone .pr-5,
+.platform_sh_standalone .px-5 {
+  padding-right: 3rem !important; }
+.platform_sh_standalone .pb-5,
+.platform_sh_standalone .py-5 {
+  padding-bottom: 3rem !important; }
+.platform_sh_standalone .pl-5,
+.platform_sh_standalone .px-5 {
+  padding-left: 3rem !important; }
+.platform_sh_standalone .m-n1 {
+  margin: -0.25rem !important; }
+.platform_sh_standalone .mt-n1,
+.platform_sh_standalone .my-n1 {
+  margin-top: -0.25rem !important; }
+.platform_sh_standalone .mr-n1,
+.platform_sh_standalone .mx-n1 {
+  margin-right: -0.25rem !important; }
+.platform_sh_standalone .mb-n1,
+.platform_sh_standalone .my-n1 {
+  margin-bottom: -0.25rem !important; }
+.platform_sh_standalone .ml-n1,
+.platform_sh_standalone .mx-n1 {
+  margin-left: -0.25rem !important; }
+.platform_sh_standalone .m-n2 {
+  margin: -0.5rem !important; }
+.platform_sh_standalone .mt-n2,
+.platform_sh_standalone .my-n2 {
+  margin-top: -0.5rem !important; }
+.platform_sh_standalone .mr-n2,
+.platform_sh_standalone .mx-n2 {
+  margin-right: -0.5rem !important; }
+.platform_sh_standalone .mb-n2,
+.platform_sh_standalone .my-n2 {
+  margin-bottom: -0.5rem !important; }
+.platform_sh_standalone .ml-n2,
+.platform_sh_standalone .mx-n2 {
+  margin-left: -0.5rem !important; }
+.platform_sh_standalone .m-n3 {
+  margin: -1rem !important; }
+.platform_sh_standalone .mt-n3,
+.platform_sh_standalone .my-n3 {
+  margin-top: -1rem !important; }
+.platform_sh_standalone .mr-n3,
+.platform_sh_standalone .mx-n3 {
+  margin-right: -1rem !important; }
+.platform_sh_standalone .mb-n3,
+.platform_sh_standalone .my-n3 {
+  margin-bottom: -1rem !important; }
+.platform_sh_standalone .ml-n3,
+.platform_sh_standalone .mx-n3 {
+  margin-left: -1rem !important; }
+.platform_sh_standalone .m-n4 {
+  margin: -1.5rem !important; }
+.platform_sh_standalone .mt-n4,
+.platform_sh_standalone .my-n4 {
+  margin-top: -1.5rem !important; }
+.platform_sh_standalone .mr-n4,
+.platform_sh_standalone .mx-n4 {
+  margin-right: -1.5rem !important; }
+.platform_sh_standalone .mb-n4,
+.platform_sh_standalone .my-n4 {
+  margin-bottom: -1.5rem !important; }
+.platform_sh_standalone .ml-n4,
+.platform_sh_standalone .mx-n4 {
+  margin-left: -1.5rem !important; }
+.platform_sh_standalone .m-n5 {
+  margin: -3rem !important; }
+.platform_sh_standalone .mt-n5,
+.platform_sh_standalone .my-n5 {
+  margin-top: -3rem !important; }
+.platform_sh_standalone .mr-n5,
+.platform_sh_standalone .mx-n5 {
+  margin-right: -3rem !important; }
+.platform_sh_standalone .mb-n5,
+.platform_sh_standalone .my-n5 {
+  margin-bottom: -3rem !important; }
+.platform_sh_standalone .ml-n5,
+.platform_sh_standalone .mx-n5 {
+  margin-left: -3rem !important; }
+.platform_sh_standalone .m-auto {
+  margin: auto !important; }
+.platform_sh_standalone .mt-auto,
+.platform_sh_standalone .my-auto {
+  margin-top: auto !important; }
+.platform_sh_standalone .mr-auto,
+.platform_sh_standalone .mx-auto {
+  margin-right: auto !important; }
+.platform_sh_standalone .mb-auto,
+.platform_sh_standalone .my-auto {
+  margin-bottom: auto !important; }
+.platform_sh_standalone .ml-auto,
+.platform_sh_standalone .mx-auto {
+  margin-left: auto !important; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .m-xxs-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-xxs-0,
+  .platform_sh_standalone .my-xxs-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-xxs-0,
+  .platform_sh_standalone .mx-xxs-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-xxs-0,
+  .platform_sh_standalone .my-xxs-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-xxs-0,
+  .platform_sh_standalone .mx-xxs-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-xxs-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-xxs-1,
+  .platform_sh_standalone .my-xxs-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-xxs-1,
+  .platform_sh_standalone .mx-xxs-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-xxs-1,
+  .platform_sh_standalone .my-xxs-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-xxs-1,
+  .platform_sh_standalone .mx-xxs-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-xxs-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-xxs-2,
+  .platform_sh_standalone .my-xxs-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-xxs-2,
+  .platform_sh_standalone .mx-xxs-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-xxs-2,
+  .platform_sh_standalone .my-xxs-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-xxs-2,
+  .platform_sh_standalone .mx-xxs-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-xxs-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-xxs-3,
+  .platform_sh_standalone .my-xxs-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-xxs-3,
+  .platform_sh_standalone .mx-xxs-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-xxs-3,
+  .platform_sh_standalone .my-xxs-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-xxs-3,
+  .platform_sh_standalone .mx-xxs-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-xxs-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-xxs-4,
+  .platform_sh_standalone .my-xxs-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-xxs-4,
+  .platform_sh_standalone .mx-xxs-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-xxs-4,
+  .platform_sh_standalone .my-xxs-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-xxs-4,
+  .platform_sh_standalone .mx-xxs-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-xxs-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-xxs-5,
+  .platform_sh_standalone .my-xxs-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-xxs-5,
+  .platform_sh_standalone .mx-xxs-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-xxs-5,
+  .platform_sh_standalone .my-xxs-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-xxs-5,
+  .platform_sh_standalone .mx-xxs-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-xxs-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-xxs-0,
+  .platform_sh_standalone .py-xxs-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-xxs-0,
+  .platform_sh_standalone .px-xxs-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-xxs-0,
+  .platform_sh_standalone .py-xxs-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-xxs-0,
+  .platform_sh_standalone .px-xxs-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-xxs-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-xxs-1,
+  .platform_sh_standalone .py-xxs-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-xxs-1,
+  .platform_sh_standalone .px-xxs-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-xxs-1,
+  .platform_sh_standalone .py-xxs-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-xxs-1,
+  .platform_sh_standalone .px-xxs-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-xxs-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-xxs-2,
+  .platform_sh_standalone .py-xxs-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-xxs-2,
+  .platform_sh_standalone .px-xxs-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-xxs-2,
+  .platform_sh_standalone .py-xxs-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-xxs-2,
+  .platform_sh_standalone .px-xxs-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-xxs-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-xxs-3,
+  .platform_sh_standalone .py-xxs-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-xxs-3,
+  .platform_sh_standalone .px-xxs-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-xxs-3,
+  .platform_sh_standalone .py-xxs-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-xxs-3,
+  .platform_sh_standalone .px-xxs-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-xxs-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-xxs-4,
+  .platform_sh_standalone .py-xxs-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-xxs-4,
+  .platform_sh_standalone .px-xxs-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-xxs-4,
+  .platform_sh_standalone .py-xxs-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-xxs-4,
+  .platform_sh_standalone .px-xxs-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-xxs-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-xxs-5,
+  .platform_sh_standalone .py-xxs-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-xxs-5,
+  .platform_sh_standalone .px-xxs-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-xxs-5,
+  .platform_sh_standalone .py-xxs-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-xxs-5,
+  .platform_sh_standalone .px-xxs-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-xxs-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-xxs-n1,
+  .platform_sh_standalone .my-xxs-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-xxs-n1,
+  .platform_sh_standalone .mx-xxs-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-xxs-n1,
+  .platform_sh_standalone .my-xxs-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-xxs-n1,
+  .platform_sh_standalone .mx-xxs-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-xxs-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-xxs-n2,
+  .platform_sh_standalone .my-xxs-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-xxs-n2,
+  .platform_sh_standalone .mx-xxs-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-xxs-n2,
+  .platform_sh_standalone .my-xxs-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-xxs-n2,
+  .platform_sh_standalone .mx-xxs-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-xxs-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-xxs-n3,
+  .platform_sh_standalone .my-xxs-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-xxs-n3,
+  .platform_sh_standalone .mx-xxs-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-xxs-n3,
+  .platform_sh_standalone .my-xxs-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-xxs-n3,
+  .platform_sh_standalone .mx-xxs-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-xxs-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-xxs-n4,
+  .platform_sh_standalone .my-xxs-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-xxs-n4,
+  .platform_sh_standalone .mx-xxs-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-xxs-n4,
+  .platform_sh_standalone .my-xxs-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-xxs-n4,
+  .platform_sh_standalone .mx-xxs-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-xxs-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-xxs-n5,
+  .platform_sh_standalone .my-xxs-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-xxs-n5,
+  .platform_sh_standalone .mx-xxs-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-xxs-n5,
+  .platform_sh_standalone .my-xxs-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-xxs-n5,
+  .platform_sh_standalone .mx-xxs-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-xxs-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-xxs-auto,
+  .platform_sh_standalone .my-xxs-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-xxs-auto,
+  .platform_sh_standalone .mx-xxs-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-xxs-auto,
+  .platform_sh_standalone .my-xxs-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-xxs-auto,
+  .platform_sh_standalone .mx-xxs-auto {
+    margin-left: auto !important; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .m-xs-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-xs-0,
+  .platform_sh_standalone .my-xs-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-xs-0,
+  .platform_sh_standalone .mx-xs-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-xs-0,
+  .platform_sh_standalone .my-xs-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-xs-0,
+  .platform_sh_standalone .mx-xs-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-xs-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-xs-1,
+  .platform_sh_standalone .my-xs-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-xs-1,
+  .platform_sh_standalone .mx-xs-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-xs-1,
+  .platform_sh_standalone .my-xs-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-xs-1,
+  .platform_sh_standalone .mx-xs-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-xs-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-xs-2,
+  .platform_sh_standalone .my-xs-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-xs-2,
+  .platform_sh_standalone .mx-xs-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-xs-2,
+  .platform_sh_standalone .my-xs-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-xs-2,
+  .platform_sh_standalone .mx-xs-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-xs-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-xs-3,
+  .platform_sh_standalone .my-xs-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-xs-3,
+  .platform_sh_standalone .mx-xs-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-xs-3,
+  .platform_sh_standalone .my-xs-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-xs-3,
+  .platform_sh_standalone .mx-xs-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-xs-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-xs-4,
+  .platform_sh_standalone .my-xs-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-xs-4,
+  .platform_sh_standalone .mx-xs-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-xs-4,
+  .platform_sh_standalone .my-xs-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-xs-4,
+  .platform_sh_standalone .mx-xs-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-xs-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-xs-5,
+  .platform_sh_standalone .my-xs-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-xs-5,
+  .platform_sh_standalone .mx-xs-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-xs-5,
+  .platform_sh_standalone .my-xs-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-xs-5,
+  .platform_sh_standalone .mx-xs-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-xs-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-xs-0,
+  .platform_sh_standalone .py-xs-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-xs-0,
+  .platform_sh_standalone .px-xs-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-xs-0,
+  .platform_sh_standalone .py-xs-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-xs-0,
+  .platform_sh_standalone .px-xs-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-xs-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-xs-1,
+  .platform_sh_standalone .py-xs-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-xs-1,
+  .platform_sh_standalone .px-xs-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-xs-1,
+  .platform_sh_standalone .py-xs-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-xs-1,
+  .platform_sh_standalone .px-xs-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-xs-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-xs-2,
+  .platform_sh_standalone .py-xs-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-xs-2,
+  .platform_sh_standalone .px-xs-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-xs-2,
+  .platform_sh_standalone .py-xs-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-xs-2,
+  .platform_sh_standalone .px-xs-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-xs-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-xs-3,
+  .platform_sh_standalone .py-xs-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-xs-3,
+  .platform_sh_standalone .px-xs-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-xs-3,
+  .platform_sh_standalone .py-xs-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-xs-3,
+  .platform_sh_standalone .px-xs-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-xs-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-xs-4,
+  .platform_sh_standalone .py-xs-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-xs-4,
+  .platform_sh_standalone .px-xs-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-xs-4,
+  .platform_sh_standalone .py-xs-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-xs-4,
+  .platform_sh_standalone .px-xs-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-xs-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-xs-5,
+  .platform_sh_standalone .py-xs-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-xs-5,
+  .platform_sh_standalone .px-xs-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-xs-5,
+  .platform_sh_standalone .py-xs-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-xs-5,
+  .platform_sh_standalone .px-xs-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-xs-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-xs-n1,
+  .platform_sh_standalone .my-xs-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-xs-n1,
+  .platform_sh_standalone .mx-xs-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-xs-n1,
+  .platform_sh_standalone .my-xs-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-xs-n1,
+  .platform_sh_standalone .mx-xs-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-xs-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-xs-n2,
+  .platform_sh_standalone .my-xs-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-xs-n2,
+  .platform_sh_standalone .mx-xs-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-xs-n2,
+  .platform_sh_standalone .my-xs-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-xs-n2,
+  .platform_sh_standalone .mx-xs-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-xs-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-xs-n3,
+  .platform_sh_standalone .my-xs-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-xs-n3,
+  .platform_sh_standalone .mx-xs-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-xs-n3,
+  .platform_sh_standalone .my-xs-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-xs-n3,
+  .platform_sh_standalone .mx-xs-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-xs-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-xs-n4,
+  .platform_sh_standalone .my-xs-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-xs-n4,
+  .platform_sh_standalone .mx-xs-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-xs-n4,
+  .platform_sh_standalone .my-xs-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-xs-n4,
+  .platform_sh_standalone .mx-xs-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-xs-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-xs-n5,
+  .platform_sh_standalone .my-xs-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-xs-n5,
+  .platform_sh_standalone .mx-xs-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-xs-n5,
+  .platform_sh_standalone .my-xs-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-xs-n5,
+  .platform_sh_standalone .mx-xs-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-xs-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-xs-auto,
+  .platform_sh_standalone .my-xs-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-xs-auto,
+  .platform_sh_standalone .mx-xs-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-xs-auto,
+  .platform_sh_standalone .my-xs-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-xs-auto,
+  .platform_sh_standalone .mx-xs-auto {
+    margin-left: auto !important; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .m-sm-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-sm-0,
+  .platform_sh_standalone .my-sm-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-sm-0,
+  .platform_sh_standalone .mx-sm-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-sm-0,
+  .platform_sh_standalone .my-sm-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-sm-0,
+  .platform_sh_standalone .mx-sm-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-sm-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-sm-1,
+  .platform_sh_standalone .my-sm-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-sm-1,
+  .platform_sh_standalone .mx-sm-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-sm-1,
+  .platform_sh_standalone .my-sm-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-sm-1,
+  .platform_sh_standalone .mx-sm-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-sm-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-sm-2,
+  .platform_sh_standalone .my-sm-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-sm-2,
+  .platform_sh_standalone .mx-sm-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-sm-2,
+  .platform_sh_standalone .my-sm-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-sm-2,
+  .platform_sh_standalone .mx-sm-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-sm-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-sm-3,
+  .platform_sh_standalone .my-sm-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-sm-3,
+  .platform_sh_standalone .mx-sm-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-sm-3,
+  .platform_sh_standalone .my-sm-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-sm-3,
+  .platform_sh_standalone .mx-sm-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-sm-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-sm-4,
+  .platform_sh_standalone .my-sm-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-sm-4,
+  .platform_sh_standalone .mx-sm-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-sm-4,
+  .platform_sh_standalone .my-sm-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-sm-4,
+  .platform_sh_standalone .mx-sm-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-sm-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-sm-5,
+  .platform_sh_standalone .my-sm-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-sm-5,
+  .platform_sh_standalone .mx-sm-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-sm-5,
+  .platform_sh_standalone .my-sm-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-sm-5,
+  .platform_sh_standalone .mx-sm-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-sm-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-sm-0,
+  .platform_sh_standalone .py-sm-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-sm-0,
+  .platform_sh_standalone .px-sm-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-sm-0,
+  .platform_sh_standalone .py-sm-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-sm-0,
+  .platform_sh_standalone .px-sm-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-sm-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-sm-1,
+  .platform_sh_standalone .py-sm-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-sm-1,
+  .platform_sh_standalone .px-sm-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-sm-1,
+  .platform_sh_standalone .py-sm-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-sm-1,
+  .platform_sh_standalone .px-sm-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-sm-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-sm-2,
+  .platform_sh_standalone .py-sm-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-sm-2,
+  .platform_sh_standalone .px-sm-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-sm-2,
+  .platform_sh_standalone .py-sm-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-sm-2,
+  .platform_sh_standalone .px-sm-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-sm-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-sm-3,
+  .platform_sh_standalone .py-sm-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-sm-3,
+  .platform_sh_standalone .px-sm-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-sm-3,
+  .platform_sh_standalone .py-sm-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-sm-3,
+  .platform_sh_standalone .px-sm-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-sm-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-sm-4,
+  .platform_sh_standalone .py-sm-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-sm-4,
+  .platform_sh_standalone .px-sm-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-sm-4,
+  .platform_sh_standalone .py-sm-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-sm-4,
+  .platform_sh_standalone .px-sm-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-sm-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-sm-5,
+  .platform_sh_standalone .py-sm-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-sm-5,
+  .platform_sh_standalone .px-sm-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-sm-5,
+  .platform_sh_standalone .py-sm-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-sm-5,
+  .platform_sh_standalone .px-sm-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-sm-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-sm-n1,
+  .platform_sh_standalone .my-sm-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-sm-n1,
+  .platform_sh_standalone .mx-sm-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-sm-n1,
+  .platform_sh_standalone .my-sm-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-sm-n1,
+  .platform_sh_standalone .mx-sm-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-sm-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-sm-n2,
+  .platform_sh_standalone .my-sm-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-sm-n2,
+  .platform_sh_standalone .mx-sm-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-sm-n2,
+  .platform_sh_standalone .my-sm-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-sm-n2,
+  .platform_sh_standalone .mx-sm-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-sm-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-sm-n3,
+  .platform_sh_standalone .my-sm-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-sm-n3,
+  .platform_sh_standalone .mx-sm-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-sm-n3,
+  .platform_sh_standalone .my-sm-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-sm-n3,
+  .platform_sh_standalone .mx-sm-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-sm-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-sm-n4,
+  .platform_sh_standalone .my-sm-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-sm-n4,
+  .platform_sh_standalone .mx-sm-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-sm-n4,
+  .platform_sh_standalone .my-sm-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-sm-n4,
+  .platform_sh_standalone .mx-sm-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-sm-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-sm-n5,
+  .platform_sh_standalone .my-sm-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-sm-n5,
+  .platform_sh_standalone .mx-sm-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-sm-n5,
+  .platform_sh_standalone .my-sm-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-sm-n5,
+  .platform_sh_standalone .mx-sm-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-sm-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-sm-auto,
+  .platform_sh_standalone .my-sm-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-sm-auto,
+  .platform_sh_standalone .mx-sm-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-sm-auto,
+  .platform_sh_standalone .my-sm-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-sm-auto,
+  .platform_sh_standalone .mx-sm-auto {
+    margin-left: auto !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .m-md-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-md-0,
+  .platform_sh_standalone .my-md-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-md-0,
+  .platform_sh_standalone .mx-md-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-md-0,
+  .platform_sh_standalone .my-md-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-md-0,
+  .platform_sh_standalone .mx-md-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-md-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-md-1,
+  .platform_sh_standalone .my-md-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-md-1,
+  .platform_sh_standalone .mx-md-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-md-1,
+  .platform_sh_standalone .my-md-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-md-1,
+  .platform_sh_standalone .mx-md-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-md-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-md-2,
+  .platform_sh_standalone .my-md-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-md-2,
+  .platform_sh_standalone .mx-md-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-md-2,
+  .platform_sh_standalone .my-md-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-md-2,
+  .platform_sh_standalone .mx-md-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-md-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-md-3,
+  .platform_sh_standalone .my-md-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-md-3,
+  .platform_sh_standalone .mx-md-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-md-3,
+  .platform_sh_standalone .my-md-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-md-3,
+  .platform_sh_standalone .mx-md-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-md-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-md-4,
+  .platform_sh_standalone .my-md-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-md-4,
+  .platform_sh_standalone .mx-md-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-md-4,
+  .platform_sh_standalone .my-md-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-md-4,
+  .platform_sh_standalone .mx-md-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-md-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-md-5,
+  .platform_sh_standalone .my-md-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-md-5,
+  .platform_sh_standalone .mx-md-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-md-5,
+  .platform_sh_standalone .my-md-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-md-5,
+  .platform_sh_standalone .mx-md-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-md-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-md-0,
+  .platform_sh_standalone .py-md-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-md-0,
+  .platform_sh_standalone .px-md-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-md-0,
+  .platform_sh_standalone .py-md-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-md-0,
+  .platform_sh_standalone .px-md-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-md-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-md-1,
+  .platform_sh_standalone .py-md-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-md-1,
+  .platform_sh_standalone .px-md-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-md-1,
+  .platform_sh_standalone .py-md-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-md-1,
+  .platform_sh_standalone .px-md-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-md-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-md-2,
+  .platform_sh_standalone .py-md-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-md-2,
+  .platform_sh_standalone .px-md-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-md-2,
+  .platform_sh_standalone .py-md-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-md-2,
+  .platform_sh_standalone .px-md-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-md-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-md-3,
+  .platform_sh_standalone .py-md-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-md-3,
+  .platform_sh_standalone .px-md-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-md-3,
+  .platform_sh_standalone .py-md-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-md-3,
+  .platform_sh_standalone .px-md-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-md-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-md-4,
+  .platform_sh_standalone .py-md-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-md-4,
+  .platform_sh_standalone .px-md-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-md-4,
+  .platform_sh_standalone .py-md-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-md-4,
+  .platform_sh_standalone .px-md-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-md-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-md-5,
+  .platform_sh_standalone .py-md-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-md-5,
+  .platform_sh_standalone .px-md-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-md-5,
+  .platform_sh_standalone .py-md-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-md-5,
+  .platform_sh_standalone .px-md-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-md-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-md-n1,
+  .platform_sh_standalone .my-md-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-md-n1,
+  .platform_sh_standalone .mx-md-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-md-n1,
+  .platform_sh_standalone .my-md-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-md-n1,
+  .platform_sh_standalone .mx-md-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-md-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-md-n2,
+  .platform_sh_standalone .my-md-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-md-n2,
+  .platform_sh_standalone .mx-md-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-md-n2,
+  .platform_sh_standalone .my-md-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-md-n2,
+  .platform_sh_standalone .mx-md-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-md-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-md-n3,
+  .platform_sh_standalone .my-md-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-md-n3,
+  .platform_sh_standalone .mx-md-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-md-n3,
+  .platform_sh_standalone .my-md-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-md-n3,
+  .platform_sh_standalone .mx-md-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-md-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-md-n4,
+  .platform_sh_standalone .my-md-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-md-n4,
+  .platform_sh_standalone .mx-md-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-md-n4,
+  .platform_sh_standalone .my-md-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-md-n4,
+  .platform_sh_standalone .mx-md-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-md-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-md-n5,
+  .platform_sh_standalone .my-md-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-md-n5,
+  .platform_sh_standalone .mx-md-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-md-n5,
+  .platform_sh_standalone .my-md-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-md-n5,
+  .platform_sh_standalone .mx-md-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-md-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-md-auto,
+  .platform_sh_standalone .my-md-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-md-auto,
+  .platform_sh_standalone .mx-md-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-md-auto,
+  .platform_sh_standalone .my-md-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-md-auto,
+  .platform_sh_standalone .mx-md-auto {
+    margin-left: auto !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .m-lg-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-lg-0,
+  .platform_sh_standalone .my-lg-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-lg-0,
+  .platform_sh_standalone .mx-lg-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-lg-0,
+  .platform_sh_standalone .my-lg-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-lg-0,
+  .platform_sh_standalone .mx-lg-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-lg-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-lg-1,
+  .platform_sh_standalone .my-lg-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-lg-1,
+  .platform_sh_standalone .mx-lg-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-lg-1,
+  .platform_sh_standalone .my-lg-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-lg-1,
+  .platform_sh_standalone .mx-lg-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-lg-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-lg-2,
+  .platform_sh_standalone .my-lg-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-lg-2,
+  .platform_sh_standalone .mx-lg-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-lg-2,
+  .platform_sh_standalone .my-lg-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-lg-2,
+  .platform_sh_standalone .mx-lg-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-lg-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-lg-3,
+  .platform_sh_standalone .my-lg-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-lg-3,
+  .platform_sh_standalone .mx-lg-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-lg-3,
+  .platform_sh_standalone .my-lg-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-lg-3,
+  .platform_sh_standalone .mx-lg-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-lg-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-lg-4,
+  .platform_sh_standalone .my-lg-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-lg-4,
+  .platform_sh_standalone .mx-lg-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-lg-4,
+  .platform_sh_standalone .my-lg-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-lg-4,
+  .platform_sh_standalone .mx-lg-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-lg-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-lg-5,
+  .platform_sh_standalone .my-lg-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-lg-5,
+  .platform_sh_standalone .mx-lg-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-lg-5,
+  .platform_sh_standalone .my-lg-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-lg-5,
+  .platform_sh_standalone .mx-lg-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-lg-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-lg-0,
+  .platform_sh_standalone .py-lg-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-lg-0,
+  .platform_sh_standalone .px-lg-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-lg-0,
+  .platform_sh_standalone .py-lg-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-lg-0,
+  .platform_sh_standalone .px-lg-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-lg-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-lg-1,
+  .platform_sh_standalone .py-lg-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-lg-1,
+  .platform_sh_standalone .px-lg-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-lg-1,
+  .platform_sh_standalone .py-lg-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-lg-1,
+  .platform_sh_standalone .px-lg-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-lg-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-lg-2,
+  .platform_sh_standalone .py-lg-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-lg-2,
+  .platform_sh_standalone .px-lg-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-lg-2,
+  .platform_sh_standalone .py-lg-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-lg-2,
+  .platform_sh_standalone .px-lg-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-lg-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-lg-3,
+  .platform_sh_standalone .py-lg-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-lg-3,
+  .platform_sh_standalone .px-lg-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-lg-3,
+  .platform_sh_standalone .py-lg-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-lg-3,
+  .platform_sh_standalone .px-lg-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-lg-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-lg-4,
+  .platform_sh_standalone .py-lg-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-lg-4,
+  .platform_sh_standalone .px-lg-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-lg-4,
+  .platform_sh_standalone .py-lg-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-lg-4,
+  .platform_sh_standalone .px-lg-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-lg-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-lg-5,
+  .platform_sh_standalone .py-lg-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-lg-5,
+  .platform_sh_standalone .px-lg-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-lg-5,
+  .platform_sh_standalone .py-lg-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-lg-5,
+  .platform_sh_standalone .px-lg-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-lg-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-lg-n1,
+  .platform_sh_standalone .my-lg-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-lg-n1,
+  .platform_sh_standalone .mx-lg-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-lg-n1,
+  .platform_sh_standalone .my-lg-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-lg-n1,
+  .platform_sh_standalone .mx-lg-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-lg-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-lg-n2,
+  .platform_sh_standalone .my-lg-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-lg-n2,
+  .platform_sh_standalone .mx-lg-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-lg-n2,
+  .platform_sh_standalone .my-lg-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-lg-n2,
+  .platform_sh_standalone .mx-lg-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-lg-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-lg-n3,
+  .platform_sh_standalone .my-lg-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-lg-n3,
+  .platform_sh_standalone .mx-lg-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-lg-n3,
+  .platform_sh_standalone .my-lg-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-lg-n3,
+  .platform_sh_standalone .mx-lg-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-lg-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-lg-n4,
+  .platform_sh_standalone .my-lg-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-lg-n4,
+  .platform_sh_standalone .mx-lg-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-lg-n4,
+  .platform_sh_standalone .my-lg-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-lg-n4,
+  .platform_sh_standalone .mx-lg-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-lg-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-lg-n5,
+  .platform_sh_standalone .my-lg-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-lg-n5,
+  .platform_sh_standalone .mx-lg-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-lg-n5,
+  .platform_sh_standalone .my-lg-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-lg-n5,
+  .platform_sh_standalone .mx-lg-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-lg-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-lg-auto,
+  .platform_sh_standalone .my-lg-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-lg-auto,
+  .platform_sh_standalone .mx-lg-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-lg-auto,
+  .platform_sh_standalone .my-lg-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-lg-auto,
+  .platform_sh_standalone .mx-lg-auto {
+    margin-left: auto !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .m-xl-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-xl-0,
+  .platform_sh_standalone .my-xl-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-xl-0,
+  .platform_sh_standalone .mx-xl-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-xl-0,
+  .platform_sh_standalone .my-xl-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-xl-0,
+  .platform_sh_standalone .mx-xl-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-xl-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-xl-1,
+  .platform_sh_standalone .my-xl-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-xl-1,
+  .platform_sh_standalone .mx-xl-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-xl-1,
+  .platform_sh_standalone .my-xl-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-xl-1,
+  .platform_sh_standalone .mx-xl-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-xl-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-xl-2,
+  .platform_sh_standalone .my-xl-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-xl-2,
+  .platform_sh_standalone .mx-xl-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-xl-2,
+  .platform_sh_standalone .my-xl-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-xl-2,
+  .platform_sh_standalone .mx-xl-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-xl-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-xl-3,
+  .platform_sh_standalone .my-xl-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-xl-3,
+  .platform_sh_standalone .mx-xl-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-xl-3,
+  .platform_sh_standalone .my-xl-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-xl-3,
+  .platform_sh_standalone .mx-xl-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-xl-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-xl-4,
+  .platform_sh_standalone .my-xl-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-xl-4,
+  .platform_sh_standalone .mx-xl-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-xl-4,
+  .platform_sh_standalone .my-xl-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-xl-4,
+  .platform_sh_standalone .mx-xl-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-xl-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-xl-5,
+  .platform_sh_standalone .my-xl-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-xl-5,
+  .platform_sh_standalone .mx-xl-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-xl-5,
+  .platform_sh_standalone .my-xl-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-xl-5,
+  .platform_sh_standalone .mx-xl-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-xl-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-xl-0,
+  .platform_sh_standalone .py-xl-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-xl-0,
+  .platform_sh_standalone .px-xl-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-xl-0,
+  .platform_sh_standalone .py-xl-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-xl-0,
+  .platform_sh_standalone .px-xl-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-xl-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-xl-1,
+  .platform_sh_standalone .py-xl-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-xl-1,
+  .platform_sh_standalone .px-xl-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-xl-1,
+  .platform_sh_standalone .py-xl-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-xl-1,
+  .platform_sh_standalone .px-xl-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-xl-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-xl-2,
+  .platform_sh_standalone .py-xl-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-xl-2,
+  .platform_sh_standalone .px-xl-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-xl-2,
+  .platform_sh_standalone .py-xl-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-xl-2,
+  .platform_sh_standalone .px-xl-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-xl-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-xl-3,
+  .platform_sh_standalone .py-xl-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-xl-3,
+  .platform_sh_standalone .px-xl-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-xl-3,
+  .platform_sh_standalone .py-xl-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-xl-3,
+  .platform_sh_standalone .px-xl-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-xl-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-xl-4,
+  .platform_sh_standalone .py-xl-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-xl-4,
+  .platform_sh_standalone .px-xl-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-xl-4,
+  .platform_sh_standalone .py-xl-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-xl-4,
+  .platform_sh_standalone .px-xl-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-xl-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-xl-5,
+  .platform_sh_standalone .py-xl-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-xl-5,
+  .platform_sh_standalone .px-xl-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-xl-5,
+  .platform_sh_standalone .py-xl-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-xl-5,
+  .platform_sh_standalone .px-xl-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-xl-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-xl-n1,
+  .platform_sh_standalone .my-xl-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-xl-n1,
+  .platform_sh_standalone .mx-xl-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-xl-n1,
+  .platform_sh_standalone .my-xl-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-xl-n1,
+  .platform_sh_standalone .mx-xl-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-xl-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-xl-n2,
+  .platform_sh_standalone .my-xl-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-xl-n2,
+  .platform_sh_standalone .mx-xl-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-xl-n2,
+  .platform_sh_standalone .my-xl-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-xl-n2,
+  .platform_sh_standalone .mx-xl-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-xl-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-xl-n3,
+  .platform_sh_standalone .my-xl-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-xl-n3,
+  .platform_sh_standalone .mx-xl-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-xl-n3,
+  .platform_sh_standalone .my-xl-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-xl-n3,
+  .platform_sh_standalone .mx-xl-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-xl-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-xl-n4,
+  .platform_sh_standalone .my-xl-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-xl-n4,
+  .platform_sh_standalone .mx-xl-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-xl-n4,
+  .platform_sh_standalone .my-xl-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-xl-n4,
+  .platform_sh_standalone .mx-xl-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-xl-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-xl-n5,
+  .platform_sh_standalone .my-xl-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-xl-n5,
+  .platform_sh_standalone .mx-xl-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-xl-n5,
+  .platform_sh_standalone .my-xl-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-xl-n5,
+  .platform_sh_standalone .mx-xl-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-xl-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-xl-auto,
+  .platform_sh_standalone .my-xl-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-xl-auto,
+  .platform_sh_standalone .mx-xl-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-xl-auto,
+  .platform_sh_standalone .my-xl-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-xl-auto,
+  .platform_sh_standalone .mx-xl-auto {
+    margin-left: auto !important; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .m-xxl-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-xxl-0,
+  .platform_sh_standalone .my-xxl-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-xxl-0,
+  .platform_sh_standalone .mx-xxl-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-xxl-0,
+  .platform_sh_standalone .my-xxl-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-xxl-0,
+  .platform_sh_standalone .mx-xxl-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-xxl-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-xxl-1,
+  .platform_sh_standalone .my-xxl-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-xxl-1,
+  .platform_sh_standalone .mx-xxl-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-xxl-1,
+  .platform_sh_standalone .my-xxl-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-xxl-1,
+  .platform_sh_standalone .mx-xxl-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-xxl-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-xxl-2,
+  .platform_sh_standalone .my-xxl-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-xxl-2,
+  .platform_sh_standalone .mx-xxl-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-xxl-2,
+  .platform_sh_standalone .my-xxl-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-xxl-2,
+  .platform_sh_standalone .mx-xxl-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-xxl-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-xxl-3,
+  .platform_sh_standalone .my-xxl-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-xxl-3,
+  .platform_sh_standalone .mx-xxl-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-xxl-3,
+  .platform_sh_standalone .my-xxl-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-xxl-3,
+  .platform_sh_standalone .mx-xxl-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-xxl-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-xxl-4,
+  .platform_sh_standalone .my-xxl-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-xxl-4,
+  .platform_sh_standalone .mx-xxl-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-xxl-4,
+  .platform_sh_standalone .my-xxl-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-xxl-4,
+  .platform_sh_standalone .mx-xxl-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-xxl-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-xxl-5,
+  .platform_sh_standalone .my-xxl-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-xxl-5,
+  .platform_sh_standalone .mx-xxl-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-xxl-5,
+  .platform_sh_standalone .my-xxl-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-xxl-5,
+  .platform_sh_standalone .mx-xxl-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-xxl-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-xxl-0,
+  .platform_sh_standalone .py-xxl-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-xxl-0,
+  .platform_sh_standalone .px-xxl-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-xxl-0,
+  .platform_sh_standalone .py-xxl-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-xxl-0,
+  .platform_sh_standalone .px-xxl-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-xxl-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-xxl-1,
+  .platform_sh_standalone .py-xxl-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-xxl-1,
+  .platform_sh_standalone .px-xxl-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-xxl-1,
+  .platform_sh_standalone .py-xxl-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-xxl-1,
+  .platform_sh_standalone .px-xxl-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-xxl-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-xxl-2,
+  .platform_sh_standalone .py-xxl-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-xxl-2,
+  .platform_sh_standalone .px-xxl-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-xxl-2,
+  .platform_sh_standalone .py-xxl-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-xxl-2,
+  .platform_sh_standalone .px-xxl-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-xxl-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-xxl-3,
+  .platform_sh_standalone .py-xxl-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-xxl-3,
+  .platform_sh_standalone .px-xxl-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-xxl-3,
+  .platform_sh_standalone .py-xxl-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-xxl-3,
+  .platform_sh_standalone .px-xxl-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-xxl-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-xxl-4,
+  .platform_sh_standalone .py-xxl-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-xxl-4,
+  .platform_sh_standalone .px-xxl-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-xxl-4,
+  .platform_sh_standalone .py-xxl-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-xxl-4,
+  .platform_sh_standalone .px-xxl-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-xxl-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-xxl-5,
+  .platform_sh_standalone .py-xxl-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-xxl-5,
+  .platform_sh_standalone .px-xxl-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-xxl-5,
+  .platform_sh_standalone .py-xxl-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-xxl-5,
+  .platform_sh_standalone .px-xxl-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-xxl-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-xxl-n1,
+  .platform_sh_standalone .my-xxl-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-xxl-n1,
+  .platform_sh_standalone .mx-xxl-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-xxl-n1,
+  .platform_sh_standalone .my-xxl-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-xxl-n1,
+  .platform_sh_standalone .mx-xxl-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-xxl-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-xxl-n2,
+  .platform_sh_standalone .my-xxl-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-xxl-n2,
+  .platform_sh_standalone .mx-xxl-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-xxl-n2,
+  .platform_sh_standalone .my-xxl-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-xxl-n2,
+  .platform_sh_standalone .mx-xxl-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-xxl-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-xxl-n3,
+  .platform_sh_standalone .my-xxl-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-xxl-n3,
+  .platform_sh_standalone .mx-xxl-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-xxl-n3,
+  .platform_sh_standalone .my-xxl-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-xxl-n3,
+  .platform_sh_standalone .mx-xxl-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-xxl-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-xxl-n4,
+  .platform_sh_standalone .my-xxl-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-xxl-n4,
+  .platform_sh_standalone .mx-xxl-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-xxl-n4,
+  .platform_sh_standalone .my-xxl-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-xxl-n4,
+  .platform_sh_standalone .mx-xxl-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-xxl-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-xxl-n5,
+  .platform_sh_standalone .my-xxl-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-xxl-n5,
+  .platform_sh_standalone .mx-xxl-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-xxl-n5,
+  .platform_sh_standalone .my-xxl-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-xxl-n5,
+  .platform_sh_standalone .mx-xxl-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-xxl-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-xxl-auto,
+  .platform_sh_standalone .my-xxl-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-xxl-auto,
+  .platform_sh_standalone .mx-xxl-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-xxl-auto,
+  .platform_sh_standalone .my-xxl-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-xxl-auto,
+  .platform_sh_standalone .mx-xxl-auto {
+    margin-left: auto !important; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .m-xxxl-0 {
+    margin: 0 !important; }
+  .platform_sh_standalone .mt-xxxl-0,
+  .platform_sh_standalone .my-xxxl-0 {
+    margin-top: 0 !important; }
+  .platform_sh_standalone .mr-xxxl-0,
+  .platform_sh_standalone .mx-xxxl-0 {
+    margin-right: 0 !important; }
+  .platform_sh_standalone .mb-xxxl-0,
+  .platform_sh_standalone .my-xxxl-0 {
+    margin-bottom: 0 !important; }
+  .platform_sh_standalone .ml-xxxl-0,
+  .platform_sh_standalone .mx-xxxl-0 {
+    margin-left: 0 !important; }
+  .platform_sh_standalone .m-xxxl-1 {
+    margin: 0.25rem !important; }
+  .platform_sh_standalone .mt-xxxl-1,
+  .platform_sh_standalone .my-xxxl-1 {
+    margin-top: 0.25rem !important; }
+  .platform_sh_standalone .mr-xxxl-1,
+  .platform_sh_standalone .mx-xxxl-1 {
+    margin-right: 0.25rem !important; }
+  .platform_sh_standalone .mb-xxxl-1,
+  .platform_sh_standalone .my-xxxl-1 {
+    margin-bottom: 0.25rem !important; }
+  .platform_sh_standalone .ml-xxxl-1,
+  .platform_sh_standalone .mx-xxxl-1 {
+    margin-left: 0.25rem !important; }
+  .platform_sh_standalone .m-xxxl-2 {
+    margin: 0.5rem !important; }
+  .platform_sh_standalone .mt-xxxl-2,
+  .platform_sh_standalone .my-xxxl-2 {
+    margin-top: 0.5rem !important; }
+  .platform_sh_standalone .mr-xxxl-2,
+  .platform_sh_standalone .mx-xxxl-2 {
+    margin-right: 0.5rem !important; }
+  .platform_sh_standalone .mb-xxxl-2,
+  .platform_sh_standalone .my-xxxl-2 {
+    margin-bottom: 0.5rem !important; }
+  .platform_sh_standalone .ml-xxxl-2,
+  .platform_sh_standalone .mx-xxxl-2 {
+    margin-left: 0.5rem !important; }
+  .platform_sh_standalone .m-xxxl-3 {
+    margin: 1rem !important; }
+  .platform_sh_standalone .mt-xxxl-3,
+  .platform_sh_standalone .my-xxxl-3 {
+    margin-top: 1rem !important; }
+  .platform_sh_standalone .mr-xxxl-3,
+  .platform_sh_standalone .mx-xxxl-3 {
+    margin-right: 1rem !important; }
+  .platform_sh_standalone .mb-xxxl-3,
+  .platform_sh_standalone .my-xxxl-3 {
+    margin-bottom: 1rem !important; }
+  .platform_sh_standalone .ml-xxxl-3,
+  .platform_sh_standalone .mx-xxxl-3 {
+    margin-left: 1rem !important; }
+  .platform_sh_standalone .m-xxxl-4 {
+    margin: 1.5rem !important; }
+  .platform_sh_standalone .mt-xxxl-4,
+  .platform_sh_standalone .my-xxxl-4 {
+    margin-top: 1.5rem !important; }
+  .platform_sh_standalone .mr-xxxl-4,
+  .platform_sh_standalone .mx-xxxl-4 {
+    margin-right: 1.5rem !important; }
+  .platform_sh_standalone .mb-xxxl-4,
+  .platform_sh_standalone .my-xxxl-4 {
+    margin-bottom: 1.5rem !important; }
+  .platform_sh_standalone .ml-xxxl-4,
+  .platform_sh_standalone .mx-xxxl-4 {
+    margin-left: 1.5rem !important; }
+  .platform_sh_standalone .m-xxxl-5 {
+    margin: 3rem !important; }
+  .platform_sh_standalone .mt-xxxl-5,
+  .platform_sh_standalone .my-xxxl-5 {
+    margin-top: 3rem !important; }
+  .platform_sh_standalone .mr-xxxl-5,
+  .platform_sh_standalone .mx-xxxl-5 {
+    margin-right: 3rem !important; }
+  .platform_sh_standalone .mb-xxxl-5,
+  .platform_sh_standalone .my-xxxl-5 {
+    margin-bottom: 3rem !important; }
+  .platform_sh_standalone .ml-xxxl-5,
+  .platform_sh_standalone .mx-xxxl-5 {
+    margin-left: 3rem !important; }
+  .platform_sh_standalone .p-xxxl-0 {
+    padding: 0 !important; }
+  .platform_sh_standalone .pt-xxxl-0,
+  .platform_sh_standalone .py-xxxl-0 {
+    padding-top: 0 !important; }
+  .platform_sh_standalone .pr-xxxl-0,
+  .platform_sh_standalone .px-xxxl-0 {
+    padding-right: 0 !important; }
+  .platform_sh_standalone .pb-xxxl-0,
+  .platform_sh_standalone .py-xxxl-0 {
+    padding-bottom: 0 !important; }
+  .platform_sh_standalone .pl-xxxl-0,
+  .platform_sh_standalone .px-xxxl-0 {
+    padding-left: 0 !important; }
+  .platform_sh_standalone .p-xxxl-1 {
+    padding: 0.25rem !important; }
+  .platform_sh_standalone .pt-xxxl-1,
+  .platform_sh_standalone .py-xxxl-1 {
+    padding-top: 0.25rem !important; }
+  .platform_sh_standalone .pr-xxxl-1,
+  .platform_sh_standalone .px-xxxl-1 {
+    padding-right: 0.25rem !important; }
+  .platform_sh_standalone .pb-xxxl-1,
+  .platform_sh_standalone .py-xxxl-1 {
+    padding-bottom: 0.25rem !important; }
+  .platform_sh_standalone .pl-xxxl-1,
+  .platform_sh_standalone .px-xxxl-1 {
+    padding-left: 0.25rem !important; }
+  .platform_sh_standalone .p-xxxl-2 {
+    padding: 0.5rem !important; }
+  .platform_sh_standalone .pt-xxxl-2,
+  .platform_sh_standalone .py-xxxl-2 {
+    padding-top: 0.5rem !important; }
+  .platform_sh_standalone .pr-xxxl-2,
+  .platform_sh_standalone .px-xxxl-2 {
+    padding-right: 0.5rem !important; }
+  .platform_sh_standalone .pb-xxxl-2,
+  .platform_sh_standalone .py-xxxl-2 {
+    padding-bottom: 0.5rem !important; }
+  .platform_sh_standalone .pl-xxxl-2,
+  .platform_sh_standalone .px-xxxl-2 {
+    padding-left: 0.5rem !important; }
+  .platform_sh_standalone .p-xxxl-3 {
+    padding: 1rem !important; }
+  .platform_sh_standalone .pt-xxxl-3,
+  .platform_sh_standalone .py-xxxl-3 {
+    padding-top: 1rem !important; }
+  .platform_sh_standalone .pr-xxxl-3,
+  .platform_sh_standalone .px-xxxl-3 {
+    padding-right: 1rem !important; }
+  .platform_sh_standalone .pb-xxxl-3,
+  .platform_sh_standalone .py-xxxl-3 {
+    padding-bottom: 1rem !important; }
+  .platform_sh_standalone .pl-xxxl-3,
+  .platform_sh_standalone .px-xxxl-3 {
+    padding-left: 1rem !important; }
+  .platform_sh_standalone .p-xxxl-4 {
+    padding: 1.5rem !important; }
+  .platform_sh_standalone .pt-xxxl-4,
+  .platform_sh_standalone .py-xxxl-4 {
+    padding-top: 1.5rem !important; }
+  .platform_sh_standalone .pr-xxxl-4,
+  .platform_sh_standalone .px-xxxl-4 {
+    padding-right: 1.5rem !important; }
+  .platform_sh_standalone .pb-xxxl-4,
+  .platform_sh_standalone .py-xxxl-4 {
+    padding-bottom: 1.5rem !important; }
+  .platform_sh_standalone .pl-xxxl-4,
+  .platform_sh_standalone .px-xxxl-4 {
+    padding-left: 1.5rem !important; }
+  .platform_sh_standalone .p-xxxl-5 {
+    padding: 3rem !important; }
+  .platform_sh_standalone .pt-xxxl-5,
+  .platform_sh_standalone .py-xxxl-5 {
+    padding-top: 3rem !important; }
+  .platform_sh_standalone .pr-xxxl-5,
+  .platform_sh_standalone .px-xxxl-5 {
+    padding-right: 3rem !important; }
+  .platform_sh_standalone .pb-xxxl-5,
+  .platform_sh_standalone .py-xxxl-5 {
+    padding-bottom: 3rem !important; }
+  .platform_sh_standalone .pl-xxxl-5,
+  .platform_sh_standalone .px-xxxl-5 {
+    padding-left: 3rem !important; }
+  .platform_sh_standalone .m-xxxl-n1 {
+    margin: -0.25rem !important; }
+  .platform_sh_standalone .mt-xxxl-n1,
+  .platform_sh_standalone .my-xxxl-n1 {
+    margin-top: -0.25rem !important; }
+  .platform_sh_standalone .mr-xxxl-n1,
+  .platform_sh_standalone .mx-xxxl-n1 {
+    margin-right: -0.25rem !important; }
+  .platform_sh_standalone .mb-xxxl-n1,
+  .platform_sh_standalone .my-xxxl-n1 {
+    margin-bottom: -0.25rem !important; }
+  .platform_sh_standalone .ml-xxxl-n1,
+  .platform_sh_standalone .mx-xxxl-n1 {
+    margin-left: -0.25rem !important; }
+  .platform_sh_standalone .m-xxxl-n2 {
+    margin: -0.5rem !important; }
+  .platform_sh_standalone .mt-xxxl-n2,
+  .platform_sh_standalone .my-xxxl-n2 {
+    margin-top: -0.5rem !important; }
+  .platform_sh_standalone .mr-xxxl-n2,
+  .platform_sh_standalone .mx-xxxl-n2 {
+    margin-right: -0.5rem !important; }
+  .platform_sh_standalone .mb-xxxl-n2,
+  .platform_sh_standalone .my-xxxl-n2 {
+    margin-bottom: -0.5rem !important; }
+  .platform_sh_standalone .ml-xxxl-n2,
+  .platform_sh_standalone .mx-xxxl-n2 {
+    margin-left: -0.5rem !important; }
+  .platform_sh_standalone .m-xxxl-n3 {
+    margin: -1rem !important; }
+  .platform_sh_standalone .mt-xxxl-n3,
+  .platform_sh_standalone .my-xxxl-n3 {
+    margin-top: -1rem !important; }
+  .platform_sh_standalone .mr-xxxl-n3,
+  .platform_sh_standalone .mx-xxxl-n3 {
+    margin-right: -1rem !important; }
+  .platform_sh_standalone .mb-xxxl-n3,
+  .platform_sh_standalone .my-xxxl-n3 {
+    margin-bottom: -1rem !important; }
+  .platform_sh_standalone .ml-xxxl-n3,
+  .platform_sh_standalone .mx-xxxl-n3 {
+    margin-left: -1rem !important; }
+  .platform_sh_standalone .m-xxxl-n4 {
+    margin: -1.5rem !important; }
+  .platform_sh_standalone .mt-xxxl-n4,
+  .platform_sh_standalone .my-xxxl-n4 {
+    margin-top: -1.5rem !important; }
+  .platform_sh_standalone .mr-xxxl-n4,
+  .platform_sh_standalone .mx-xxxl-n4 {
+    margin-right: -1.5rem !important; }
+  .platform_sh_standalone .mb-xxxl-n4,
+  .platform_sh_standalone .my-xxxl-n4 {
+    margin-bottom: -1.5rem !important; }
+  .platform_sh_standalone .ml-xxxl-n4,
+  .platform_sh_standalone .mx-xxxl-n4 {
+    margin-left: -1.5rem !important; }
+  .platform_sh_standalone .m-xxxl-n5 {
+    margin: -3rem !important; }
+  .platform_sh_standalone .mt-xxxl-n5,
+  .platform_sh_standalone .my-xxxl-n5 {
+    margin-top: -3rem !important; }
+  .platform_sh_standalone .mr-xxxl-n5,
+  .platform_sh_standalone .mx-xxxl-n5 {
+    margin-right: -3rem !important; }
+  .platform_sh_standalone .mb-xxxl-n5,
+  .platform_sh_standalone .my-xxxl-n5 {
+    margin-bottom: -3rem !important; }
+  .platform_sh_standalone .ml-xxxl-n5,
+  .platform_sh_standalone .mx-xxxl-n5 {
+    margin-left: -3rem !important; }
+  .platform_sh_standalone .m-xxxl-auto {
+    margin: auto !important; }
+  .platform_sh_standalone .mt-xxxl-auto,
+  .platform_sh_standalone .my-xxxl-auto {
+    margin-top: auto !important; }
+  .platform_sh_standalone .mr-xxxl-auto,
+  .platform_sh_standalone .mx-xxxl-auto {
+    margin-right: auto !important; }
+  .platform_sh_standalone .mb-xxxl-auto,
+  .platform_sh_standalone .my-xxxl-auto {
+    margin-bottom: auto !important; }
+  .platform_sh_standalone .ml-xxxl-auto,
+  .platform_sh_standalone .mx-xxxl-auto {
+    margin-left: auto !important; } }
+.platform_sh_standalone .text-monospace {
+  font-family: "Moderat Mono", "Courier New", monospace !important; }
+.platform_sh_standalone .text-justify {
+  text-align: justify !important; }
+.platform_sh_standalone .text-wrap {
+  white-space: normal !important; }
+.platform_sh_standalone .text-nowrap {
+  white-space: nowrap !important; }
+.platform_sh_standalone .text-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap; }
+.platform_sh_standalone .text-left {
+  text-align: left !important; }
+.platform_sh_standalone .text-right {
+  text-align: right !important; }
+.platform_sh_standalone .text-center {
+  text-align: center !important; }
+@media (min-width: 320px) {
+  .platform_sh_standalone .text-xxs-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-xxs-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-xxs-center {
+    text-align: center !important; } }
+@media (min-width: 414px) {
+  .platform_sh_standalone .text-xs-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-xs-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-xs-center {
+    text-align: center !important; } }
+@media (min-width: 667px) {
+  .platform_sh_standalone .text-sm-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-sm-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-sm-center {
+    text-align: center !important; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .text-md-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-md-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-md-center {
+    text-align: center !important; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .text-lg-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-lg-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-lg-center {
+    text-align: center !important; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .text-xl-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-xl-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-xl-center {
+    text-align: center !important; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .text-xxl-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-xxl-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-xxl-center {
+    text-align: center !important; } }
+@media (min-width: 1600px) {
+  .platform_sh_standalone .text-xxxl-left {
+    text-align: left !important; }
+  .platform_sh_standalone .text-xxxl-right {
+    text-align: right !important; }
+  .platform_sh_standalone .text-xxxl-center {
+    text-align: center !important; } }
+.platform_sh_standalone .text-lowercase {
+  text-transform: lowercase !important; }
+.platform_sh_standalone .text-uppercase {
+  text-transform: uppercase !important; }
+.platform_sh_standalone .text-capitalize {
+  text-transform: capitalize !important; }
+.platform_sh_standalone .font-weight-light {
+  font-weight: 300 !important; }
+.platform_sh_standalone .font-weight-lighter {
+  font-weight: lighter !important; }
+.platform_sh_standalone .font-weight-normal {
+  font-weight: 400 !important; }
+.platform_sh_standalone .font-weight-bold {
+  font-weight: 700 !important; }
+.platform_sh_standalone .font-weight-bolder {
+  font-weight: 900 !important; }
+.platform_sh_standalone .font-italic {
+  font-style: italic !important; }
+.platform_sh_standalone .text-white {
+  color: #fff !important; }
+.platform_sh_standalone .text-primary {
+  color: #145CC6 !important; }
+.platform_sh_standalone a.text-primary:hover, .platform_sh_standalone a.text-primary:focus {
+  color: #0d3c81 !important; }
+.platform_sh_standalone .text-secondary {
+  color: #6c757d !important; }
+.platform_sh_standalone a.text-secondary:hover, .platform_sh_standalone a.text-secondary:focus {
+  color: #494f54 !important; }
+.platform_sh_standalone .text-success {
+  color: #28a745 !important; }
+.platform_sh_standalone a.text-success:hover, .platform_sh_standalone a.text-success:focus {
+  color: #19692c !important; }
+.platform_sh_standalone .text-info {
+  color: #17a2b8 !important; }
+.platform_sh_standalone a.text-info:hover, .platform_sh_standalone a.text-info:focus {
+  color: #0f6674 !important; }
+.platform_sh_standalone .text-warning {
+  color: #F4BA37 !important; }
+.platform_sh_standalone a.text-warning:hover, .platform_sh_standalone a.text-warning:focus {
+  color: #d3960c !important; }
+.platform_sh_standalone .text-danger {
+  color: #dc3545 !important; }
+.platform_sh_standalone a.text-danger:hover, .platform_sh_standalone a.text-danger:focus {
+  color: #a71d2a !important; }
+.platform_sh_standalone .text-light {
+  color: #f8f9fa !important; }
+.platform_sh_standalone a.text-light:hover, .platform_sh_standalone a.text-light:focus {
+  color: #cbd3da !important; }
+.platform_sh_standalone .text-dark {
+  color: #343a40 !important; }
+.platform_sh_standalone a.text-dark:hover, .platform_sh_standalone a.text-dark:focus {
+  color: #121416 !important; }
+.platform_sh_standalone .text-body {
+  color: #49475F !important; }
+.platform_sh_standalone .text-muted {
+  color: #6c757d !important; }
+.platform_sh_standalone .text-black-50 {
+  color: rgba(0, 0, 0, 0.5) !important; }
+.platform_sh_standalone .text-white-50 {
+  color: rgba(255, 255, 255, 0.5) !important; }
+.platform_sh_standalone .text-hide {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0; }
+.platform_sh_standalone .text-decoration-none {
+  text-decoration: none !important; }
+.platform_sh_standalone .text-break {
+  word-break: break-word !important;
+  overflow-wrap: break-word !important; }
+.platform_sh_standalone .text-reset {
+  color: inherit !important; }
+.platform_sh_standalone .visible {
+  visibility: visible !important; }
+.platform_sh_standalone .invisible {
+  visibility: hidden !important; }
+@media print {
+  .platform_sh_standalone *,
+  .platform_sh_standalone *::before,
+  .platform_sh_standalone *::after {
+    text-shadow: none !important;
+    box-shadow: none !important; }
+  .platform_sh_standalone a:not(.btn) {
+    text-decoration: underline; }
+  .platform_sh_standalone abbr[title]::after {
+    content: " (" attr(title) ")"; }
+  .platform_sh_standalone pre {
+    white-space: pre-wrap !important; }
+  .platform_sh_standalone pre,
+  .platform_sh_standalone blockquote {
+    border: 1px solid #adb5bd;
+    page-break-inside: avoid; }
+  .platform_sh_standalone thead {
+    display: table-header-group; }
+  .platform_sh_standalone tr,
+  .platform_sh_standalone img {
+    page-break-inside: avoid; }
+  .platform_sh_standalone p,
+  .platform_sh_standalone h2,
+  .platform_sh_standalone h3 {
+    orphans: 3;
+    widows: 3; }
+  .platform_sh_standalone h2,
+  .platform_sh_standalone h3 {
+    page-break-after: avoid; }
+  @page {
+  .platform_sh_standalone {
+    size: a3; } }
+.platform_sh_standalone body {
+  min-width: 992px !important; }
+.platform_sh_standalone .container {
+  min-width: 992px !important; }
+.platform_sh_standalone .navbar {
+  display: none; }
+.platform_sh_standalone .badge {
+  border: 1px solid #000; }
+.platform_sh_standalone .table {
+  border-collapse: collapse !important; }
+.platform_sh_standalone .table td,
+.platform_sh_standalone .table th {
+  background-color: #fff !important; }
+.platform_sh_standalone .table-bordered th,
+.platform_sh_standalone .table-bordered td {
+  border: 1px solid #dee2e6 !important; }
+.platform_sh_standalone .table-dark {
+  color: inherit; }
+.platform_sh_standalone .table-dark th,
+.platform_sh_standalone .table-dark td,
+.platform_sh_standalone .table-dark thead th,
+.platform_sh_standalone .table-dark tbody + tbody {
+  border-color: #dee2e6; }
+.platform_sh_standalone .table .thead-dark th {
+  color: inherit;
+  border-color: #dee2e6; } }
+.platform_sh_standalone h1 {
+  line-height: 1.25; }
+.platform_sh_standalone p, .platform_sh_standalone h2, .platform_sh_standalone h4, .platform_sh_standalone h5, .platform_sh_standalone h6 {
+  line-height: 1.3125;
+  margin-bottom: 1.4rem; }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone h1 {
+    font-size: 1.875rem; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone h2 {
+    font-size: 1.25rem; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone h3 {
+    font-size: 2.5rem; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone h4 {
+    font-size: 1.125rem; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone h5 {
+    font-size: 1.125rem; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone p, .platform_sh_standalone li {
+    font-size: 0.875rem; } }
+.platform_sh_standalone h3 {
+  -moz-text-fill-color: transparent;
+  -webkit-text-fill-color: transparent;
+  -moz-text-stroke-color: #FFBDBB;
+  -webkit-text-stroke-color: #FFBDBB;
+  -moz-text-stroke-width: 1px;
+  -webkit-text-stroke-width: 1px;
+  line-height: 1rem;
+  text-transform: lowercase; }
+.platform_sh_standalone .text-leader {
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.8rem; }
+.platform_sh_standalone .text-highlight {
+  color: #145CC6;
+  font-size: 1.125rem;
+  line-height: 1.875rem;
+  font-weight: 700;
+  display: inline-block;
+  position: relative; }
+.platform_sh_standalone .text-highlight:before {
+  position: absolute;
+  bottom: 3px;
+  left: -10px;
+  content: " ";
+  width: 100%;
+  height: 1rem;
+  background-color: #ECF2FA;
+  z-index: -1; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .text-highlight {
+    font-size: 1.125rem; } }
+.platform_sh_standalone .text-xlarge {
+  color: #49475F;
+  font-size: 15px;
+  line-height: 1.7; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .text-xlarge {
+    font-size: 1.25rem; } }
+.platform_sh_standalone .text-large, .platform_sh_standalone .callout p {
+  color: #49475F;
+  font-size: 0.875rem;
+  line-height: 1.8; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .text-large, .platform_sh_standalone .callout p {
+    font-size: 1.125rem; } }
+.platform_sh_standalone .text-medium {
+  color: #49475F;
+  font-size: 0.875rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .text-medium {
+    font-size: 1.0625rem;
+    line-height: 1.8; } }
+.platform_sh_standalone .text-small, .platform_sh_standalone .card .card-text {
+  color: #49475F;
+  font-size: 0.875rem;
+  line-height: 1.8; }
+.platform_sh_standalone .text-stat {
+  color: #145CC6;
+  font-family: "Moderat", "Helvetica Neue", Arial;
+  font-size: 3.75rem;
+  line-height: 1.8; }
+.platform_sh_standalone .text-code {
+  color: #FFFFFF;
+  font-family: "Moderat Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  background-color: #1A182A;
+  padding: 0.25rem 0.5rem;
+  line-height: 1rem; }
+.platform_sh_standalone .no-link-color {
+  color: inherit; }
+.platform_sh_standalone .no-text-decoration:hover {
+  text-decoration: none; }
+.platform_sh_standalone a {
+  color: #145CC6; }
+.platform_sh_standalone .text-weight-normal {
+  font-weight: 400; }
+.platform_sh_standalone .text-weight-medium {
+  font-weight: 500; }
+.platform_sh_standalone .text-weight-bold {
+  font-weight: 700; }
+.platform_sh_standalone .text-weight-strong {
+  font-weight: 700; }
+.platform_sh_standalone .color-box {
+  width: 5rem;
+  height: 5rem; }
+.platform_sh_standalone .Colors {
+  font-size: 0.875rem; }
+.platform_sh_standalone .grid-highlight {
+  background-color: #FFBDBB; }
+.platform_sh_standalone .grid-highlight .inner {
+  min-height: 300px;
+  background-color: #FFEEEE;
+  text-align: center; }
+.platform_sh_standalone .bg-night {
+  background-color: #1A182A; }
+.platform_sh_standalone .bg-slate {
+  background-color: #49475F; }
+.platform_sh_standalone .bg-grey {
+  background-color: #A4A4B4; }
+.platform_sh_standalone .bg-stone {
+  background-color: #EDEDEF; }
+.platform_sh_standalone .bg-sand {
+  background-color: #EEEDE4; }
+.platform_sh_standalone .bg-snow {
+  background-color: #FFFFFF; }
+.platform_sh_standalone .bg-blue {
+  background-color: #145CC6; }
+.platform_sh_standalone .bg-lightblue {
+  background-color: #ECF2FA; }
+.platform_sh_standalone .bg-orange {
+  background-color: #FB3728; }
+.platform_sh_standalone .bg-pink {
+  background-color: #FFBDBB; }
+.platform_sh_standalone .bg-lightpink {
+  background-color: #FFEEEE; }
+.platform_sh_standalone .bg-gold {
+  background-color: #DD901A; }
+.platform_sh_standalone .bg-yellow {
+  background-color: #F4BA37; }
+.platform_sh_standalone .bg-wine {
+  background-color: #871665; }
+.platform_sh_standalone .bg-hotpink {
+  background-color: #E04AA5; }
+.platform_sh_standalone .bg-aqua {
+  background-color: #7ADDCA; }
+.platform_sh_standalone .bg-candygreen {
+  background-color: #289B3F; }
+.platform_sh_standalone .bg-deepgreen {
+  background-color: #1C3B1A; }
+.platform_sh_standalone .color-night,
+.platform_sh_standalone .text-black {
+  color: #1A182A; }
+.platform_sh_standalone .color-slate {
+  color: #49475F; }
+.platform_sh_standalone .color-grey {
+  color: #A4A4B4; }
+.platform_sh_standalone .color-stone {
+  color: #EDEDEF; }
+.platform_sh_standalone .color-sand {
+  color: #EEEDE4; }
+.platform_sh_standalone .color-snow,
+.platform_sh_standalone .text-white {
+  color: #FFFFFF; }
+.platform_sh_standalone .color-blue,
+.platform_sh_standalone .text-blue {
+  color: #145CC6; }
+.platform_sh_standalone .color-green,
+.platform_sh_standalone .text-green {
+  color: #289B3F; }
+.platform_sh_standalone .color-lightblue {
+  color: #ECF2FA; }
+.platform_sh_standalone .color-orange,
+.platform_sh_standalone .text-red {
+  color: #FB3728; }
+.platform_sh_standalone .color-pink,
+.platform_sh_standalone .text-pink {
+  color: #FFBDBB; }
+.platform_sh_standalone .color-lightpink {
+  color: #FFEEEE; }
+.platform_sh_standalone .color-gold,
+.platform_sh_standalone .text-gold {
+  color: #DD901A; }
+.platform_sh_standalone .color-yellow {
+  color: #F4BA37; }
+.platform_sh_standalone .color-wine {
+  color: #871665; }
+.platform_sh_standalone .color-hotpink {
+  color: #E04AA5; }
+.platform_sh_standalone .color-aqua {
+  color: #7ADDCA; }
+.platform_sh_standalone .color-candygreen {
+  color: #289B3F; }
+.platform_sh_standalone .color-deepgreen {
+  color: #1C3B1A; }
+.platform_sh_standalone .lh-1 {
+  line-height: 1; }
+.platform_sh_standalone .lh-1-5 {
+  line-height: 1.5; }
+.platform_sh_standalone .lh-2 {
+  line-height: 2; }
+.platform_sh_standalone .lh-2-5 {
+  line-height: 2.5; }
+.platform_sh_standalone .lh-3 {
+  line-height: 3; }
+.platform_sh_standalone .mt-5x {
+  margin-top: 5rem; }
+.platform_sh_standalone .mb-5x {
+  margin-bottom: 5rem; }
+.platform_sh_standalone .mt-10x {
+  margin-top: 10rem; }
+.platform_sh_standalone .display-grids div[class="row"] {
+  outline: 1px dotted rgba(0, 0, 0, 0.25); }
+.platform_sh_standalone .display-grids div[class^="col-"] {
+  background-color: rgba(255, 0, 0, 0.2);
+  outline: 1px dotted rgba(0, 0, 0, 0.5); }
+.platform_sh_standalone .max-width-wrapper {
+  max-width: 1980px;
+  margin: 0 auto;
+  overflow-x: hidden;
+  box-shadow: 0 4px 144px rgba(0, 0, 0, 0.05);
+  padding-top: 6rem; }
+.platform_sh_standalone .blockquote {
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: #1A182A;
+  line-height: 1.375;
+  padding: 3rem 3rem 3rem 6rem;
+  background-color: #FFEEEE;
+  position: relative; }
+.platform_sh_standalone .blockquote:before {
+  content: "\201C";
+  color: #FFFFFF;
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  font-size: 9rem;
+  line-height: 9rem; }
+.platform_sh_standalone .blockquote .blockquote-footer {
+  font-family: "Moderat Mono", "Courier New", monospace;
+  font-weight: 700; }
+.platform_sh_standalone .blockquote .blockquote-footer:before {
+  content: "\2014";
+  color: #FB3728;
+  margin-right: 1rem; }
+.platform_sh_standalone .blockquote .blockquote-footer cite {
+  font-style: normal;
+  font-weight: 300; }
+.platform_sh_standalone .blockquote.card {
+  background: #FFFFFF;
+  font-weight: 400;
+  font-size: 1rem;
+  padding: 1rem 1rem 2rem 1rem;
+  box-shadow: #A4A4B4 1px 0 5px;
+  color: #49475F; }
+.platform_sh_standalone .blockquote.card:before {
+  color: #145CC6;
+  font-size: 1.5rem;
+  line-height: 1; }
+.platform_sh_standalone .blockquote.card .card-body {
+  padding: 0 1rem; }
+.platform_sh_standalone .blockquote.card .card-footer {
+  background: none;
+  border: none;
+  padding: 1rem;
+  font-style: normal; }
+.platform_sh_standalone .blockquote.card .rounded-circle {
+  margin-right: 1rem; }
+.platform_sh_standalone .blockquote.card .text-stat {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  line-height: 1; }
+.platform_sh_standalone .bullets {
+  list-style-type: none;
+  padding-left: 0; }
+.platform_sh_standalone .bullets li {
+  padding-left: 20px;
+  margin-bottom: 1rem;
+  background: transparent url(/images/icons/bullets/bullet-red.svg) 0 10px no-repeat; }
+.platform_sh_standalone .btn, .platform_sh_standalone #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .user-widget__free-trial {
+  font-family: "Moderat Mono", "Courier New", monospace;
+  font-weight: 700;
+  white-space: nowrap;
+  line-height: 1;
+  padding: 1rem; }
+.platform_sh_standalone .btn-sm, .platform_sh_standalone .btn-group-sm > .btn, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__log-in, .platform_sh_standalone #user-widget .btn-group-sm > .user-widget__free-trial {
+  font-size: 0.875rem; }
+.platform_sh_standalone .btn-primary:hover, .platform_sh_standalone #user-widget .user-widget__free-trial:hover {
+  background-color: #FB3728; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .btn-primary, .platform_sh_standalone #user-widget .user-widget__free-trial {
+    padding: 0.75rem 1rem; } }
+.platform_sh_standalone .btn-secondary:hover {
+  color: #FFFFFF;
+  background-color: #FFBDBB; }
+.platform_sh_standalone .btn-login {
+  color: #1A182A;
+  background-color: #FFBDBB; }
+.platform_sh_standalone .btn-login:hover {
+  background-color: #FB3728; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .btn-login {
+    color: #145CC6;
+    background-color: transparent; }
+  .platform_sh_standalone .btn-login:hover {
+    color: #FB3728;
+    background: none; } }
+.platform_sh_standalone .btn-cta {
+  padding-left: 0; }
+.platform_sh_standalone .btn.btn-back span.icon, .platform_sh_standalone #user-widget .btn-back.user-widget__log-in span.icon, .platform_sh_standalone #user-widget .btn-back.user-widget__free-trial span.icon {
+  transform: rotate(180deg);
+  display: inline-block;
+  height: 20px; }
+.platform_sh_standalone .btn.btn-download, .platform_sh_standalone #user-widget .btn-download.user-widget__log-in, .platform_sh_standalone #user-widget .btn-download.user-widget__free-trial {
+  background-color: #145CC6; }
+.platform_sh_standalone .btn.btn-download svg, .platform_sh_standalone #user-widget .btn-download.user-widget__log-in svg, .platform_sh_standalone #user-widget .btn-download.user-widget__free-trial svg {
+  margin-top: -5px;
+  display: none; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .btn.btn-download svg, .platform_sh_standalone #user-widget .btn-download.user-widget__log-in svg, .platform_sh_standalone #user-widget .btn-download.user-widget__free-trial svg {
+    display: inherit; } }
+.platform_sh_standalone .btn.btn-download.blue, .platform_sh_standalone #user-widget .btn-download.blue.user-widget__log-in, .platform_sh_standalone #user-widget .btn-download.blue.user-widget__free-trial {
+  color: #FFFFFF;
+  background-color: #145CC6; }
+.platform_sh_standalone .btn.btn-download.red, .platform_sh_standalone #user-widget .btn-download.red.user-widget__log-in, .platform_sh_standalone #user-widget .btn-download.red.user-widget__free-trial {
+  color: #FFFFFF;
+  background-color: #FB3728; }
+.platform_sh_standalone .btn.wine, .platform_sh_standalone #user-widget .wine.user-widget__log-in, .platform_sh_standalone #user-widget .wine.user-widget__free-trial {
+  background-color: #871665;
+  color: #FFFFFF;
+  font-weight: 400; }
+.platform_sh_standalone .btn.wine:hover, .platform_sh_standalone #user-widget .wine.user-widget__log-in:hover, .platform_sh_standalone #user-widget .wine.user-widget__free-trial:hover {
+  font-weight: 700; }
+.platform_sh_standalone .btn-animate {
+  font-size: 13px;
+  border-radius: 0;
+  border: none;
+  background-color: #FFEEEE; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .btn-animate {
+    color: #FFFFFF;
+    font-size: 1rem;
+    padding: 1rem 63px 1rem 40px;
+    overflow: hidden;
+    position: relative; }
+  .platform_sh_standalone .btn-animate:hover {
+    color: #FFFFFF; }
+  .platform_sh_standalone .btn-animate:hover span.icon {
+    transition-delay: 0.75s;
+    transition: background-image 0.1s linear;
+    background-image: url(/images/icons/chevrons/chevrons-red.svg); }
+  .platform_sh_standalone .btn-animate::before,
+  .platform_sh_standalone .btn-animate span.text {
+    -webkit-transition: -webkit-transform 0.3s;
+    transition: transform 0.3s;
+    -webkit-transition-timing-function: cubic-bezier(0.75, 0, 0.125, 1);
+    transition-timing-function: cubic-bezier(0.75, 0, 0.125, 1); }
+  .platform_sh_standalone .btn-animate::before {
+    color: #FFFFFF;
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.5);
+    -webkit-transform: translate3d(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0); }
+  .platform_sh_standalone .btn-animate:hover::before {
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0); }
+  .platform_sh_standalone .btn-animate:hover > span.text {
+    -webkit-transform: translate3d(0, 100%, 0);
+    transform: translate3d(0, 100%, 0); }
+  .platform_sh_standalone .btn-animate span.icon {
+    background-image: url(/images/icons/chevrons/chevrons.svg);
+    background-size: 13px 11px;
+    background-position: center center;
+    background-repeat: no-repeat;
+    right: 40px;
+    top: 20px;
+    position: absolute;
+    width: 13px;
+    height: 11px; }
+  .platform_sh_standalone .btn-animate.inactive::before,
+  .platform_sh_standalone .btn-animate.inactive span.text {
+    transform: none; }
+  .platform_sh_standalone .btn-animate.inactive:hover span.icon {
+    transition: none;
+    background-image: url(/images/icons/chevrons/chevrons.svg); } }
+.platform_sh_standalone .btn-animate.gold {
+  background-color: #DD901A; }
+.platform_sh_standalone .btn-animate.gold:hover span.icon {
+  background-image: url(/images/icons/chevrons/chevrons-submit.svg); }
+.platform_sh_standalone .btn-animate.gold .text {
+  color: #FFFFFF; }
+.platform_sh_standalone .btn-animate.blue {
+  background-color: #145CC6; }
+.platform_sh_standalone .btn-animate.blue .text {
+  color: #FFFFFF; }
+.platform_sh_standalone .btn-animate.red {
+  background-color: #FB3728; }
+.platform_sh_standalone .btn-animate.red .text {
+  color: #FFFFFF; }
+.platform_sh_standalone .btn-animate.pink {
+  color: #145CC6;
+  background-color: #FFEEEE; }
+.platform_sh_standalone .btn-animate.pink::before {
+  color: #145CC6;
+  background-color: #FFBDBB; }
+.platform_sh_standalone .btn-animate.pink span.icon {
+  background-image: url(/images/icons/chevrons/chevrons-blue.svg); }
+.platform_sh_standalone .btn-animate.pink span.text {
+  position: relative; }
+.platform_sh_standalone .btn-animate.aqua {
+  background-color: #7ADDCA; }
+.platform_sh_standalone .btn-animate.aqua span.text {
+  color: #FFFFFF;
+  position: relative; }
+.platform_sh_standalone .btn-animate.aqua::before {
+  background-color: #289B3F; }
+.platform_sh_standalone .btn-animate.aqua:hover span.text {
+  color: #FFFFFF; }
+.platform_sh_standalone .btn-animate.aqua:hover span.icon {
+  background-image: url(/images/icons/chevrons/chevrons.svg); }
+.platform_sh_standalone .btn-animate.purple {
+  background: #871665; }
+.platform_sh_standalone .btn-animate.purple span.text {
+  color: #FFFFFF;
+  position: relative; }
+.platform_sh_standalone .btn-animate.purple span.icon {
+  right: 35px; }
+.platform_sh_standalone .btn-animate.purple::before {
+  background: #E04AA5; }
+.platform_sh_standalone .btn-animate.purple:hover span.text {
+  color: #FFFFFF; }
+.platform_sh_standalone .btn-animate.purple:hover span.icon {
+  background-image: url(/images/icons/chevrons/chevrons.svg); }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .btn-animate.mobile-block {
+    width: 100%;
+    padding: 1rem 0; } }
+.platform_sh_standalone .btn-animate.no-fill {
+  color: #1A182A;
+  padding: 0 1.125rem;
+  line-height: 40px;
+  height: 40px; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .btn-animate.no-fill {
+    padding: 0 3.375rem 0 1.875rem;
+    line-height: 50px;
+    height: 50px;
+    background: linear-gradient(90deg, #FFEEEE 50px, #FFFFFF 50px); }
+  .platform_sh_standalone .btn-animate.no-fill span.text {
+    position: relative; }
+  .platform_sh_standalone .btn-animate.no-fill span.icon {
+    right: 30px;
+    top: 21px;
+    background-image: url(/images/icons/chevrons/chevrons-red.svg); }
+  .platform_sh_standalone .btn-animate.no-fill::before {
+    background-color: #FFBDBB; }
+  .platform_sh_standalone .btn-animate.no-fill.sand {
+    background: linear-gradient(90deg, #FFFFFF 50px, #EEEDE4 50px); } }
+.platform_sh_standalone .callout {
+  width: 100%;
+  padding: 2rem;
+  background-color: #EEEDE4; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .callout {
+    background: #EEEDE4 url(/images/solutions/SaaSWorkshopBlock_Illustration@2x.png) 100% 0% no-repeat;
+    background-size: 50%;
+    padding: 2rem 4rem; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .callout {
+    padding: 3rem 6rem; } }
+@media (min-width: 1440px) {
+  .platform_sh_standalone .callout {
+    padding: 4rem 8rem; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .callout .copy {
+    flex: 0 0 50%;
+    max-width: 50%; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .callout .copy {
+    flex: 0 0 50%;
+    max-width: 50%; } }
+.platform_sh_standalone .callout h2 {
+  margin-bottom: 1rem; }
+.platform_sh_standalone .callout h6 {
+  color: #871665;
+  text-transform: uppercase;
+  font-family: Overpass, Arial;
+  font-size: 0.85rem;
+  margin-bottom: 0; }
+.platform_sh_standalone .card {
+  border: none;
+  background: none; }
+.platform_sh_standalone .card .card-img-top {
+  margin-bottom: 2rem; }
+.platform_sh_standalone .customers .card {
+  padding-bottom: 30px;
+  margin-bottom: 30px;
+  border-bottom: 1px solid #EDEDEF; }
+.platform_sh_standalone .customers .card .card-header {
+  padding: 0;
+  margin-bottom: 20px;
+  background: none;
+  border: none;
+  font-family: "Moderat", "Helvetica Neue", Arial; }
+.platform_sh_standalone .customers .card .card-header .profile-pic,
+.platform_sh_standalone .customers .card .card-header .profile-name {
+  float: left; }
+.platform_sh_standalone .customers .card .card-header .profile-pic {
+  margin-right: 20px; }
+.platform_sh_standalone .customers .card .card-header .name {
+  font-weight: 700;
+  margin-bottom: 10px; }
+.platform_sh_standalone .customers .card .card-header .handle {
+  font-size: 14px; }
+.platform_sh_standalone .customers .card .card-header .logo {
+  float: right; }
+.platform_sh_standalone .customers .card .card-body {
+  padding: 0; }
+.platform_sh_standalone .customers .card .card-body blockquote {
+  font-weight: 800;
+  font-size: 14px;
+  line-height: 21px; }
+.platform_sh_standalone .customers .card .card-body blockquote:before {
+  content: '"'; }
+.platform_sh_standalone .customers .card .card-body blockquote:after {
+  content: '"'; }
+.platform_sh_standalone .customers .card .card-footer {
+  padding: 0;
+  background: none;
+  border: none;
+  font-size: 13px; }
+.platform_sh_standalone .customers .card .card-footer .name {
+  font-weight: 700; }
+.platform_sh_standalone .customers .card.twitter {
+  padding: 20px;
+  box-shadow: 0px 8px 40px rgba(73, 71, 95, 0.1); }
+.platform_sh_standalone .customers .card.twitter blockquote {
+  font-weight: 600; }
+.platform_sh_standalone .customers .card.emphasized {
+  background: transparent url(/images/customers/love/quotes.svg) 0 70% no-repeat; }
+.platform_sh_standalone .customers .card.emphasized .card-body blockquote {
+  font-weight: 900;
+  font-size: 18px;
+  line-height: 25px; }
+.platform_sh_standalone .carousel .carousel-item {
+  display: block;
+  margin-left: -30px; }
+.platform_sh_standalone .cta h2 {
+  color: #FFFFFF;
+  line-height: 1;
+  margin-bottom: 0;
+  position: relative;
+  z-index: 2; }
+.platform_sh_standalone .cta h3 {
+  margin-top: -3.25rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .cta h3 {
+    margin-top: -100px; } }
+.platform_sh_standalone .cta.vertical {
+  padding: 3rem 0;
+  background-size: 100% auto;
+  background: #1A182A url(/images/solutions/solutions-footer@2x.png) no-repeat center top; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .cta.vertical {
+    padding-top: 135px;
+    padding-bottom: 104px; } }
+.platform_sh_standalone .cta.vertical h2 {
+  margin-bottom: 2rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .cta.vertical h2 {
+    margin-bottom: 50px; } }
+.platform_sh_standalone .cta.vertical h3 {
+  display: none; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .cta.vertical h3 {
+    display: block; } }
+.platform_sh_standalone .cta.vertical .btn, .platform_sh_standalone .cta.vertical #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .cta.vertical .user-widget__log-in, .platform_sh_standalone .cta.vertical #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .cta.vertical .user-widget__free-trial {
+  background: #7ADDCA; }
+.platform_sh_standalone .cta.vertical .btn span.text, .platform_sh_standalone .cta.vertical #user-widget .user-widget__log-in span.text, .platform_sh_standalone #user-widget .cta.vertical .user-widget__log-in span.text, .platform_sh_standalone .cta.vertical #user-widget .user-widget__free-trial span.text, .platform_sh_standalone #user-widget .cta.vertical .user-widget__free-trial span.text {
+  color: #FFFFFF;
+  position: relative; }
+.platform_sh_standalone .cta.vertical .btn::before, .platform_sh_standalone .cta.vertical #user-widget .user-widget__log-in::before, .platform_sh_standalone #user-widget .cta.vertical .user-widget__log-in::before, .platform_sh_standalone .cta.vertical #user-widget .user-widget__free-trial::before, .platform_sh_standalone #user-widget .cta.vertical .user-widget__free-trial::before {
+  background: #289B3F; }
+.platform_sh_standalone .cta.vertical .btn:hover span.icon, .platform_sh_standalone .cta.vertical #user-widget .user-widget__log-in:hover span.icon, .platform_sh_standalone #user-widget .cta.vertical .user-widget__log-in:hover span.icon, .platform_sh_standalone .cta.vertical #user-widget .user-widget__free-trial:hover span.icon, .platform_sh_standalone #user-widget .cta.vertical .user-widget__free-trial:hover span.icon {
+  background-image: url(/images/icons/chevrons/chevrons.svg); }
+.platform_sh_standalone .cta.vertical .center-behind {
+  position: absolute;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%); }
+.platform_sh_standalone .cta.vertical .buttons {
+  margin-top: 2rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .cta.vertical .buttons {
+    margin-top: 2.9375rem; } }
+.platform_sh_standalone .cta.vertical .btn-group > .btn:first-child, .platform_sh_standalone .cta.vertical #user-widget .btn-group > .user-widget__log-in:first-child, .platform_sh_standalone #user-widget .cta.vertical .btn-group > .user-widget__log-in:first-child, .platform_sh_standalone .cta.vertical #user-widget .btn-group > .user-widget__free-trial:first-child, .platform_sh_standalone #user-widget .cta.vertical .btn-group > .user-widget__free-trial:first-child {
+  margin-right: 2rem; }
+.platform_sh_standalone .cta.horizontal {
+  padding: 6rem 0; }
+.platform_sh_standalone .cta.horizontal h3 {
+  margin-top: -50px; }
+.platform_sh_standalone .cta.gold {
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  background-image: url(/images/cta/bg-plants.svg); }
+.platform_sh_standalone .cta.gold .btn, .platform_sh_standalone .cta.gold #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .cta.gold .user-widget__log-in, .platform_sh_standalone .cta.gold #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .cta.gold .user-widget__free-trial {
+  background-color: #DD901A; }
+.platform_sh_standalone .cta.blue {
+  background-color: #145CC6; }
+.platform_sh_standalone .cta.blue h2 {
+  color: #FFBDBB; }
+.platform_sh_standalone .cta.red .btn, .platform_sh_standalone .cta.red #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .cta.red .user-widget__log-in, .platform_sh_standalone .cta.red #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .cta.red .user-widget__free-trial {
+  background-color: #FB3728; }
+.platform_sh_standalone .cta.red .btn::before, .platform_sh_standalone .cta.red #user-widget .user-widget__log-in::before, .platform_sh_standalone #user-widget .cta.red .user-widget__log-in::before, .platform_sh_standalone .cta.red #user-widget .user-widget__free-trial::before, .platform_sh_standalone #user-widget .cta.red .user-widget__free-trial::before {
+  background-color: #FFBDBB; }
+.platform_sh_standalone .cta.red .btn:hover span.icon, .platform_sh_standalone .cta.red #user-widget .user-widget__log-in:hover span.icon, .platform_sh_standalone #user-widget .cta.red .user-widget__log-in:hover span.icon, .platform_sh_standalone .cta.red #user-widget .user-widget__free-trial:hover span.icon, .platform_sh_standalone #user-widget .cta.red .user-widget__free-trial:hover span.icon {
+  background-image: url(/images/icons/chevrons/chevrons-red.svg); }
+.platform_sh_standalone .cta.subscribe-form h2, .platform_sh_standalone .cta.subscribe-form h3 {
+  text-align: right;
+  margin-right: 2rem; }
+.platform_sh_standalone .cta.subscribe-form h3 {
+  margin-right: 10rem; }
+.platform_sh_standalone .cta.subscribe-form .form-control,
+.platform_sh_standalone .cta.subscribe-form .btn,
+.platform_sh_standalone .cta.subscribe-form #user-widget .user-widget__log-in,
+.platform_sh_standalone #user-widget .cta.subscribe-form .user-widget__log-in,
+.platform_sh_standalone .cta.subscribe-form #user-widget .user-widget__free-trial,
+.platform_sh_standalone #user-widget .cta.subscribe-form .user-widget__free-trial {
+  height: 3.125rem; }
+.platform_sh_standalone .cta.subscribe-form .form-control {
+  width: 18.75rem;
+  margin-right: 1rem; }
+.platform_sh_standalone .cta.subscribe-form .btn, .platform_sh_standalone .cta.subscribe-form #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .cta.subscribe-form .user-widget__log-in, .platform_sh_standalone .cta.subscribe-form #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .cta.subscribe-form .user-widget__free-trial {
+  padding: 0 3rem 0 2rem;
+  color: #145CC6;
+  background-size: 12px 12px;
+  background-repeat: no-repeat;
+  background-position: 80% 52%;
+  background-image: url(/images/icons/chevrons/chevrons-blue.svg); }
+.platform_sh_standalone .cta.subscribe-form .btn:hover, .platform_sh_standalone .cta.subscribe-form #user-widget .user-widget__log-in:hover, .platform_sh_standalone #user-widget .cta.subscribe-form .user-widget__log-in:hover, .platform_sh_standalone .cta.subscribe-form #user-widget .user-widget__free-trial:hover, .platform_sh_standalone #user-widget .cta.subscribe-form .user-widget__free-trial:hover {
+  background-position: 85% 52%; }
+.platform_sh_standalone .cta-inline {
+  width: 100%;
+  padding: 1.5rem 2rem;
+  background-color: #FFEEEE; }
+.platform_sh_standalone .cta-inline p {
+  margin: 0;
+  line-height: 1; }
+.platform_sh_standalone .cta-inline p.leader-text {
+  margin-top: 5px; }
+.platform_sh_standalone .cta-inline .btn, .platform_sh_standalone .cta-inline #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .cta-inline .user-widget__log-in, .platform_sh_standalone .cta-inline #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .cta-inline .user-widget__free-trial {
+  line-height: 1;
+  padding: 0 1.5rem 0 0.5rem;
+  background-size: 12px 12px;
+  background-repeat: no-repeat;
+  background-position: 99% 100%;
+  background-image: url(/images/icons/chevrons/chevrons-red.svg); }
+.platform_sh_standalone .cta-inline .btn:hover, .platform_sh_standalone .cta-inline #user-widget .user-widget__log-in:hover, .platform_sh_standalone #user-widget .cta-inline .user-widget__log-in:hover, .platform_sh_standalone .cta-inline #user-widget .user-widget__free-trial:hover, .platform_sh_standalone #user-widget .cta-inline .user-widget__free-trial:hover {
+  background-position-x: 100%; }
+.platform_sh_standalone .form .form-control,
+.platform_sh_standalone .form .help-text {
+  color: #49475F;
+  font-family: "Moderat Mono", "Courier New", monospace;
+  font-weight: 700;
+  font-size: 0.875rem;
+  line-height: 1; }
+.platform_sh_standalone .form .form-control {
+  background-color: #EEEDE4;
+  padding: 1.5rem 1.25rem;
+  border: none; }
+.platform_sh_standalone .form .form-control:focus {
+  border: 1px solid #145CC6;
+  box-shadow: none;
+  background-color: #FFFFFF; }
+.platform_sh_standalone .form .form-control::placeholder {
+  color: #49475F;
+  opacity: 0.8;
+  letter-spacing: 0.1rem;
+  font-family: "Moderat", "Helvetica Neue", Arial; }
+.platform_sh_standalone .form .form-control.required, .platform_sh_standalone .form .form-control:required {
+  border-left: 2px solid #DD901A; }
+.platform_sh_standalone .form .form-control:invalid, .platform_sh_standalone .form .form-control.invalid {
+  border: 1px solid #FB3728; }
+.platform_sh_standalone .form .form-control .invalid-msg {
+  color: #FB3728; }
+.platform_sh_standalone .form .btn-submit {
+  background-color: #FFBDBB; }
+.platform_sh_standalone .form .select-css {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: 3rem;
+  padding: 1rem 1.5rem;
+  box-sizing: border-box;
+  margin: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url(/images/icons/chevrons/chevrons-select-down.svg);
+  background-position: right .7em top 50%, 0 0;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .form .select-css::-ms-expand {
+  display: none; }
+.platform_sh_standalone .form .select-css:focus {
+  outline: none; }
+.platform_sh_standalone .form .select-css option {
+  font-weight: normal; }
+.platform_sh_standalone .form .select-css.required {
+  border-left: 2px solid #DD901A; }
+.platform_sh_standalone .form-subscribe {
+  position: relative;
+  font-weight: 400; }
+.platform_sh_standalone .form-subscribe label {
+  margin-bottom: 10px;
+  font-size: 14px;
+  color: #49475F; }
+.platform_sh_standalone .form-subscribe .btn, .platform_sh_standalone .form-subscribe #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .form-subscribe .user-widget__log-in, .platform_sh_standalone .form-subscribe #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .form-subscribe .user-widget__free-trial {
+  border: none;
+  text-indent: -999rem;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  background: transparent url(/images/icons/chevrons/chevrons-submit.svg) center center no-repeat;
+  position: absolute;
+  bottom: 0;
+  right: 0; }
+.platform_sh_standalone .form-subscribe .btn:hover, .platform_sh_standalone .form-subscribe #user-widget .user-widget__log-in:hover, .platform_sh_standalone #user-widget .form-subscribe .user-widget__log-in:hover, .platform_sh_standalone .form-subscribe #user-widget .user-widget__free-trial:hover, .platform_sh_standalone #user-widget .form-subscribe .user-widget__free-trial:hover {
+  background-position: 75% center; }
+.platform_sh_standalone .mktoErrorMsg {
+  color: #FB3728;
+  text-align: left; }
+.platform_sh_standalone .styled-select {
+  width: auto;
+  border: none;
+  padding: 0rem 1.5rem 0.25rem 0;
+  box-sizing: border-box;
+  margin: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url(/images/icons/chevrons/chevrons-select-down.svg);
+  background-position: 100% 30%;
+  background-repeat: no-repeat;
+  background-color: transparent; }
+.platform_sh_standalone .styled-select:focus {
+  outline: none; }
+.platform_sh_standalone .footer {
+  padding-top: 2rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .footer {
+    padding-top: 7rem; } }
+.platform_sh_standalone .footer .logo {
+  width: 24px;
+  height: 24px;
+  text-indent: -999rem;
+  background: transparent url(/images/logo/logo-small.svg) 0 0 no-repeat; }
+@media (min-width: 768px) {
+  .platform_sh_standalone .footer .logo {
+    width: 152px;
+    height: 30px;
+    margin-bottom: 2.25rem;
+    background: transparent;
+    text-indent: 0; }
+  .platform_sh_standalone .footer .logo svg {
+    width: 100%;
+    height: auto; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .footer .logo {
+    width: 218px;
+    height: 44px;
+    margin-bottom: 2.5rem; } }
+.platform_sh_standalone .footer h4, .platform_sh_standalone .footer h6 {
+  font-family: "Moderat Mono", "Courier New", monospace; }
+.platform_sh_standalone .footer h4 {
+  margin-bottom: 3rem; }
+.platform_sh_standalone .footer h6 {
+  margin-bottom: 1.25rem;
+  font-size: 0.9375rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .footer h6 {
+    margin-bottom: 1.4375rem;
+    font-size: 1.25rem; } }
+.platform_sh_standalone .footer .icons-social {
+  margin-bottom: 3rem; }
+.platform_sh_standalone .footer .icons-social .list-inline-item:hover path {
+  fill: #FB3728; }
+.platform_sh_standalone .footer .icons-social .list-inline-item:not(:last-child) {
+  margin-right: 1.5rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .footer .icons-social .list-inline-item:not(:last-child) {
+    margin-right: 1.25rem; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .footer .icons-social .list-inline-item:not(:last-child) {
+    margin-right: 1.5rem; } }
+.platform_sh_standalone .footer .footer-links {
+  display: block;
+  padding-bottom: 0.75rem;
+  font-size: 13px;
+  color: #49475F;
+  font-family: Overpass, Arial;
+  line-height: 1.5; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .footer .footer-links {
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    padding-bottom: 0; } }
+.platform_sh_standalone .footer .footer-links:hover {
+  color: #FB3728;
+  text-decoration: none; }
+.platform_sh_standalone .footer hr {
+  border-top-color: #EDEDEF;
+  margin-top: 4.25rem;
+  margin-bottom: 0; }
+.platform_sh_standalone .footer .footer-legal {
+  font-size: 0.75rem;
+  color: #A4A4B4;
+  font-family: "Moderat Mono", "Courier New", monospace;
+  text-align: center;
+  padding-top: 1.75rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .footer .footer-legal {
+    font-size: 0.875rem;
+    text-align: left; } }
+.platform_sh_standalone .footer .footer-legal .footer-links {
+  color: #A4A4B4; }
+.platform_sh_standalone .footer .footer-legal .footer-links:last-child {
+  margin: auto !important; }
+.platform_sh_standalone .chevron {
+  width: 14px;
+  height: 12px; }
+.platform_sh_standalone .chevron.red rect,
+.platform_sh_standalone .chevron.red path {
+  fill: #FB3728; }
+.platform_sh_standalone .chevron.multi .chevron-left-top,
+.platform_sh_standalone .chevron.multi .chevron-left-bottom {
+  fill: #FFBDBB; }
+.platform_sh_standalone .chevron.multi .chevron-right-top,
+.platform_sh_standalone .chevron.multi .chevron-right-bottom {
+  fill: #145CC6; }
+.platform_sh_standalone .link:hover {
+  text-decoration: none; }
+.platform_sh_standalone .link-more {
+  padding: 0 1.5rem 0.5rem 0;
+  font-weight: 700;
+  background-image: url(/images/icons/chevrons/chevrons-more.svg);
+  background-size: 12px 12px;
+  background-position: 100% 50%;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .link-more:hover {
+  background-position: 100% 100%; }
+.platform_sh_standalone .link-top {
+  padding: 1.5rem 0;
+  font-weight: 700;
+  background-image: url(/images/icons/chevrons/chevrons-top.svg);
+  background-size: 12px 12px;
+  background-position: 50% 15%;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .link-top:hover {
+  background-position: 50% 0%; }
+.platform_sh_standalone .link-back {
+  color: #1A182A;
+  padding: 0 0 0 1.5rem;
+  font-family: "Moderat", "Helvetica Neue", Arial;
+  background-image: url(/images/icons/chevrons/chevrons-back.svg);
+  background-size: 12px 12px;
+  background-position: 3% 66%;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .link-back:hover {
+  background-position: 0% 66%; }
+.platform_sh_standalone .link-back.white {
+  color: #FFFFFF; }
+.platform_sh_standalone .link-cta {
+  padding: 0 2rem 0 0;
+  font-weight: 700;
+  background-image: url(/images/icons/chevrons/chevrons-cta.svg);
+  background-size: 12px 12px;
+  background-position: 95% 100%;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .link-cta:hover {
+  background-position: 100% 100%; }
+.platform_sh_standalone .link-view {
+  color: #1A182A;
+  padding: 0 1.25rem 0 0;
+  font-weight: 700;
+  background-image: url(/images/icons/chevrons/chevrons-cta.svg);
+  background-size: 12px 12px;
+  background-position: 95% 70%;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .link-view:hover {
+  text-decoration: none;
+  background-position: 100% 70%; }
+.platform_sh_standalone .link-subscribe {
+  color: #145CC6;
+  padding: 0 1.25rem 0 0;
+  font-weight: 700;
+  background-image: url(/images/icons/chevrons/chevrons-cta.svg);
+  background-size: 12px 12px;
+  background-position: 97% 70%;
+  background-repeat: no-repeat; }
+.platform_sh_standalone .link-subscribe:hover {
+  text-decoration: none;
+  background-position: 100% 70%; }
+.platform_sh_standalone .linked-block {
+  position: relative;
+  padding-bottom: 3rem; }
+.platform_sh_standalone .linked-block.related {
+  background: #EEEDE4; }
+.platform_sh_standalone .linked-block .bunnies,
+.platform_sh_standalone .linked-block .people {
+  background: #EEEDE4;
+  background-size: auto 100%;
+  height: 152px;
+  box-sizing: border-box;
+  padding: 30px 20px; }
+@media (min-width: 768px) {
+  .platform_sh_standalone .linked-block .bunnies,
+  .platform_sh_standalone .linked-block .people {
+    background: #EEEDE4 url(/images/linked-block/bunny-carrots.svg) no-repeat 80% 0;
+    background-size: auto 100%;
+    height: 380px;
+    padding: 60px; } }
+@incude media-breakpoint-up(md) {
+  .platform_sh_standalone .linked-block .bunnies h2,
+  .platform_sh_standalone .linked-block .people h2 {
+    width: 420px;
+    float: left;
+    margin-right: 30px; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .linked-block .people {
+    background-image: url(/images/linked-block/people.png); } }
+.platform_sh_standalone .linked-block .link-wrapper {
+  padding: 30px;
+  background: #FFFFFF; }
+@media (max-width: 767.98px) {
+  .platform_sh_standalone .linked-block .link-wrapper {
+    margin-left: 20px; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone .linked-block .link-wrapper {
+    height: 310px;
+    padding: 60px;
+    margin-right: 30px; } }
+.platform_sh_standalone .linked-block .link-wrapper h2 {
+  margin-bottom: 3.75rem; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .linked-block .link-wrapper h2 {
+    font-size: 2rem; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .linked-block .link-wrapper h2 {
+    font-size: 3rem; } }
+.platform_sh_standalone .linked-block .link-wrapper:hover {
+  box-shadow: 0 8px 70px rgba(73, 71, 95, 0.24); }
+.platform_sh_standalone .linked-block .link-wrapper a {
+  cursor: pointer; }
+.platform_sh_standalone .linked-block .row.overlap {
+  margin-top: -50px;
+  flex-direction: row;
+  flex-wrap: nowrap; }
+@media (min-width: 768px) {
+  .platform_sh_standalone .linked-block .row.overlap {
+    margin-top: -220px; } }
+.platform_sh_standalone .linked-block.overlay:hover:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: black;
+  opacity: .1; }
+.platform_sh_standalone .linked-block .linked-block-header {
+  padding-top: 2rem; }
+.platform_sh_standalone .navbar {
+  font-family: "Moderat", "Helvetica Neue", Arial;
+  font-size: 15px;
+  background-color: #FFFFFF;
+  width: 100%;
+  margin: 0 auto;
+  position: fixed;
+  z-index: 9999;
+  padding: 0;
+  top: 0; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar {
+    padding: 0.5rem 0 0.25rem 0; } }
+.platform_sh_standalone .navbar .navbar-wrapper {
+  width: 100%;
+  position: relative; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar .navbar-wrapper {
+    padding: 0rem 3rem;
+    display: flex;
+    justify-content: space-between;
+    max-width: 1980px;
+    margin: 0 auto; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .navbar .navbar-wrapper {
+    padding: 0rem 5rem; } }
+.platform_sh_standalone .navbar .navbar-brand {
+  padding: 1rem 1.25rem 1rem 1.25rem; }
+.platform_sh_standalone .navbar .navbar-brand svg {
+  width: 120px;
+  padding-top: 0.375rem; }
+.platform_sh_standalone .navbar .navbar-brand svg:focus {
+  outline: #FFFFFF; }
+@media (min-width: 768px) {
+  .platform_sh_standalone .navbar .navbar-brand svg {
+    width: auto; } }
+.platform_sh_standalone .navbar .navbar-toggler {
+  border: none;
+  font-size: 1rem;
+  padding: 1.75rem 1.25rem;
+  float: right; }
+.platform_sh_standalone .navbar .navbar-toggler:focus {
+  outline: none; }
+.platform_sh_standalone .navbar .navbar-toggler .navbar-toggler-icon {
+  background: none;
+  width: 1.875rem;
+  height: 0.75rem;
+  vertical-align: top; }
+.platform_sh_standalone .navbar .navbar-toggler .closed {
+  display: none; }
+.platform_sh_standalone .navbar .navbar-toggler .open {
+  display: block; }
+.platform_sh_standalone .navbar .navbar-toggler.collapsed .open {
+  display: none; }
+.platform_sh_standalone .navbar .navbar-toggler.collapsed .closed {
+  display: block; }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .navbar .navbar-collapse {
+    width: 150%;
+    margin: auto -20px;
+    padding: 3rem 0;
+    background-color: #FFFFFF; } }
+.platform_sh_standalone .navbar .navbar-nav {
+  position: static;
+  padding: 0; }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .navbar .navbar-nav.main-menu {
+    background-color: #FFFFFF;
+    width: 100%; } }
+.platform_sh_standalone .navbar .navbar-nav:hover .nav-link {
+  color: #A4A4B4; }
+.platform_sh_standalone .navbar .navbar-nav:hover .nav-link:hover {
+  color: #1A182A;
+  cursor: pointer; }
+.platform_sh_standalone .navbar .navbar-nav.navbar-active {
+  padding-right: 0; }
+.platform_sh_standalone .navbar .navbar-nav.navbar-active .nav-link {
+  color: #A4A4B4; }
+.platform_sh_standalone .navbar .navbar-nav.navbar-active .nav-link:hover {
+  color: #1A182A; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar .navbar-nav.navbar-active .active > .nav-link {
+    color: #1A182A;
+    background: transparent url(/images/icons/nav-highlight.svg) center 90% no-repeat; } }
+.platform_sh_standalone .navbar .navbar-nav .dropdown {
+  position: static; }
+.platform_sh_standalone .navbar .navbar-nav .dropdown:hover > .mega-menu-wrapper {
+  display: block; }
+.platform_sh_standalone .navbar .navbar-nav .nav-link {
+  padding: 0 0 1.75rem 3rem;
+  line-height: 1;
+  color: #49475F;
+  font-size: 1.25rem; }
+.platform_sh_standalone .navbar .navbar-nav .nav-link.active + .mega-menu-wrapper {
+  display: block; }
+@media (min-width: 768px) {
+  .platform_sh_standalone .navbar .navbar-nav .nav-link {
+    padding-bottom: 2rem; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar .navbar-nav .nav-link {
+    font-size: inherit;
+    padding: 1rem 0.5rem; }
+  .platform_sh_standalone .navbar .navbar-nav .nav-link > svg {
+    display: none; }
+  .platform_sh_standalone .navbar .navbar-nav .nav-link:hover {
+    background: transparent url(/images/icons/nav-highlight.svg) center 90% no-repeat; }
+  .platform_sh_standalone .navbar .navbar-nav .nav-link.expand:hover + .mega-menu-wrapper, .platform_sh_standalone .navbar .navbar-nav .nav-link.expand.active + .mega-menu-wrapper {
+    display: block; } }
+@media (min-width: 992px) and (max-width: 991.98px) {
+  .platform_sh_standalone .navbar .navbar-nav .nav-link.expand:hover + .mega-menu-wrapper rect,
+  .platform_sh_standalone .navbar .navbar-nav .nav-link.expand:hover + .mega-menu-wrapper path, .platform_sh_standalone .navbar .navbar-nav .nav-link.expand.active + .mega-menu-wrapper rect,
+  .platform_sh_standalone .navbar .navbar-nav .nav-link.expand.active + .mega-menu-wrapper path {
+    fill: #A4A4B4; } }
+
+@media (min-width: 1290px) {
+  .platform_sh_standalone .navbar .navbar-nav .nav-link {
+    padding: 1rem 1.25rem; } }
+.platform_sh_standalone .navbar .divider {
+  display: none; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar .divider {
+    display: block;
+    margin: 0.5rem 0.5rem 0;
+    height: 30px;
+    border-left: 1px solid rgba(26, 24, 42, 0.2); } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone .navbar .divider {
+    margin: 0 0.875rem 0; } }
+.platform_sh_standalone .navbar .mega-menu-wrapper {
+  display: none; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar .mega-menu-wrapper {
+    position: absolute;
+    left: 0;
+    padding: 12px 0 0; } }
+.platform_sh_standalone .navbar .mega-menu-wrapper:hover {
+  display: block; }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone .navbar .mega-menu {
+    margin: -1rem 0 1.5rem 4rem;
+    background-color: #FFFFFF; }
+  .platform_sh_standalone .navbar .mega-menu .title,
+  .platform_sh_standalone .navbar .mega-menu .promo,
+  .platform_sh_standalone .navbar .mega-menu .subscibe,
+  .platform_sh_standalone .navbar .mega-menu p {
+    display: none; }
+  .platform_sh_standalone .navbar .mega-menu h5 {
+    font-weight: 400;
+    color: inherit;
+    margin-bottom: 0rem;
+    padding: 0.5rem 0; }
+  .platform_sh_standalone .navbar .mega-menu .row {
+    display: flex;
+    flex-direction: column; } }
+@media (max-width: 767.98px) {
+  .platform_sh_standalone .navbar .mega-menu h5 {
+    font-size: 1rem; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar .mega-menu {
+    padding: 2.5rem 5rem 2.5rem;
+    font-family: Overpass, Arial;
+    font-size: 1rem;
+    box-shadow: 0px 14px 44px 0 rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid #EDEDEF;
+    margin-bottom: 5rem;
+    background-color: #FFFFFF;
+    clip-path: inset(2px 0 -60px 0); } }
+.platform_sh_standalone .navbar .mega-menu .form-subscribe label {
+  display: none; }
+.platform_sh_standalone .navbar .mega-menu .form-subscribe .btn, .platform_sh_standalone .navbar .mega-menu .form-subscribe #user-widget .user-widget__log-in, .platform_sh_standalone #user-widget .navbar .mega-menu .form-subscribe .user-widget__log-in, .platform_sh_standalone .navbar .mega-menu .form-subscribe #user-widget .user-widget__free-trial, .platform_sh_standalone #user-widget .navbar .mega-menu .form-subscribe .user-widget__free-trial {
+  font-size: 15px;
+  letter-spacing: 0.2rem; }
+.platform_sh_standalone .navbar .mega-menu h5, .platform_sh_standalone .navbar .mega-menu h6 {
+  font-family: "Moderat", "Helvetica Neue", Arial;
+  font-weight: 700;
+  color: #000; }
+.platform_sh_standalone .navbar .mega-menu .mega-menu-link {
+  color: inherit; }
+.platform_sh_standalone .navbar .mega-menu .mega-menu-link p {
+  color: #49475F; }
+.platform_sh_standalone .navbar .mega-menu .mega-menu-link:hover {
+  text-decoration: none;
+  color: #145CC6; }
+.platform_sh_standalone .navbar .mega-menu .mega-menu-link:hover h5 {
+  color: #145CC6; }
+.platform_sh_standalone .navbar .mega-menu .label {
+  color: #A4A4B4;
+  font-size: 1rem;
+  font-weight: 600; }
+.platform_sh_standalone .navbar .mega-menu .list-stack {
+  margin: 0;
+  column-count: 2; }
+.platform_sh_standalone .navbar .mega-menu .list-stack li {
+  margin-bottom: 1rem; }
+.platform_sh_standalone .navbar .mega-menu .list-stack img {
+  display: none; }
+.platform_sh_standalone .navbar .mega-menu .list-stack a {
+  color: #1A182A; }
+.platform_sh_standalone .navbar .mega-menu .list-stack a:hover {
+  padding-right: 1.5rem;
+  text-decoration: none;
+  background: transparent url(/images/icons/chevrons/chevrons-pink-red.svg) 100% 50% no-repeat; }
+.platform_sh_standalone .navbar-top {
+  background: transparent !important; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-top .navbar-nav .nav-link {
+    color: #FFFFFF; } }
+.platform_sh_standalone .navbar-top .navbar-nav:hover .nav-link {
+  color: #A4A4B4; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-top .navbar-nav:hover .nav-link:hover {
+    color: #FFFFFF;
+    background-image: url(/images/icons/nav-highlight-light.svg); } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-top .navbar-nav:hover .active .nav-link {
+    color: #FFFFFF; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-top .navbar-nav .active .nav-link {
+    color: #FFFFFF;
+    background: transparent url(/images/icons/nav-highlight-light.svg) center 90% no-repeat; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar-top a.navbar-brand svg path {
+    fill: #FFFFFF; } }
+.platform_sh_standalone .navbar-top #user-widget .user-widget__log-in {
+  color: #FFFFFF; }
+.platform_sh_standalone .navbar-top #user-widget .user-widget__log-in:hover {
+  color: #FB3728; }
+.platform_sh_standalone .navbar-top #user-widget .user-widget__projects_menu_toggle {
+  padding: 1rem 1.25rem;
+  height: 47px; }
+.platform_sh_standalone .navbar-top #user-widget .user-widget__projects_menu_toggle img {
+  display: none; }
+.platform_sh_standalone .navbar-top #user-widget .user-widget__projects_menu_toggle:hover, .platform_sh_standalone .navbar-top #user-widget .user-widget__projects_menu_toggle.user-widget__projects_menu_toggle--active {
+  color: #FFFFFF;
+  background: transparent url(/images/icons/nav-highlight-light.svg) center 90% no-repeat; }
+.platform_sh_standalone #user-widget {
+  height: 47px; }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone #user-widget {
+    margin: 2rem 0 0 3rem; } }
+.platform_sh_standalone #user-widget .dropdown-wrapper {
+  height: 47px; }
+.platform_sh_standalone #user-widget .dropdown-wrapper:hover .user-widget__dropdown__menu {
+  display: block; }
+.platform_sh_standalone #user-widget .user-widget__log-in {
+  color: #1A182A;
+  background-color: #FFBDBB; }
+.platform_sh_standalone #user-widget .user-widget__log-in:hover {
+  background-color: #FB3728; }
+@media (min-width: 992px) {
+  .platform_sh_standalone #user-widget .user-widget__log-in {
+    color: #145CC6;
+    background-color: transparent;
+    padding: 1rem 0.5rem; }
+  .platform_sh_standalone #user-widget .user-widget__log-in:hover {
+    color: #FB3728;
+    background: none; } }
+@media (min-width: 1200px) {
+  .platform_sh_standalone #user-widget .user-widget__log-in {
+    padding: 1rem; } }
+.platform_sh_standalone #user-widget .user-widget__free-trial {
+  height: auto;
+  line-height: inherit;
+  margin-left: 12px;
+  text-transform: lowercase; }
+.platform_sh_standalone #user-widget .user-widget__free-trial strong {
+  display: inline-block; }
+.platform_sh_standalone #user-widget .user-widget__free-trial strong::first-letter {
+  text-transform: uppercase; }
+@media (min-width: 1200px) {
+  .platform_sh_standalone #user-widget .user-widget__free-trial {
+    margin-left: 30px; } }
+.platform_sh_standalone #user-widget .user-widget__user_name,
+.platform_sh_standalone #user-widget .user-widget__projects_menu_toggle {
+  color: #A4A4B4; }
+.platform_sh_standalone #user-widget .user-widget__user_name:hover,
+.platform_sh_standalone #user-widget .user-widget__projects_menu_toggle:hover {
+  color: #1A182A; }
+.platform_sh_standalone #user-widget .user-widget__avatar {
+  max-width: 24px;
+  max-height: 24px;
+  border-radius: 2px; }
+.platform_sh_standalone #user-widget .user-widget__projects_menu_toggle {
+  padding: 1rem 1.25rem;
+  height: 47px; }
+.platform_sh_standalone #user-widget .user-widget__projects_menu_toggle img {
+  display: none; }
+.platform_sh_standalone #user-widget .user-widget__projects_menu_toggle:hover, .platform_sh_standalone #user-widget .user-widget__projects_menu_toggle.user-widget__projects_menu_toggle--active {
+  color: #1A182A;
+  background: transparent url(/images/icons/nav-highlight.svg) center 90% no-repeat; }
+.platform_sh_standalone #user-widget .user-widget__dropdown__menu {
+  background: #FFFFFF;
+  border-radius: 2px;
+  box-shadow: 0px 4px 8px rgba(152, 160, 171, 0.4);
+  padding: 8px; }
+.platform_sh_standalone #user-widget .user-widget__dropdown__menu a {
+  color: #38485E; }
+.platform_sh_standalone #user-widget .user-widget__dropdown__menu a:hover {
+  color: #38485E;
+  background: rgba(134, 181, 255, 0.2);
+  border-radius: 4px; }
+.platform_sh_standalone #user-widget .user-widget__dropdown__menu--projects div.user-widget__dropdown__menu__list_item {
+  color: inherit; }
+.platform_sh_standalone #user-widget .user-widget__dropdown__menu--projects div.user-widget__dropdown__menu__list_item:hover {
+  background: transparent; }
+.platform_sh_standalone .navbar.navbar-top {
+  background: transparent !important; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar.navbar-top .navbar-nav .nav-link {
+    color: #FFFFFF; } }
+.platform_sh_standalone .navbar.navbar-top .navbar-nav:hover .nav-link {
+  color: #A4A4B4; }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar.navbar-top .navbar-nav:hover .nav-link:hover {
+    color: #FFFFFF;
+    background-image: url(/images/icons/nav-highlight-light.svg); } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar.navbar-top .navbar-nav:hover .active .nav-link {
+    color: #FFFFFF; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar.navbar-top .navbar-nav .active .nav-link {
+    color: #FFFFFF;
+    background: transparent url(/images/icons/nav-highlight-light.svg) center 90% no-repeat; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone .navbar.navbar-top a.navbar-brand svg path {
+    fill: #FFFFFF; } }
+.platform_sh_standalone .navbar.navbar-top #user-widget .user-widget__log-in {
+  color: #FFFFFF; }
+.platform_sh_standalone .navbar.navbar-top #user-widget .user-widget__log-in:hover {
+  color: #FB3728; }
+.platform_sh_standalone .navbar.navbar-top #user-widget .user-widget__projects_menu_toggle {
+  padding: 1rem 1.25rem;
+  height: 47px; }
+.platform_sh_standalone .navbar.navbar-top #user-widget .user-widget__projects_menu_toggle img {
+  display: none; }
+.platform_sh_standalone .navbar.navbar-top #user-widget .user-widget__projects_menu_toggle:hover, .platform_sh_standalone .navbar.navbar-top #user-widget .user-widget__projects_menu_toggle.user-widget__projects_menu_toggle--active {
+  color: #FFFFFF;
+  background: transparent url(/images/icons/nav-highlight-light.svg) center 90% no-repeat; }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone body.home .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.home .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.home .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.home .navbar.navbar-top .navbar-toggler path,
+  .platform_sh_standalone body.product .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.product .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.product .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.product .navbar.navbar-top .navbar-toggler path,
+  .platform_sh_standalone body.solutions .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.solutions .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.solutions .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.solutions .navbar.navbar-top .navbar-toggler path,
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-toggler path,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-toggler path,
+  .platform_sh_standalone body.contact .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.contact .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.contact .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.contact .navbar.navbar-top .navbar-toggler path {
+    fill: #FFFFFF; } }
+@media (max-width: 991.98px) {
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-toggler path,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-brand rect,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-brand path,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-toggler rect,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-toggler path {
+    fill: #1A182A; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone body.company .navbar.navbar-top {
+    background: transparent; }
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-brand svg path {
+    fill: #1A182A; }
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-nav .active .nav-link {
+    background: transparent url(/images/icons/nav-highlight-light.svg) center 90% no-repeat; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone body.stacks .navbar.navbar-top,
+  .platform_sh_standalone body.board .navbar.navbar-top,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top,
+  .platform_sh_standalone body.pricing .navbar.navbar-top,
+  .platform_sh_standalone body.events .navbar.navbar-top,
+  .platform_sh_standalone body.blog .navbar.navbar-top,
+  .platform_sh_standalone body.security .navbar.navbar-top,
+  .platform_sh_standalone body.legal .navbar.navbar-top,
+  .platform_sh_standalone body.downloads .navbar.navbar-top,
+  .platform_sh_standalone body.logos .navbar.navbar-top,
+  .platform_sh_standalone body.preferences .navbar.navbar-top,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top {
+    background: transparent; }
+  .platform_sh_standalone body.stacks .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.pricing .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.events .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.blog .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.security .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.legal .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.downloads .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.logos .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.preferences .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top .navbar-brand svg path,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top .navbar-brand svg path {
+    fill: #1A182A; }
+  .platform_sh_standalone body.stacks .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.stacks .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.pricing .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.pricing .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.events .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.events .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.blog .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.blog .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.security .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.security .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.legal .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.legal .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.downloads .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.downloads .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.logos .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.logos .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.preferences .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.preferences .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top .navbar-nav .btn-login,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top .navbar-nav .nav-link,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top .navbar-nav .btn-login {
+    color: #A4A4B4; }
+  .platform_sh_standalone body.stacks .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.pricing .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.events .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.blog .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.security .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.legal .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.downloads .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.logos .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.preferences .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top .navbar-nav:hover .nav-link,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top .navbar-nav:hover .nav-link {
+    color: #A4A4B4; }
+  .platform_sh_standalone body.stacks .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.pricing .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.events .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.blog .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.security .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.legal .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.downloads .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.logos .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.preferences .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top .navbar-nav:hover .nav-link:hover,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top .navbar-nav:hover .nav-link:hover {
+    color: #1A182A;
+    background: transparent url(/images/icons/nav-highlight.svg) center 90% no-repeat; }
+  .platform_sh_standalone body.stacks .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.board .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.pricing .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.events .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.blog .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.security .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.legal .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.downloads .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.logos .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.preferences .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top #user-widget .user-widget__log-in,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top #user-widget .user-widget__log-in {
+    color: #145CC6; }
+  .platform_sh_standalone body.stacks .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.board .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.pricing .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.events .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.blog .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.security .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.legal .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.downloads .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.logos .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.preferences .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.customers.stories .navbar.navbar-top #user-widget .user-widget__log-in:hover,
+  .platform_sh_standalone body.customers.story .navbar.navbar-top #user-widget .user-widget__log-in:hover {
+    color: #FB3728; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone body.stacks .navbar.navbar-top .navbar-nav .active .nav-link,
+  .platform_sh_standalone body.board .navbar.navbar-top .navbar-nav .active .nav-link,
+  .platform_sh_standalone body.company-careers-jobs .navbar.navbar-top .navbar-nav .active .nav-link,
+  .platform_sh_standalone body.blog .navbar.navbar-top .navbar-nav .active .nav-link,
+  .platform_sh_standalone body.downloads .navbar.navbar-top .navbar-nav .active .nav-link,
+  .platform_sh_standalone body.pricing .navbar.navbar-top .navbar-nav .active .nav-link {
+    color: #1A182A;
+    background: transparent url(/images/icons/nav-highlight.svg) center 90% no-repeat; } }
+@media (min-width: 992px) {
+  .platform_sh_standalone body.company .navbar.navbar-top {
+    background: transparent; }
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-brand svg path {
+    fill: #1A182A; }
+  .platform_sh_standalone body.company .navbar.navbar-top .navbar-nav .active .nav-link {
+    background: transparent url(/images/icons/nav-highlight-light.svg) center 90% no-repeat; } }
+@media (min-width: 768px) {
+  .platform_sh_standalone body.company-careers .navbar.navbar-top .navbar-brand svg path {
+    fill: #FFFFFF; } }
+.platform_sh_standalone .pagination .page-item .page-link {
+  color: #A4A4B4;
+  background-color: #FFFFFF;
+  border: 1px solid #A4A4B4;
+  padding: 0.5rem 1rem; }
+.platform_sh_standalone .pagination .page-item.active .page-link {
+  background-color: #FFBDBB;
+  border-color: #49475F;
+  font-weight: 700; }
+.platform_sh_standalone .range {
+  height: 0px; }
+.platform_sh_standalone .range input {
+  width: 100%;
+  height: 0;
+  -webkit-appearance: none;
+  z-index: 1;
+  position: absolute;
+  left: 0;
+  top: 10px; }
+.platform_sh_standalone .range input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: #FB3728;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  margin-top: -5px;
+  margin-left: 0px;
+  z-index: 102; }
+.platform_sh_standalone .range input::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: #FB3728;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  margin-top: -5px;
+  margin-left: 0px;
+  z-index: 102; }
+.platform_sh_standalone .range input::-ms-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: #FB3728;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  margin-top: -5px;
+  margin-left: 0px;
+  z-index: 102; }
+.platform_sh_standalone .range input .large::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: #FB3728;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  margin-top: -5px;
+  margin-left: 0px;
+  z-index: 102;
+  width: 30px;
+  height: 30px;
+  margin-top: -10px; }
+.platform_sh_standalone .range input .large::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: #FB3728;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  margin-top: -5px;
+  margin-left: 0px;
+  z-index: 102;
+  width: 30px;
+  height: 30px;
+  margin-top: -10px; }
+.platform_sh_standalone .range input .large::-ms-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  background: #FB3728;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  margin-top: -5px;
+  margin-left: 0px;
+  z-index: 102;
+  width: 30px;
+  height: 30px;
+  margin-top: -10px; }
+.platform_sh_standalone .range input::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 10px;
+  cursor: pointer;
+  background: #EEEDE4;
+  border-radius: 12px;
+  position: relative; }
+.platform_sh_standalone .range input::-moz-range-track {
+  width: 100%;
+  height: 10px;
+  cursor: pointer;
+  background: #EEEDE4;
+  border-radius: 12px; }
+.platform_sh_standalone .range input::-ms-track {
+  width: 100%;
+  height: 10px;
+  cursor: pointer;
+  background: #EEEDE4;
+  border-radius: 12px; }
+.platform_sh_standalone .range input:focus {
+  background: none;
+  outline: none; }
+.platform_sh_standalone .range input::-ms-track {
+  width: 100%;
+  cursor: pointer;
+  background: transparent;
+  border-color: transparent;
+  color: transparent; }
+.platform_sh_standalone .range-labels {
+  padding: 0;
+  list-style: none;
+  font-weight: 900;
+  height: 0px;
+  padding-top: 30px; }
+.platform_sh_standalone .range-labels li {
+  font-size: 0.875rem;
+  cursor: pointer;
+  width: 25px;
+  text-align: center; }
+.platform_sh_standalone .range-labels li:first-child {
+  text-align: left;
+  margin-left: 5px; }
+.platform_sh_standalone .range-labels .active {
+  color: #FB3728; }
+.platform_sh_standalone .range-labels .selected::before {
+  background: #FB3728; }
+.platform_sh_standalone .range-labels .active.selected::before {
+  display: none; }
+.platform_sh_standalone .range-labels.addon li {
+  visibility: hidden; }
+.platform_sh_standalone .range-labels.addon li.active {
+  visibility: visible; }
+.platform_sh_standalone #sto-range .range-labels li,
+.platform_sh_standalone #env-range .range-labels li {
+  position: absolute; }
+.platform_sh_standalone #plan-range .range-labels li {
+  text-align: left;
+  width: 15px; }
+.platform_sh_standalone .range-form {
+  position: relative; }
+.platform_sh_standalone .range-tick-container {
+  z-index: 10;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%; }
+.platform_sh_standalone .range-tick {
+  position: absolute;
+  cursor: pointer;
+  width: 6px;
+  height: 6px;
+  border-radius: 30%;
+  background: #FFFFFF;
+  cursor: pointer;
+  border: 0 !important;
+  transform: rotate(45deg);
+  top: 12px;
+  -webkit-box-shadow: inset 0 0 0px 1px #EEEDE4;
+  box-shadow: inset 0 0 0px 1px #EEEDE4;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  filter: none; }
+.platform_sh_standalone .range-tick.active {
+  display: none; }


### PR DESCRIPTION
## Why

Prepares the docs sites for migration of api docs


## What's changed

* refactors api workflow to save api docs file into shared/pages
* adds stylesheet for api docs
* adds location for both docs to allow for /api.
*  adds steps to build hook to copy api docs page into new location

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
