### PR TITLE
Fixes broken links

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -17,6 +17,7 @@ ignore=
     https://dev.mysql.com/doc/refman/en/
     https://www.microsoft.com/en-us/trust-center/privacy/data-management
     http://localhost:1337/*
+    https://platform.openai.com/docs*
 
 [output]
 warnings=0

--- a/shared/pages/api-style.css
+++ b/shared/pages/api-style.css
@@ -15273,7 +15273,7 @@ a.platform_sh_standalone .badge-dark:focus, a.platform_sh_standalone .badge-dark
 .platform_sh_standalone .btn-animate.aqua:hover span.text {
   color: #FFFFFF; }
 .platform_sh_standalone .btn-animate.aqua:hover span.icon {
-  background-image: url(/images/icons/chevrons/chevrons.svg); }
+  background-image: url(/images/icons/chevrons.svg); }
 .platform_sh_standalone .btn-animate.purple {
   background: #871665; }
 .platform_sh_standalone .btn-animate.purple span.text {
@@ -15286,7 +15286,7 @@ a.platform_sh_standalone .badge-dark:focus, a.platform_sh_standalone .badge-dark
 .platform_sh_standalone .btn-animate.purple:hover span.text {
   color: #FFFFFF; }
 .platform_sh_standalone .btn-animate.purple:hover span.icon {
-  background-image: url(/images/icons/chevrons/chevrons.svg); }
+  background-image: url(/images/icons/chevrons.svg); }
 @media (max-width: 991.98px) {
   .platform_sh_standalone .btn-animate.mobile-block {
     width: 100%;
@@ -15438,7 +15438,7 @@ a.platform_sh_standalone .badge-dark:focus, a.platform_sh_standalone .badge-dark
 .platform_sh_standalone .cta.vertical .btn::before, .platform_sh_standalone .cta.vertical #user-widget .user-widget__log-in::before, .platform_sh_standalone #user-widget .cta.vertical .user-widget__log-in::before, .platform_sh_standalone .cta.vertical #user-widget .user-widget__free-trial::before, .platform_sh_standalone #user-widget .cta.vertical .user-widget__free-trial::before {
   background: #289B3F; }
 .platform_sh_standalone .cta.vertical .btn:hover span.icon, .platform_sh_standalone .cta.vertical #user-widget .user-widget__log-in:hover span.icon, .platform_sh_standalone #user-widget .cta.vertical .user-widget__log-in:hover span.icon, .platform_sh_standalone .cta.vertical #user-widget .user-widget__free-trial:hover span.icon, .platform_sh_standalone #user-widget .cta.vertical .user-widget__free-trial:hover span.icon {
-  background-image: url(/images/icons/chevrons/chevrons.svg); }
+  background-image: url(/images/icons/chevrons.svg); }
 .platform_sh_standalone .cta.vertical .center-behind {
   position: absolute;
   left: 50%;

--- a/sites/upsun/src/add-services/redis.md
+++ b/sites/upsun/src/add-services/redis.md
@@ -858,13 +858,13 @@ The following table presents the possible values:
 | `volatile-ttl`    | Removes cache items with the `expire` field set to `true` and the shortest remaining `time-to -live` value. |
 
 For more information on the different policies,
-see the official [Redis documentation](https://redis.io/docs/reference/eviction/).
+see the official [Redis documentation](https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/).
 
 ## Access your Redis service
 
 After you've [configured your Redis service](#usage-example),
 you can access it using either the {{% vendor/name %}} CLI
-or through the [Redis CLI](https://redis.io/docs/ui/cli/).
+or through the [Redis CLI](https://redis.io/docs/latest/operate/rs/references/cli-utilities/).
 
 ### {{% vendor/name %}} CLI
 


### PR DESCRIPTION
## Why

Closes #4879 
Closes #4880 

## What's changed

- Corrects a few missed icon locations in the api docs stylesheet
- Ignore links to openai.com as the are blocking all requests 
- Fixes broken links to redis docs on the upsun side

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
