### PR TITLE
Update the Mariadb/mysql upgrade path

### DIFF
--- a/sites/platform/src/add-services/mysql/_index.md
+++ b/sites/platform/src/add-services/mysql/_index.md
@@ -69,7 +69,7 @@ See how to [convert tables to the InnoDB engine](#storage-engine).
 ### Upgrade
 
 When upgrading your service, skipping versions may result in data loss.
-Upgrade sequentially from one supported version to another (10.5 -> 10.6 -> 10.11 -> 11.0),
+Upgrade sequentially from one supported version to another (10.6 -> 10.11 -> 11.0 -> 11.4),
 and check that each upgrade commit translates into an actual deployment.
 
 To upgrade, update the service version in your [service configuration](/add-services/_index.md).

--- a/sites/platform/src/add-services/mysql/_index.md
+++ b/sites/platform/src/add-services/mysql/_index.md
@@ -69,7 +69,7 @@ See how to [convert tables to the InnoDB engine](#storage-engine).
 ### Upgrade
 
 When upgrading your service, skipping versions may result in data loss.
-Upgrade sequentially from one supported version to another (10.6 -> 10.11 -> 11.0 -> 11.4),
+Upgrade sequentially from one supported version to another (10.6 -> 10.11 -> 11.4),
 and check that each upgrade commit translates into an actual deployment.
 
 To upgrade, update the service version in your [service configuration](/add-services/_index.md).

--- a/sites/upsun/src/add-services/mysql/_index.md
+++ b/sites/upsun/src/add-services/mysql/_index.md
@@ -37,7 +37,7 @@ When you deploy your app, you always get the latest available patches.
 ### Upgrade
 
 When upgrading your service, skipping versions may result in data loss.
-Upgrade sequentially from one supported version to another (10.6 -> 10.11 -> 11.0 -> 11.4),
+Upgrade sequentially from one supported version to another (10.6 -> 10.11 -> 11.4),
 and check that each upgrade commit translates into an actual deployment.
 
 To upgrade, update the service version in your [service configuration](../_index.md).

--- a/sites/upsun/src/add-services/mysql/_index.md
+++ b/sites/upsun/src/add-services/mysql/_index.md
@@ -37,7 +37,7 @@ When you deploy your app, you always get the latest available patches.
 ### Upgrade
 
 When upgrading your service, skipping versions may result in data loss.
-Upgrade sequentially from one supported version to another (10.5 -> 10.6 -> 10.11 -> 11.0),
+Upgrade sequentially from one supported version to another (10.6 -> 10.11 -> 11.0 -> 11.4),
 and check that each upgrade commit translates into an actual deployment.
 
 To upgrade, update the service version in your [service configuration](../_index.md).


### PR DESCRIPTION
## Why

Based on updates to the supported/deprecated versions, the example migration path must also be updated. 

--------------
Closes #4784 

## What's changed

Edit the upgrade path to include only supported versions

## Where are changes
[Upgrade](https://docs.upsun.com/add-services/mysql.html#upgrade)
[Upgrade](https://docs.platform.sh/add-services/mysql.html#upgrade)

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
