### PR TITLE
updates redirection checker action to support markers

### DIFF
--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -129,14 +129,21 @@ const verify = async () => {
       let location = object.actions.find((element) => element.type == 'redirection').location
 
       if (path.includes("@") && object.markers.length > 0) {
-        // we have a marker path. let's use an example path to test
-        let examplePaths = object.examples.filter( example => example.url.startsWith('/') )
-        if (examplePaths.length > 0 && examplePaths[0]) {
-          path = examplePaths[0].url
+        // make sure we have some examples
+        if (object.examples && Array.isArray(object.examples)) {
+          // we have a marker path. let's use an example path to test
+          let examplePaths = object.examples.filter( example => example.url.startsWith('/') )
+          if (examplePaths.length > 0 && examplePaths[0]) {
+            path = examplePaths[0].url
+          } else {
+            core.error(`path ${path} appears to contain a marker, but I was unable to find a valid example to use.`)
+            path = "/"
+          }
         } else {
-          core.error(`path ${path} appears to contain a marker, but I was unable to find a valid example to use.`)
+          core.error(`path ${path} appears to contain a marker, but the rule does not contain any examples. This needs to be fixed.`)
           path = "/"
         }
+
       }
 
       core.debug(`I'm going to test ${path} to see if it goes to ${location}`)

--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -129,6 +129,7 @@ const verify = async () => {
       let location = object.actions.find((element) => element.type == 'redirection').location
 
       if (path.includes("@") && object.markers.length > 0) {
+        core.notice(`${path} contains a marker. We will need to switch to an example path for testing.`)
         // make sure we have some examples
         if (object.examples && Array.isArray(object.examples)) {
           // we have a marker path. let's use an example path to test

--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -128,6 +128,17 @@ const verify = async () => {
       let path = object.trigger.source
       let location = object.actions.find((element) => element.type == 'redirection').location
 
+      if (path.includes("@") && object.markers.length > 0) {
+        // we have a marker path. let's use an example path to test
+        let examplePaths = object.examples.filter( example => example.url.startsWith('/') )
+        if (examplePaths.length > 0 && examplePaths[0]) {
+          path = examplePaths[0].url
+        } else {
+          core.error(`path ${path} appears to contain a marker, but I was unable to find a valid example to use.`)
+          path = "/"
+        }
+      }
+
       core.debug(`I'm going to test ${path} to see if it goes to ${location}`)
 
       try {


### PR DESCRIPTION
redirection rules that contain markers appear as `@marker-name` in the `rule.trigger.source` return from the API. Due to this, we can't test those directly using the `source` property. 

This change updates the action to detect this occurrence and swaps out the tested source value with one from the examples array. 
