### PR TITLE
feat: added imap for 8.4

### DIFF
--- a/shared/data/php_extensions.yaml
+++ b/shared/data/php_extensions.yaml
@@ -1482,6 +1482,7 @@ grid:
       - iconv  
       - igbinary 
       - imagick 
+      - imap
       - intl  
       - ioncube  
       - ldap  


### PR DESCRIPTION
added imap extension back into php-extensions.yaml as it is now available for php 8.4

## Why

Closes #4758 

## What's changed

added imap extension back into php-extensions.yaml as it is now available for php 8.4

## Where are changes

Changes were made to the php-extensions.yaml but will be reflected in:
https://docs.upsun.com/languages/php/extensions.html and https://docs.platform.sh/languages/php/extensions.html

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
