### PR TITLE
feat: updated content style guide

### DIFF
--- a/contributing/content-style.md
+++ b/contributing/content-style.md
@@ -158,23 +158,23 @@ For more information, see how to [configure apps](https://example.com). | For mo
 
 ### Use verbs (imperatives) for headings and section titles
 
-To maintain a clear, authoritative, and action-oriented tone, use imperative verbs (the base form of the verb) rather than gerunds (*-ing* forms) in headings and section titles.
+To maintain a clear and authoritative tone, use imperative verbs (the base form of the verb) rather than gerunds (*-ing*) in headings and section titles.
 
 This approach helps guide the reader with direct instructions, making it immediately clear what action they should take.
 
-**Do this:**
+Do this:
 * Set up your environment  
 * Deploy your project  
 * Configure environment variables  
 * Troubleshoot common errors
 
-**Not this:**
+Not this:
 * Setting up your environment  
 * Deploying your project  
 * Configuring environment variables  
 * Troubleshooting common errors
 
-Using verbs keeps the content focused, concise, and easier to scan, while reinforcing the step-by-step, instructional nature of our documentation.
+Using verbs keeps the content focused, concise, and easier to scan, while reinforcing the instructional nature of our documentation.
 
 ### Minimize distractions
 


### PR DESCRIPTION
Added point about using imperative verbs instead of gerunds.

## Why

Closes #4732 

## What's changed

Added point about using imperative verbs instead of gerunds.

## Where are changes

The changes are in the content style guide.

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
