### PR TITLE
adds pagination support for retrieving rules from redirection.io's api

### DIFF
--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -89,11 +89,31 @@ const verify = async () => {
 
     const redirectionrules = async ()=>{
       try {
-        return await redirectionInstance.get(`/rules?projectId=${redirectionProjectID}`  )
-          .then(response => {
-            //core.debug(response.data)
-            return response.data
-          })
+        let allRules = []
+        let searchAfter = null
+        let hasMoreResults = true
+
+        while (hasMoreResults) {
+          let url = `/rules?projectId=${redirectionProjectID}`
+          if (searchAfter) {
+            url += `&searchAfterId=${searchAfter}`
+          }
+
+          const response = await redirectionInstance.get(url)
+          const rules = response.data
+
+          if (rules && rules.length > 0 ) {
+            allRules = allRules.concat(rules)
+            // get the last rule id for the next page of results
+            searchAfter = rules[rules.length - 1].id
+          } else {
+            // no more results
+            hasMoreResults = false
+          }
+        }
+        core.debug(`Total rules retrieved: ${allRules.length} rules`)
+        return allRules
+
       } catch (error) {
         core.setFailed(`Action failed calling redirection Api with error ${error}`)
       }

--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -175,7 +175,7 @@ const verify = async () => {
         core.summary.write()
         core.setFailed('There was an error with one or more contracted redirects.')
       } else  {
-        core.notice('All contracted redirections are valid.')
+        core.notice(`All contracted redirections are valid. ${anchors.length} rules evaluated.`)
       }
     });
 


### PR DESCRIPTION
redirection.io limits responses to 100 objects in the returned array.  

this change adds support for retrieving all redirection rules so we can test all of them
