### PR TITLE
Nix channels: add context

### DIFF
--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -107,8 +107,15 @@ If you use PHP, note that PHP-FPM is only started automatically if PHP is define
 
 ### Supported Nix channels
 
-- `24.05`
+A Nix channel represents a curated, tested snapshot of the Nixpkgs repository, which contains a collection of Nix expressions (code for building packages and configuring systems). 
+
+Using the latest stable Nix channel ensures that you get stable, verified packages (not all `git` commits are heavily tested before being merged into the `master` branch). 
+
+Upsun typically supports only the most recent channel, but sometimes support for a previous channel is extended. 
+
+The following channels are supported: 
 - `25.05`
+- `24.05`
 
 ### Configure Nix channels
 

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -128,8 +128,15 @@ If you use PHP, note that PHP-FPM is only started automatically if PHP is define
 
 ### Supported Nix channels
 
-- `24.05`
+A Nix channel represents a curated, tested snapshot of the Nixpkgs repository, which contains a collection of Nix expressions (code for building packages and configuring systems). 
+
+Using the latest stable Nix channel ensures that you get stable, verified packages (not all `git` commits are heavily tested before being merged into the `master` branch). 
+
+Upsun typically supports only the most recent channel, but sometimes support for a previous channel is extended. 
+
+The following channels are supported: 
 - `25.05`
+- `24.05`
 
 ### Configure Nix channels
 


### PR DESCRIPTION
## Why

Closes #4762.

## What's changed
Added some text to explain Nix channels and their support.


## Where are changes
/create-apps/app-reference/composable-image.html#supported-nix-channels

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
