### PR TITLE
strapi: remove unnecessary bashism

### DIFF
--- a/sites/upsun/src/get-started/stacks/strapi/add-database.md
+++ b/sites/upsun/src/get-started/stacks/strapi/add-database.md
@@ -142,16 +142,16 @@ export DATABASE_SCHEME="$DB_SCHEME"
 
 # Set secrets needed by Strapi, if they are not set
 # Prefer setting these as project secret variables with {{% vendor/cli %}} variable:create env:SECRET_NAME --sensitive=true
-if [[ -z "$ADMIN_JWT_SECRET" ]]; then
+if [ -z "$ADMIN_JWT_SECRET" ]; then
   export ADMIN_JWT_SECRET="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$JWT_SECRET" ]]; then
+if [ -z "$JWT_SECRET" ]; then
   export JWT_SECRET="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$API_TOKEN_SALT" ]]; then
+if [ -z "$API_TOKEN_SALT" ]; then
     export API_TOKEN_SALT="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$APP_KEYS" ]]; then
+if [ -z "$APP_KEYS" ]; then
     export APP_KEYS="$PLATFORM_PROJECT_ENTROPY"
 fi
 ```
@@ -168,21 +168,21 @@ title=PostgreSQL
 ```bash {location=".environment"}
 # Set secrets needed by Strapi, if they are not set
 # Prefer setting these as project secret variables with {{% vendor/cli %}} variable:create env:SECRET_NAME --sensitive=true
-if [[ -z "$ADMIN_JWT_SECRET" ]]; then
+if [ -z "$ADMIN_JWT_SECRET" ]; then
   export ADMIN_JWT_SECRET="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$JWT_SECRET" ]]; then
+if [ -z "$JWT_SECRET" ]; then
   export JWT_SECRET="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$API_TOKEN_SALT" ]]; then
+if [ -z "$API_TOKEN_SALT" ]; then
     export API_TOKEN_SALT="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$APP_KEYS" ]]; then
+if [ -z "$APP_KEYS" ]; then
     export APP_KEYS="$PLATFORM_PROJECT_ENTROPY"
 fi
 
 # Switch to configure to the production database service _only_ at deploy time.
-if [[ -z "$PLATFORM_ENVIRONMENT" ]]; then
+if [ -z "$PLATFORM_ENVIRONMENT" ]; then
     export DATABASE_CLIENT="postgres"
 fi
 ```
@@ -194,21 +194,21 @@ title=Oracle MySQL
 ```bash {location=".environment"}
 # Set secrets needed by Strapi, if they are not set
 # Prefer setting these as project secret variables with {{% vendor/cli %}} variable:create env:SECRET_NAME --sensitive=true
-if [[ -z "$ADMIN_JWT_SECRET" ]]; then
+if [ -z "$ADMIN_JWT_SECRET" ]; then
   export ADMIN_JWT_SECRET="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$JWT_SECRET" ]]; then
+if [ -z "$JWT_SECRET" ]; then
   export JWT_SECRET="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$API_TOKEN_SALT" ]]; then
+if [ -z "$API_TOKEN_SALT" ]; then
     export API_TOKEN_SALT="$PLATFORM_PROJECT_ENTROPY"
 fi
-if [[ -z "$APP_KEYS" ]]; then
+if [ -z "$APP_KEYS" ]; then
     export APP_KEYS="$PLATFORM_PROJECT_ENTROPY"
 fi
 
 # Switch to configure to the production database service _only_ at deploy time.
-if [[ -z "$PLATFORM_ENVIRONMENT" ]]; then
+if [ -z "$PLATFORM_ENVIRONMENT" ]; then
     export DATABASE_CLIENT="mysql"
 fi
 ```


### PR DESCRIPTION
They don't work in our deploy hooks, so if they're part of the .environment file, they need to be compatible with dash.

Here is a copy paste from a local session where I validated this:

```
ralt@taz:~$ if [[ -z "$FOO" ]]; then echo 1; fi
1
ralt@taz:~$ dash
$ if [[ -z "$FOO" ]]; then echo 1; fi
dash: 1: [[: not found
$ if [ -z "$foo" ]; then echo 1; fi
1
$ export foo=1
$ if [ -z "$foo" ]; then echo 1; fi
$
```

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
