### PR TITLE
feat: removed beta tag from composable image docs

### DIFF
--- a/sites/platform/src/create-apps/app-reference/_index.md
+++ b/sites/platform/src/create-apps/app-reference/_index.md
@@ -6,14 +6,14 @@ layout: single
 ---
 
 To define your app, you can either use one of {{% vendor/name %}}'s [single-runtime image](/create-apps/app-reference/single-runtime-image.md)
-or its [composable image (BETA)](/create-apps/app-reference/composable-image.md).
+or its [composable image](/create-apps/app-reference/composable-image.md).
 
 ## Single-runtime image
 
 {{% vendor/name %}} provides and maintains a list of single-runtime images you can use for each of your application containers.</br>
 See [all of the options you can use](/create-apps/app-reference/single-runtime-image.md) to define your app using a single-runtime image.
 
-## Composable image (BETA)
+## Composable image
 
 The {{% vendor/name %}} composable image provides more flexibility than single-runtime images.
 When using a composable image, you can define a stack (or group of packages) for your application container to use.

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -2,11 +2,6 @@
 title: "Composable image"
 weight: 5
 description: Use {{% vendor/name %}}'s composable image to build and deploy your app.
-beta: true
-banner:
-  title: Beta Feature
-  body: The {{% vendor/name %}} composable image is currently available in Beta.
-        This feature as well as its documentation is subject to change.
 keywords:
   - sleepy crons
   - sleepy_crons

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -2,11 +2,6 @@
 title: "Composable image"
 weight: 5
 description: Use {{% vendor/name %}}'s composable image to build and deploy your app.
-beta: true
-banner:
-  title: Beta Feature
-  body: The {{% vendor/name %}} composable image is currently available in Beta.
-        This feature as well as its documentation is subject to change.
 ---
 
 The {{% vendor/name %}} composable image provides enhanced flexibility when defining your app.


### PR DESCRIPTION
removed beta tag and any mentions of beta from docs

## Why

Closes #4738 

## What's changed

removed beta tag and any mentions of beta from docs

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
