### PR TITLE
ignore all ReadTimeout errors in linkchecker

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -30,5 +30,4 @@ ignoreerrors=
     ^https://www.baeldung.com/maven-wrapper$ ^403 Forbidden
     ^https://dzone\.com/.*$ ^403 Forbidden
     ^https://docs\.pimcore\.com/.*$ ^403 Forbidden
-    ^https://www\.pixelant\.net/.*$ ^ReadTimeOut
-    ^https://www\.gatsbyjs\.com/.*$ ^ReadTimeOut
+    ^https:// ^ReadTimeout


### PR DESCRIPTION
## Why

Closes #4812 

## What's changed

Removes the specific `ignoreerrors` entries for individual sites and makes a new entry ignoring the error altogether. I have yet to see a link with a Readtimeout error that wasn't fine when we checked manually. 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
