### PR TITLE
Show an example of the error you get when having a version mismatch

### DIFF
--- a/sites/platform/src/languages/ruby.md
+++ b/sites/platform/src/languages/ruby.md
@@ -354,14 +354,20 @@ For Rails, you have two choices:
 - For garbage collection tuning, you can read [this article](https://shopify.engineering/17489064-tuning-rubys-global-method-cache)
   and look for [discourse configurations](https://github.com/discourse/discourse_docker/blob/b259c8d38e0f42288fd279c9f9efd3cefbc2c1cb/templates/web.template.yml#L8)
 
-- New images are released on a regular basis to apply security patches.
+- New images are released on a regular basis to apply security patches. While the minor version will not change (as you are specifying it in the `type` property), the patch version will be updated. You may encounter this kind of error:
+
+  ```
+  bundler: failed to load command: puma (/app/vendor/bundle/ruby/3.2.0/bin/puma)
+  /app/.global/gems/bundler-2.4.22/lib/bundler/definition.rb:447:in `validate_ruby!': Your Ruby version is 3.2.9, but your Gemfile specified 3.2.8 (Bundler::RubyVersionMismatch)
+  ```
+
   To avoid issues when such updates are performed, use
 
   ``` ruby
   ruby ENV["TARGET_RUBY_VERSION"] || File.read(File.join(File.dirname(__FILE__), ".ruby-version")).strip
   ```
 
-  in your `Gemfile`.
+  in your `Gemfile`, where `TARGET_RUBY_VERSION` has been defined as above.
 
 ## Troubleshooting
 

--- a/sites/upsun/src/languages/ruby.md
+++ b/sites/upsun/src/languages/ruby.md
@@ -398,14 +398,20 @@ For Rails, you can use the standard Rails `config/database.yml` with the values 
 
 - For garbage collection tuning, you can read [this article](https://shopify.engineering/17489064-tuning-rubys-global-method-cache)
   and look for [discourse configurations](https://github.com/discourse/discourse_docker/blob/b259c8d38e0f42288fd279c9f9efd3cefbc2c1cb/templates/web.template.yml#L8)
-- New images are released on a regular basis to apply security patches.
+- New images are released on a regular basis to apply security patches. While the minor version will not change (as you are specifying it in the `type` property), the patch version will be updated. You may encounter this kind of error:
+
+  ```
+  bundler: failed to load command: puma (/app/vendor/bundle/ruby/3.2.0/bin/puma)
+  /app/.global/gems/bundler-2.4.22/lib/bundler/definition.rb:447:in `validate_ruby!': Your Ruby version is 3.2.9, but your Gemfile specified 3.2.8 (Bundler::RubyVersionMismatch)
+  ```
+
   To avoid issues when such updates are performed, use
 
   ``` ruby
   ruby ENV["TARGET_RUBY_VERSION"] || File.read(File.join(File.dirname(__FILE__), ".ruby-version")).strip
   ```
 
-  in your `Gemfile`.
+  in your `Gemfile`, where `TARGET_RUBY_VERSION` has been defined as above.
 
 
 {{< repolist lang="ruby" displayName="Ruby" >}}


### PR DESCRIPTION
This should make it easier to search when someone gets this error in a ruby app, as it's a fairly common one.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
