### PR TITLE
feat: added tag back in

### DIFF
--- a/sites/platform/src/create-apps/_index.md
+++ b/sites/platform/src/create-apps/_index.md
@@ -120,7 +120,7 @@ Unlike other runtimes most PHP applications do not have a start command. There i
 
 {{< /note >}}
 
-The following example shows a setup for a PHP app with comments to explain the settings.
+The following example shows a setup for a PHP app with comments to explain the settings.  Please note that Composable image is currently available as a Beta feature.
 
 {{< codetabs >}}
 
@@ -186,7 +186,7 @@ web:
 <--->
 
 +++
-title=Composable image
+title=Composable image (BETA)
 +++
 
 ```yaml {configFile="app"}

--- a/sites/platform/src/create-apps/app-reference/_index.md
+++ b/sites/platform/src/create-apps/app-reference/_index.md
@@ -6,14 +6,14 @@ layout: single
 ---
 
 To define your app, you can either use one of {{% vendor/name %}}'s [single-runtime image](/create-apps/app-reference/single-runtime-image.md)
-or its [composable image](/create-apps/app-reference/composable-image.md).
+or its [composable image (BETA)](/create-apps/app-reference/composable-image.md).
 
 ## Single-runtime image
 
 {{% vendor/name %}} provides and maintains a list of single-runtime images you can use for each of your application containers.</br>
 See [all of the options you can use](/create-apps/app-reference/single-runtime-image.md) to define your app using a single-runtime image.
 
-## Composable image
+## Composable image (BETA)
 
 The {{% vendor/name %}} composable image provides more flexibility than single-runtime images.
 When using a composable image, you can define a stack (or group of packages) for your application container to use.

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -5,6 +5,11 @@ description: Use {{% vendor/name %}}'s composable image to build and deploy your
 keywords:
   - sleepy crons
   - sleepy_crons
+  beta: true
+banner:
+  title: Beta Feature
+  body: The {{% vendor/name %}} composable image is currently available in Beta.
+        This feature as well as its documentation is subject to change.
 ---
 
 The {{% vendor/name %}} composable image provides enhanced flexibility when defining your app.

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -5,7 +5,7 @@ description: Use {{% vendor/name %}}'s composable image to build and deploy your
 keywords:
   - sleepy crons
   - sleepy_crons
-  beta: true
+beta: true
 banner:
   title: Beta Feature
   body: The {{% vendor/name %}} composable image is currently available in Beta.

--- a/sites/upsun/src/create-apps/_index.md
+++ b/sites/upsun/src/create-apps/_index.md
@@ -114,7 +114,7 @@ Unlike other runtimes, most PHP applications do not have a start command. There 
 
 {{< /note >}}
 
-The following example shows a setup for a PHP app with comments to explain the settings. 
+The following example shows a setup for a PHP app with comments to explain the settings.  Please note that Composable image is currently available as a Beta feature.
 
 {{< codetabs >}}
 
@@ -182,7 +182,7 @@ services:
 <--->
 
 +++
-title=Composable image
+title=Composable image (BETA)
 +++
 
 ```yaml {configFile="app"}

--- a/sites/upsun/src/create-apps/app-reference/_index.md
+++ b/sites/upsun/src/create-apps/app-reference/_index.md
@@ -6,14 +6,14 @@ layout: single
 ---
 
 To define your app, you can either use one of {{% vendor/name %}}'s [single-runtime image](/create-apps/app-reference/single-runtime-image.md)
-or its [composable image](/create-apps/app-reference/composable-image.md).
+or its [composable image (BETA)](/create-apps/app-reference/composable-image.md).
 
 ## Single-runtime image
 
 {{% vendor/name %}} provides and maintains a list of single-runtime images you can use for each of your application containers.</br>
 See [all of the options you can use](/create-apps/app-reference/single-runtime-image.md) to define your app using a single-runtime image.
 
-## Composable image 
+## Composable image (BETA)
 
 The {{% vendor/name %}} composable image provides more flexibility than single-runtime images.
 When using a composable image, you can define a stack (or group of packages) for your application container to use.

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -2,6 +2,11 @@
 title: "Composable image"
 weight: 5
 description: Use {{% vendor/name %}}'s composable image to build and deploy your app.
+beta: true
+banner:
+  title: Beta Feature
+  body: The {{% vendor/name %}} composable image is currently available in Beta.
+        This feature as well as its documentation is subject to change.
 ---
 
 The {{% vendor/name %}} composable image provides enhanced flexibility when defining your app.


### PR DESCRIPTION
added tag back in composable image docs

## Why

Closes #4756 

## What's changed

The docs now have the appropriate tags added back in. 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
