### PR TITLE
feat: removed all mentions of standard

### DIFF
--- a/sites/upsun/src/administration/billing/add-on-subscription.md
+++ b/sites/upsun/src/administration/billing/add-on-subscription.md
@@ -17,10 +17,9 @@ You can do so directly from the Console.
 
 The Advanced User Management add-on gives you access to the following features:
 
-- [Free viewers](../users.md)
-- [Organization permissions](../users.md#organization-permissions)
 - [Teams](/administration/teams.md)
 - [MFA enforcement](/administration/mfa.md)
+- [Single sign-on (Google)](#single-sign-on-google)
 
 ### Upgrade to the Advanced User Management add-on
 
@@ -121,6 +120,8 @@ Downgrades are permitted only after the 365 day MTC has been completed. Organiza
 
 Downgrades are performed through the Console and take effect based on the Organization's billing cycle.
 
+## Single sign-on (Google)
 
+{{% vendor/name %}} allows you to set up Single sign-on (SSO) with Google. To learn more about this feature, contact our [sales team](https://upsun.com/contact-us/) or visit [the pricing page](https://upsun.com/pricing/).
 
 

--- a/sites/upsun/src/administration/billing/add-on-subscription.md
+++ b/sites/upsun/src/administration/billing/add-on-subscription.md
@@ -2,7 +2,7 @@
 title: Subscribe to an add-on
 description: Subscribe to add-ons to enhance your user experience.
 keywords:
-  - Standard User Management
+  - Advanced User Management
   - Add-on
   - Sellable
   - Continuous profiling
@@ -11,26 +11,26 @@ keywords:
 Depending on your needs, you may want to upgrade to the following {{% vendor/name %}} add-ons.
 You can do so directly from the Console.
 
-## Standard User Management add-on
+## Advanced User Management add-on
 
 ### Included features
 
-The Standard User Management add-on gives you access to the following features:
+The Advanced User Management add-on gives you access to the following features:
 
 - [Free viewers](../users.md)
 - [Organization permissions](../users.md#organization-permissions)
 - [Teams](/administration/teams.md)
 - [MFA enforcement](/administration/mfa.md)
 
-### Upgrade to the Standard User Management add-on
+### Upgrade to the Advanced User Management add-on
 
-To upgrade to the Standard User Management add-on, follow these steps:
+To upgrade to the Advanced User Management add-on, follow these steps:
 
 1. In the Console, navigate to your organization.
 2. Open the user menu (your name or profile picture), then select **Billing**.
 3. In the **Organization add-ons** section of the **Overview** tab,
    locate the **User management** panel and click **Upgrade**.
-4. In the pop-up window, select **Standard user management** and check the 30-day commitment box.
+4. In the pop-up window, select **Advanced user management** and check the 30-day commitment box.
 5. Click **Upgrade**.
 
 After the add-on is added to your organization,

--- a/sites/upsun/src/administration/billing/add-on-subscription.md
+++ b/sites/upsun/src/administration/billing/add-on-subscription.md
@@ -21,6 +21,12 @@ The Advanced User Management add-on gives you access to the following features:
 - [MFA enforcement](/administration/mfa.md)
 - [Single sign-on (Google)](#single-sign-on-google)
 
+{{% note theme="info" %}}
+
+Note that the minimum commitment for this add-on is **30 days** before any changes can be made.
+
+{{% /note %}}
+
 ### Upgrade to the Advanced User Management add-on
 
 To upgrade to the Advanced User Management add-on, follow these steps:

--- a/sites/upsun/src/administration/mfa.md
+++ b/sites/upsun/src/administration/mfa.md
@@ -37,7 +37,7 @@ To enable MFA on your user account, follow these steps:
 
 {{< note theme="info" title="Feature availability and permissions">}}
 
-This feature is available as part of the Standard User Management add-on.
+This feature is available as part of the Advanced User Management add-on.
 To add it to your organization, [administer your organization's billing](/administration/billing/billing-admin.md).
 
 Only **organization owners** and **admin users** can enable MFA within an organization.

--- a/sites/upsun/src/administration/users.md
+++ b/sites/upsun/src/administration/users.md
@@ -10,9 +10,9 @@ When a user is added to a project, they are automatically added to your organiza
 
 {{< note title="Available add-on" >}}
 
-The Standard User Management add-on offers free viewer permissions, custom [organization permissions](#organization-permissions),
+The Advanced User Management add-on offers free viewer permissions, custom [organization permissions](#organization-permissions),
 [teams](/administration/teams.md), and [MFA enforcement within an organization](/administration/mfa.md).
-See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#standard-user-management-add-on).
+See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
 
 {{< /note >}}
 

--- a/sites/upsun/src/administration/users.md
+++ b/sites/upsun/src/administration/users.md
@@ -10,9 +10,7 @@ When a user is added to a project, they are automatically added to your organiza
 
 {{< note title="Available add-on" >}}
 
-The Advanced User Management add-on offers free viewer permissions, custom [organization permissions](#organization-permissions),
-[teams](/administration/teams.md), and [MFA enforcement within an organization](/administration/mfa.md).
-See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
+The Advanced User Management add-on offers [teams](/administration/teams.md),[MFA enforcement within an organization](/administration/mfa.md) and [Single sign-on (Google)](/adminstration/billing/add-on-subscription.md#single-sign-on-google). See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
 
 {{< /note >}}
 

--- a/sites/upsun/src/administration/users.md
+++ b/sites/upsun/src/administration/users.md
@@ -10,7 +10,7 @@ When a user is added to a project, they are automatically added to your organiza
 
 {{< note title="Available add-on" >}}
 
-The Advanced User Management add-on offers [teams](/administration/teams.md),[MFA enforcement within an organization](/administration/mfa.md) and [Single sign-on (Google)](/adminstration/billing/add-on-subscription.md#single-sign-on-google). See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
+The Advanced User Management add-on offers [teams](/administration/teams.md), [MFA enforcement within an organization](/administration/mfa.md) and [Single sign-on (Google)](/adminstration/billing/add-on-subscription.md#single-sign-on-google). See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
 
 {{< /note >}}
 

--- a/sites/upsun/src/administration/users.md
+++ b/sites/upsun/src/administration/users.md
@@ -10,7 +10,7 @@ When a user is added to a project, they are automatically added to your organiza
 
 {{< note title="Available add-on" >}}
 
-The Advanced User Management add-on offers [teams](/administration/teams.md), [MFA enforcement within an organization](/administration/mfa.md) and [Single sign-on (Google)](/adminstration/billing/add-on-subscription.md#single-sign-on-google). See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
+The Advanced User Management add-on offers [teams](/administration/teams.md), [MFA enforcement within an organization](/administration/mfa.md) and [Single sign-on (Google)](/administration/billing/add-on-subscription.md#single-sign-on-google). See how to [subscribe to this add-on](/administration/billing/add-on-subscription.md#advanced-user-management-add-on).
 
 {{< /note >}}
 

--- a/themes/psh-docs/layouts/partials/user-mgt-sellable/body.md
+++ b/themes/psh-docs/layouts/partials/user-mgt-sellable/body.md
@@ -1,4 +1,4 @@
-{{ $content := `This feature is available as part of the Standard User Management add-on.
+{{ $content := `This feature is available as part of the Advanced User Management add-on.
 To enable it on your organization, [administer your organization's billing](/administration/billing/billing-admin).`}}
 
 {{ partial "premium-features/banner" ( dict "context" . "content" $content "title" "Feature Availability" )}}


### PR DESCRIPTION
### replaced standard with advanced 

## Why

Closes #4780 

## What's changed

All pages that mention standard user management have been replaced with advanced user management. A redirect may need to be set up for the add-on page. 

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
