### PR TITLE
feat: removed stray beta tag

### DIFF
--- a/sites/upsun/src/create-apps/app-reference/_index.md
+++ b/sites/upsun/src/create-apps/app-reference/_index.md
@@ -6,14 +6,14 @@ layout: single
 ---
 
 To define your app, you can either use one of {{% vendor/name %}}'s [single-runtime image](/create-apps/app-reference/single-runtime-image.md)
-or its [composable image (BETA)](/create-apps/app-reference/composable-image.md).
+or its [composable image](/create-apps/app-reference/composable-image.md).
 
 ## Single-runtime image
 
 {{% vendor/name %}} provides and maintains a list of single-runtime images you can use for each of your application containers.</br>
 See [all of the options you can use](/create-apps/app-reference/single-runtime-image.md) to define your app using a single-runtime image.
 
-## Composable image (BETA)
+## Composable image 
 
 The {{% vendor/name %}} composable image provides more flexibility than single-runtime images.
 When using a composable image, you can define a stack (or group of packages) for your application container to use.


### PR DESCRIPTION
removed stray beta tag

## Why

Closes #4751 

## What's changed

removed stray beta tag in the upsun app reference page 

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
