### PR TITLE
Remove java on dependencies block is not supported

### DIFF
--- a/sites/platform/src/create-apps/app-reference/single-runtime-image.md
+++ b/sites/platform/src/create-apps/app-reference/single-runtime-image.md
@@ -898,7 +898,6 @@ They're installed before the `build` hook runs using a package manager for the l
 | Python 3 | `python3`             | [Pip 3](https://packaging.python.org/tutorials/installing-packages/)                                               |
 | Ruby     | `ruby`                | [Bundler](https://bundler.io/)                                                                                     |
 | Node.js  | `nodejs`              | [npm](https://www.npmjs.com/) (see [how to use yarn](/languages/nodejs/_index.md#use-yarn-as-a-package-manager))   |
-| Java     | `java`                | [Apache Maven](https://maven.apache.org/), [Gradle](https://gradle.org/), or [Apache Ant](https://ant.apache.org/) |
 
 The format for package names and version constraints are defined by the specific package manager.
 

--- a/sites/upsun/src/create-apps/app-reference/single-runtime-image.md
+++ b/sites/upsun/src/create-apps/app-reference/single-runtime-image.md
@@ -1022,7 +1022,6 @@ They're installed before the `build` hook runs using a package manager for the l
 | Python 3 | `python3`             | [Pip 3](https://packaging.python.org/tutorials/installing-packages/)                                               |
 | Ruby     | `ruby`                | [Bundler](https://bundler.io/)                                                                                     |
 | Node.js  | `nodejs`              | [npm](https://www.npmjs.com/) (see [how to use yarn](/languages/nodejs/_index.md#use-yarn-as-a-package-manager))   |
-| Java     | `java`                | [Apache Maven](https://maven.apache.org/), [Gradle](https://gradle.org/), or [Apache Ant](https://ant.apache.org/) |
 
 The format for package names and version constraints are defined by the specific package manager.
 


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

On https://docs.upsun.com/create-apps/app-reference/single-runtime-image.html#dependencies

java is not supported on the denpendencies block:

```
dependencies:
  java:
    maven: "*"
```

this will give:

```
      E: Error building project: Unknown stack: java

    E: Error: Unable to build application, aborting.
```

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Remove java line

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
