### PR TITLE
Remove "MRI" in Ruby doc

### DIFF
--- a/sites/platform/src/languages/ruby.md
+++ b/sites/platform/src/languages/ruby.md
@@ -14,7 +14,7 @@ You can select the major and minor version.
 
 Patch versions are applied periodically for bug fixes and the like. When you deploy your app, you always get the latest available patches.
 
-### Ruby MRI
+### Ruby
 
 <table>
     <thead>

--- a/sites/upsun/src/languages/ruby.md
+++ b/sites/upsun/src/languages/ruby.md
@@ -15,7 +15,7 @@ You can select the major and minor version.
 Patch versions are applied periodically for bug fixes and the like.
 When you deploy your app, you always get the latest available patches.
 
-### Ruby MRI
+### Ruby
 
 {{< image-versions image="ruby" status="supported" environment="grid" >}}
 


### PR DESCRIPTION
It's just Ruby, even if MRI is part of the internals