### PR TITLE
Update maxmemory policy descriptions

### DIFF
--- a/sites/platform/src/add-services/valkey.md
+++ b/sites/platform/src/add-services/valkey.md
@@ -481,16 +481,16 @@ services:
 
 The following table presents the possible values:
 
-| Value             | Policy description                                                                                          |
-|-------------------|-------------------------------------------------------------------------------------------------------------|
-| `allkeys-lru`     | Removes the oldest cache items first. This is the default policy when `maxmemory_policy` isn't set.         |
-| `noeviction`      | New items aren’t saved when the memory limit is reached.                                                    |
-| `allkeys-lfu`     | Removes least frequently used cache items first.                                                            |
-| `volatile-lru`    | Removes least recently used cache items with the `expire` field set to `true`.                              |
-| `volatile-lfu`    | Removes least frequently used cache items with the `expire` field set to `true`.                            |
-| `allkeys-random`  | Randomly removes cache items to make room for new data.                                                     |
-| `volatile-random` | Randomly removes cache items with the `expire` field set to `true`.                                         |
-| `volatile-ttl`    | Removes cache items with the `expire` field set to `true` and the shortest remaining `time-to -live` value. |
+| Value             | Policy description                                                                                                                   |
+|-------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `allkeys-lru`     | Keeps most recently used keys; removes least recently used (LRU) keys. This is the default policy when `maxmemory_policy` isn't set. |
+| `noeviction`      | New values aren't saved when memory limit is reached.                                                                                |
+| `allkeys-lfu`     | Keeps frequently used keys; removes least frequently used (LFU) keys                                                                 |
+| `volatile-lru`    | Removes least recently used keys with a time-to-live (TTL) set.                                                                      |
+| `volatile-lfu`    | Removes least frequently used keys with a TTL set.                                                                                   |
+| `allkeys-random`  | Randomly removes keys to make space for the new data added.                                                                          |
+| `volatile-random` | Randomly removes keys with a TTL set.                                                                                                |
+| `volatile-ttl`    | Removes keys with a TTL set, the keys with the shortest remaining time-to-live value first.                                          |
 
 For more information on the different policies,
 see the official [Valkey documentation](https://valkey.io/topics/lru-cache/).


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The valkey (and redis) documentation talks about an expire field being true/false. There is no such thing. I suspect this got mixed up with the Drupal redis module, which stores a such a flag as part of it's cache items.

What valkey/redis does have is a TTL, set with EXPIRE and read with TTL.

## What's changed

Copy paste of the descriptions from the valkey docs which consistently use TTL instead of expire

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
