### PR TITLE
adds retrieval of swagger json/yaml files from gitlab for api docs

### DIFF
--- a/.github/workflows/check-openapi-spec-update.yaml
+++ b/.github/workflows/check-openapi-spec-update.yaml
@@ -39,6 +39,15 @@ jobs:
           curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
             --output shared/pages/api.html \
             "https://lab.plat.farm/api/v4/projects/${PROJECT_ENCODED}/repository/files/$(python3 -c "import urllib.parse; print(urllib.parse.quote('web/redoc-static.html',safe=''))")/raw?ref=${REF}"
+          # @todo let's refactor this to be more concise. maybe just retrieve everything in the directory?
+          curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            --output shared/pages/openapispec-platformsh.json \
+            "https://lab.plat.farm/api/v4/projects/${PROJECT_ENCODED}/repository/files/$(python3 -c "import urllib.parse; print(urllib.parse.quote('web/openapispec-platformsh.json',safe=''))")/raw?ref=${REF}"
+          # @todo see above
+          curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            --output shared/pages/openapispec-platformsh.yaml \
+            "https://lab.plat.farm/api/v4/projects/${PROJECT_ENCODED}/repository/files/$(python3 -c "import urllib.parse; print(urllib.parse.quote('web/openapispec-platformsh.yaml',safe=''))")/raw?ref=${REF}"
+
 
       - name: Create Pull Request if changes
         uses: peter-evans/create-pull-request@v6

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -28,7 +28,7 @@
           # @todo once api docs are fully moved we can alter the template.hbs file so style.css can be in /api
           mkdir -p "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles"
           if [ -f "${PLATFORM_APP_DIR}/shared/pages/api.html" ]; then
-            cp "${PLATFORM_APP_DIR}/shared/pages/api.html" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
+            cp -a "${PLATFORM_APP_DIR}/shared/pages/." "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/"
             cp "${PLATFORM_APP_DIR}/shared/pages/api-style.css" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles/style.css"
           else
             echo "<p>Currently under maintenance. Please check back later.</p>" >> "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
@@ -114,7 +114,7 @@
           # @todo once api docs are fully moved we can alter the template.hbs file so style.css can be in /api
           mkdir -p "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles"
           if [ -f "${PLATFORM_APP_DIR}/shared/pages/api.html" ]; then
-            cp "${PLATFORM_APP_DIR}/shared/pages/api.html" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"
+            cp -a "${PLATFORM_APP_DIR}/shared/pages/." "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/"
             cp "${PLATFORM_APP_DIR}/shared/pages/api-style.css" "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/styles/style.css"
           else
             echo "<p>Currently under maintenance. Please check back later.</p>" >> "${PLATFORM_APP_DIR}/${SITE_DIR}/public/api/index.html"


### PR DESCRIPTION
## Why

Closes #4843 

## What's changed

- adds retrieval of swagger json/yaml files from gitlab in the workflow
- adds copying those files into the public api directory in each site's build hook

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
