### PR TITLE
feat: Adjusted composable image page

### DIFF
--- a/sites/platform/src/create-apps/_index.md
+++ b/sites/platform/src/create-apps/_index.md
@@ -122,6 +122,7 @@ Unlike other runtimes most PHP applications do not have a start command. There i
 
 The following example shows a setup for a PHP app with comments to explain the settings. Please note that Composable image is currently available as a Beta feature.
 
+
 {{< codetabs >}}
 
 +++
@@ -183,6 +184,7 @@ web:
       allow: true
       passthru: '/app.php'
 ```
+
 <--->
 
 +++

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -19,7 +19,7 @@ in a **"one image to rule them all"** approach.
 The composable image is built on [Nix](https://nix.dev), which offers the following benefits:
 
 - You can add as many packages to your application container as you need,
-  choosing from over 80,000 packages from [the Nixpkgs collection](https://search.nixos.org/packages).
+  choosing from over 120,000 packages from [the Nixpkgs collection](https://search.nixos.org/packages).
 - The packages you add are built in total isolation, so you can install different versions of the same package.
 - With [Nix](https://nix.dev/reference/glossary#term-Nix), there are no undeclared dependencies in your source code.
   What works on your local machine is guaranteed to work on any other machine.

--- a/sites/upsun/src/create-apps/_index.md
+++ b/sites/upsun/src/create-apps/_index.md
@@ -116,6 +116,7 @@ Unlike other runtimes, most PHP applications do not have a start command. There 
 
 The following example shows a setup for a PHP app with comments to explain the settings. Please note that Composable image is currently available as a Beta feature.
 
+
 {{< codetabs >}}
 
 +++

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -16,7 +16,7 @@ in a **"one image to rule them all"** approach.
 The composable image is built on [Nix](https://nix.dev), which offers the following benefits:
 
 - You can add as many packages to your application container as you need,
-  choosing from over 80,000 packages from [the Nixpkgs collection](https://search.nixos.org/packages).
+  choosing from over 120,000 packages from [the Nixpkgs collection](https://search.nixos.org/packages).
 - The packages you add are built in total isolation, so you can install different versions of the same package.
 - With [Nix](https://nix.dev/reference/glossary#term-Nix), there are no undeclared dependencies in your source code.
   What works on your local machine is guaranteed to work on any other machine.


### PR DESCRIPTION
Changed 80k to 120k and ensured codetabs in comprehensive example work. 

To do:
- Still need to adjust actual example to include type usage.
- Still need to adjust comprehensive example for composable image tab to ensure it's correct.

## Why

Closes #4740 

## What's changed

Changed 80k to 120k and ensured codetabs in comprehensive example work. 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
