### PR TITLE
4806 4807 broken links

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -30,3 +30,5 @@ ignoreerrors=
     ^https://www.baeldung.com/maven-wrapper$ ^403 Forbidden
     ^https://dzone\.com/.*$ ^403 Forbidden
     ^https://docs\.pimcore\.com/.*$ ^403 Forbidden
+    ^https://www\.pixelant\.net/.*$ ^ReadTimeOut
+    ^https://www\.gatsbyjs\.com/.*$ ^ReadTimeOut

--- a/sites/platform/src/add-services/mysql/_index.md
+++ b/sites/platform/src/add-services/mysql/_index.md
@@ -738,7 +738,7 @@ ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_
 For further details, see the [MariaDB documentation](https://mariadb.com/kb/en/character-set-and-collation-overview/).
 
 {{% note theme="info" %}}
-MariaDB configuration properties like [`max_connections`](https://mariadb.com/docs/server/ref/mdb/system-variables/max_connections/) and [`innodb_buffer_pool_size`](https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_size) are not directly configurable from `configuration.properties` in your services configuration.
+MariaDB configuration properties like [`max_connections`](https://mariadb.com/docs/server/server-management/variables-and-modes/server-system-variables#max_connections) and [`innodb_buffer_pool_size`](https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_size) are not directly configurable from `configuration.properties` in your services configuration.
 They can, however, be set indirectly, which can be useful for solving `Too many connection` errors.
 See [the troubleshooting documentation](/add-services/mysql/troubleshoot.md#too-many-connections) for more details.
 {{% /note %}}

--- a/sites/upsun/src/add-services/mysql/_index.md
+++ b/sites/upsun/src/add-services/mysql/_index.md
@@ -728,7 +728,7 @@ ALTER TABLE table_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_
 For further details, see the [MariaDB documentation](https://mariadb.com/kb/en/character-set-and-collation-overview/).
 
 {{% note theme="info" %}}
-MariaDB configuration properties like [`max_connections`](https://mariadb.com/docs/server/ref/mdb/system-variables/max_connections/) and [`innodb_buffer_pool_size`](https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_size) are not directly configurable from `configuration.properties` in your services configuration.
+MariaDB configuration properties like [`max_connections`](https://mariadb.com/docs/server/server-management/variables-and-modes/server-system-variables#max_connections) and [`innodb_buffer_pool_size`](https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_size) are not directly configurable from `configuration.properties` in your services configuration.
 They can, however, be set indirectly, which can be useful for solving `Too many connection` errors.
 See [the troubleshooting documentation](/add-services/mysql/troubleshoot.md#too-many-connections) for more details.
 {{% /note %}}

--- a/sites/upsun/src/add-services/opensearch.md
+++ b/sites/upsun/src/add-services/opensearch.md
@@ -20,8 +20,6 @@ The latest compatible minor version and patches are applied automatically.
 
 {{< image-versions image="opensearch" status="supported" environment="grid" >}}
 
-You can see the latest minor and patch versions of OpenSearch available from the [`2.x`](https://docs.opensearch.org/lines/2x.html) and [`1.x`](https://docs.opensearch.org/lines/1x.html) (1.3) release lines.
-
 ## Deprecated versions
 
 The following versions are still available in your projects,


### PR DESCRIPTION
## Why

Closes #4806 
Closes #4807 

## What's changed

* removes links to opensearch.org/lines/* as those are no longer available on the opensearch site
* adds pixelant.com and gatsby.com to  `ignoreerrors` for ReadTimeOut in linkcheckerrc
* fixes moved mariadb link

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
