### PR TITLE
add AI section to How to Deploy

### DIFF
--- a/sites/upsun/src/get-started/stacks/AI/_index.md
+++ b/sites/upsun/src/get-started/stacks/AI/_index.md
@@ -1,0 +1,42 @@
+---
+title: AI with Upsun
+weight: -150
+layout: single
+sectionBefore: Artificial intelligence (AI)
+---
+
+{{% vendor/name %}} provides powerful capabilities for hosting AI applications, agents, and services. You can deploy AI workloads using any supported runtime and integrate with various LLM APIs and services.
+
+{{< note theme="info" >}}
+Before you start, check out the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project) and the main [Getting started guide](/get-started/here/_index.md).
+They provide all the core concepts and common commands you need to know before using the following materials.
+{{< /note >}}
+
+## AI Applications and Services
+
+| Category | Description | Resources |
+|----------|-------------|-----------|
+| **AI Agents** | Host conversational AI agents and chatbots using any supported runtime | [Host AI Agents](aiagent.md) |
+| **MCP Servers** | Deploy Model Context Protocol servers for AI tool integration | [Host MCP Servers](mcp.md) |
+
+## Supported Technologies
+
+- **Runtimes**: Python, Node.js, PHP, Ruby, Go, Java, and [more](/create-apps/app-reference/single-runtime-image.md#types)
+- **LLM APIs**: [OpenAI](https://platform.openai.com/docs), [Anthropic Claude](https://docs.anthropic.com/en/docs/getting-started-with-the-api), [Google Gemini](https://ai.google.dev/docs), [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/), [AWS Bedrock](https://docs.aws.amazon.com/bedrock/), and any other HTTP-based API service
+- **AI Frameworks**: [LangChain](https://python.langchain.com/docs/get_started/introduction), [LlamaIndex](https://docs.llamaindex.ai/), [Chainlit](https://docs.chainlit.io/), and custom implementations
+- **Integration**: REST APIs, WebSockets, and event-driven architectures
+
+{{< note theme="info" title="API Flexibility" >}}
+Upsun supports integration with **any** LLM service that provides an HTTP API. The services listed above are just popular examples. You can integrate with self-hosted models, specialized AI services, or any custom API endpoint that follows standard HTTP protocols.
+{{< /note >}}
+
+## Getting Started
+
+1. **Choose your runtime**: Select the programming language that best fits your AI application needs
+2. **Configure your app**: Set up your application in the `.upsun/config.yaml` file
+3. **Integrate LLM APIs**: Connect to your preferred AI service providers
+4. **Deploy and scale**: Push your code and let Upsun handle the infrastructure
+
+For detailed examples and tutorials, see the [AI and Machine Learning tutorials on DevCenter](https://devcenter.upsun.com/posts/?utm_source=docs&utm_medium=ai-section&utm_campaign=tutorials).
+
+Find out more about the many [languages {{% vendor/name %}} supports](/languages/_index.md).

--- a/sites/upsun/src/get-started/stacks/AI/aiagent.md
+++ b/sites/upsun/src/get-started/stacks/AI/aiagent.md
@@ -1,0 +1,98 @@
+---
+title: Hosting AI Agents
+weight: -40
+---
+
+You can host AI agents on Upsun using any runtime that supports your preferred programming language and integrate with various LLM APIs. Upsun provides container-based deployments that give you control over your application architecture and dependencies.
+
+## AI Agent Runtimes and Languages Supported
+
+Upsun supports multiple runtimes through container-based deployments including Python, Node.js, PHP, Ruby, Go, Java, and more. For the complete list of supported runtimes and their versions, see the [runtime types reference](/create-apps/app-reference/single-runtime-image.md#types).
+
+You configure your runtime in the [`.upsun/config.yaml`](/learn/overview/yaml/yaml-structure.md) file. The platform builds your application in a container with the specified runtime and dependencies.
+
+## LLM API Integration
+
+You can integrate your AI agent with any LLM API that your chosen runtime supports:
+
+- **OpenAI API**: Use the [official OpenAI client libraries](https://platform.openai.com/docs/libraries) for Python, Node.js, and other languages
+- **Anthropic Claude API**: Use the [Anthropic client libraries](https://docs.anthropic.com/en/docs/getting-started-with-the-api) for Python, Node.js, and other languages
+- **Google Gemini**: Use the [Google AI client libraries](https://ai.google.dev/docs) for Python, Node.js, and other languages
+- **Azure OpenAI**: Use the [Azure OpenAI client libraries](https://learn.microsoft.com/en-us/azure/ai-services/openai/) for Python, Node.js, and other languages
+- **AWS Bedrock**: Use the [AWS Bedrock client libraries](https://docs.aws.amazon.com/bedrock/) for Python, Node.js, and other languages
+- **Other providers**: Integrate with any API that provides HTTP endpoints
+
+Your application code handles the API calls and response processing. Upsun doesn't restrict which services you can use.
+
+## Environment Management
+
+Upsun provides isolated environments for development, testing, and production:
+
+- **Branch-based environments**: Each Git branch creates a separate environment
+- **Data isolation**: Each environment has its own services and data
+- **Easy cloning**: Clone production data to development environments for testing
+- **Environment variables**: Store API keys and configuration securely using [variables](/development/variables/_index.md)
+
+## Tutorials
+
+- [**Deploy a RAG-Based Conversational Agent with Chainlit**](https://devcenter.upsun.com/posts/deploying-chainlit-with-rag/): Build a Retrieval-Augmented Generation agent using Chainlit, llama_index, and OpenAI, then deploy it on Upsun.
+- [**Access Documentation Contextually via Context7 + MCP**](https://devcenter.upsun.com/posts/context7-mcp/): Use the Model Context Protocol to let AI assistants fetch your Upsun documentation in real-time.
+- **Use the Upsun API to Automate Agent Deployment**: Automate deployments, environment management, and configuration through the Upsun API. See the [API usage guide](https://devcenter.upsun.com/posts/using-the-upsun-api/).
+
+## Configuration Example
+
+Here's a basic configuration for a Python AI agent. For more configuration options, see the [complete application config reference](/create-apps/app-reference/single-runtime-image.md):
+
+```yaml
+# .upsun/config.yaml
+applications:
+  ai-agent:
+    source:
+      root: "/"
+    type: "python:3.11"
+    mounts:
+      ".data": source: "storage", source_path: "data"
+    web:
+      commands:
+        start: "python agent.py"
+      upstream:
+        socket_family: tcp
+        locations:
+          "/": root: "", passthru: true
+```
+
+## Application Code
+
+For examples of how to implement AI agents with different frameworks and APIs, see the [AI and Machine Learning tutorials on DevCenter](https://devcenter.upsun.com/posts/?utm_source=docs&utm_medium=ai-agent&utm_campaign=tutorials).
+
+## Deploy Your Agent
+
+1. Add your code to Git:
+   ```bash
+   git add .
+   git commit -m "Add AI agent service"
+   ```
+
+2. Set your OpenAI API key as an environment variable using the [CLI](/administration/cli/_index.md):
+   ```bash
+   upsun variable:create env:OPENAI_API_KEY --value=<your_key>
+   ```
+
+   For more information about setting variables, see [how to set variables](/development/variables/set-variables.md).
+
+3. Deploy to Upsun:
+   ```bash
+   upsun push
+   ```
+
+Your agent will be available at your Upsun environment URL. The platform handles the containerization, networking, and scaling automatically. For more deployment options, see [deploy your project](/learn/overview/build-deploy.md).
+
+## Key Benefits
+
+- **Runtime flexibility**: Choose the programming language and version that fits your needs
+- **Service independence**: Use any LLM API or external service
+- **Environment isolation**: Test changes safely in separate environments
+- **Automated deployment**: Deploy through Git pushes or API calls
+- **Scalability**: The platform handles load balancing and resource allocation
+
+For more information about building and deploying applications, see the [configure apps](/create-apps/_index.md) section.

--- a/sites/upsun/src/get-started/stacks/AI/mcp.md
+++ b/sites/upsun/src/get-started/stacks/AI/mcp.md
@@ -1,0 +1,50 @@
+---
+title: Hosting Model Context Protocal (MCP) Servers
+weight: -40
+---
+
+**Model Context Protocol (MCP)** is a standard interface that allows large language models (LLMs) to communicate with external tools and data sources. With MCP, developers and tool providers integrate once and ensure interoperability across any MCP-compatible system.
+
+## Get Started with MCP on Upsun
+
+- **[Build and deploy AI-native applications with MCP servers on Upsun](https://devcenter.upsun.com/posts/tutorials/?utm_source=chatgpt.com)**  
+  Learn how to build and deploy AI-native applications by leveraging MCP servers hosted on Upsun.
+
+## Why Connect LLMs to External Systems?
+
+LLMs typically lack direct access to real-time or system-specific data. To provide current, relevant responses—such as live configuration settings or API data—LLMs need to connect with external systems.
+
+Every service offers a different API, schema, and authentication. Without a standard, managing multiple integrations becomes complex, brittle, and error-prone.
+
+## Standardizing LLM Interactions with MCP
+
+MCP standardizes how LLMs interact with external services. Developers create a single MCP integration point that can interface with any MCP-compatible provider.
+
+Similarly, tool and data providers only need to expose their service via an MCP interface once—making it accessible to any MCP-enabled application.
+
+Think of MCP as the **USB-C of LLM integration**—one interface that works uniformly across devices.
+
+## MCP Hosts, Clients, and Servers
+
+MCP operates on a client–server model:
+
+- **MCP Host**: The AI application environment (e.g., your IDE, ChatGPT-like interface, or AI agent).
+- **MCP Client**: The connection created by the host to talk to a service.
+- **MCP Server**: The external service that exposes an MCP interface.
+
+To connect to multiple external services, a single host needs to manage multiple MCP clients, each connecting to a different MCP server.
+
+## Additional Resources
+
+- **[Deep Dive into MCP’s Interaction Model](https://devcenter.upsun.com/posts/mcp-interaction-types-article/?utm_source=chatgpt.com)**  
+  Explore MCP’s three core interaction types—*prompts* (user-driven), *resources* (application-driven), and *tools* (model-driven)—to design more powerful and flexible AI workflows.
+
+## Summary Table
+
+| Concept         | Upsun Article (Link)                                                                 |
+|-----------------|--------------------------------------------------------------------------------------|
+| Accessing Docs | [Access Upsun documentation via Context7 using MCP](https://devcenter.upsun.com/posts/context7-mcp/?utm_source=chatgpt.com) |
+| Deploying MCP   | [Build and deploy AI-native applications with MCP servers on Upsun](https://devcenter.upsun.com/posts/tutorials/?utm_source=chatgpt.com) |
+| MCP Interaction | [Beyond Tool Calling: Understanding MCP’s Three Core Interaction Types](https://devcenter.upsun.com/posts/mcp-interaction-types-article/?utm_source=chatgpt.com) |
+
+---


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #4841

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Added a section to the the How to Deploy area of docs that give a high level overview of AI with Upsun and hosting Agents and MCP Servers.  Mainly points to articles that G/ has written in the devcenter, links to other docs pages, and stating the obvious. 
<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

## Where are changes
/get-started/stacks/ai.html

Updates are for:

- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
