### PR TITLE
Set DG3 files to list: local

### DIFF
--- a/sites/platform/src/dedicated-environments/dedicated-gen-3/development.md
+++ b/sites/platform/src/dedicated-environments/dedicated-gen-3/development.md
@@ -4,7 +4,7 @@ weight: 1
 sidebarTitle: "DG3 development"
 layout: single
 build:
-  list: never
+  list: local
   render: always
 description:  "Learn about the cluster infrastructure of Dedicated Generation 3, and discover key details about deployment, which regions are supported, storage limits, backups, restores and supported languages and frameworks."
 ---
@@ -82,16 +82,16 @@ Each cluster comes with 50GB of storage per environment by default. This storage
 
 | Type           | Basic               | Advanced        | Premium    |
 |----------------|---------------------|-----------------|------------|
-| 6-hourly       | -                   | -               | 1 day      |                
+| 6-hourly       | -                   | -               | 1 day      |
 | Daily          | 2 days              | 1 week          | 1 month    |
 | Weekly         | -                   | 4 weeks         | -          |
-| Monthly        | -                   | 1 year          | 1 year     | 
+| Monthly        | -                   | 1 year          | 1 year     |
 
 ## Restores
 
 Backups and restores are the same as Grid, so you can use them with the management console and the [Platform.sh CLI](/administration/cli/_index.md).
 
-## Supported languages 
+## Supported languages
 
 Dedicated Generation 3 supports a wide range of languages to power your applications:
 

--- a/sites/platform/src/dedicated-environments/dedicated-gen-3/metrics.md
+++ b/sites/platform/src/dedicated-environments/dedicated-gen-3/metrics.md
@@ -3,8 +3,8 @@ title: "Monitor metrics"
 sidebarTitle: "{{% names/dedicated-gen-3 %}} metrics"
 description: "Understand how to read metrics for {{% names/dedicated-gen-3 %}} environments."
 build:
-  list: never
-  render: always 
+  list: local
+  render: always
 ---
 
 These environments consist of various containers running across dedicated hosts:
@@ -71,7 +71,7 @@ at 9.51&nbsp;GB, while the temporary disk is 49.04&nbsp;GB.
 
 ![All of the metrics for the Scheduler worker container](/images/metrics/DG3-worker-container.png)
 
-### Thresholds 
+### Thresholds
 
 If you have one container in a temporary burst state but your host still has plenty of available resources, it might not be an issue as long as the site is functioning properly. Burst allows your container to use additional resources when they aren't needed elsewhere.
 

--- a/sites/platform/src/dedicated-environments/dedicated-gen-3/overview.md
+++ b/sites/platform/src/dedicated-environments/dedicated-gen-3/overview.md
@@ -2,7 +2,7 @@
 title: "Dedicated Gen 3 Overview"
 weight: -10
 build:
-  list: never
+  list: local
   render: always
 sidebarTitle: "DG3 overview"
 description:  "Designed to cater to the needs of organizations that build demanding apps, Dedicated Generation 3 (DG3) offers increased resources and High Availability (HA) for all your services, along with stricter isolation requirements and additional compliance frameworks."


### PR DESCRIPTION
## Why

We dont want the DG3 collection of pages to show up in the navigation, but we still want them to be accessible in the docs, AND we still want a landing page for DG3

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
