### PR TITLE
Add paused as a environment status

### DIFF
--- a/sites/platform/src/environments/_index.md
+++ b/sites/platform/src/environments/_index.md
@@ -62,13 +62,16 @@ You might want to give it a [custom domain name](/domains/steps/_index.md).
 
 ## Environment status
 
-Your environments can have one of two statuses:
+Your environments can have one of three statuses:
 
 -   [Active](/glossary/_index.md#active-environment):
     A deployed environment with services and data.
 
 -   [Inactive](/glossary/_index.md#inactive-environment):
     An environment that isn't deployed and has no services or data, only code.
+
+-   [Paused](#paused-environments):
+    An environment that hasn't been redeployed in 14 days or longer.
 
 You can see the status of your environments in the [Console](/administration/web/_index.md) or the [CLI](/administration/cli/_index.md).
 
@@ -213,7 +216,7 @@ To prevent your production environment from being paused automatically,
 
 {{< /note >}}
 
-You can also pause an environment manually at any time.
+You can pause (and resume) an environment manually at any time.
 
 ### Pause an environment
 

--- a/sites/upsun/src/environments/_index.md
+++ b/sites/upsun/src/environments/_index.md
@@ -63,6 +63,9 @@ Your environments can have one of two statuses:
 -   [Inactive](/glossary.md#inactive-environment):
     An environment that isn't deployed and has no services or data, only code.
 
+-   [Paused](#paused-environments):
+    An environment that hasn't been redeployed in 14 days or longer.
+
 You can see the status of your environments in the [Console](../administration/web/_index.md) or the [CLI](/administration/cli/_index.md).
 
 {{< codetabs >}}
@@ -196,7 +199,7 @@ Staging
 To prevent unnecessary consumption of resources,
 {{% vendor/name %}} automatically pauses preview environments ([of both development and staging types](/glossary.md#environment-type)) that haven't been redeployed in 14 days.
 
-You can also pause an environment manually at any time.
+You can pause (and resume) an environment manually at any time.
 
 ### Pause an environment
 

--- a/sites/upsun/src/environments/_index.md
+++ b/sites/upsun/src/environments/_index.md
@@ -55,7 +55,7 @@ environment, but you can [name it as you want](/environments/default-environment
 
 ## Environment status
 
-Your environments can have one of two statuses:
+Your environments can have one of three statuses:
 
 -   [Active](/glossary.md#active-environment):
     A deployed environment with services and data.


### PR DESCRIPTION


## Why

Closes #4691 


## What's changed

Added "paused" to the list of environment statuses.

## Where are changes

https://docs.platform.sh/environments.html#environment-status
https://docs.upsun.com/environments.html#environment-status

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
