### PR TITLE
update URL for certificate checker tool

### DIFF
--- a/sites/upsun/src/domains/troubleshoot.md
+++ b/sites/upsun/src/domains/troubleshoot.md
@@ -36,7 +36,7 @@ If it isn't, try the following steps:
 ## Verify SSL/TLS encryption
 
 To find out where your domain is pointing to,
-you can use [the certificate checker tool](https://certcheck.upsun.con/).
+you can use [the certificate checker tool](https://certcheck.upsun.com/).
 This tool provides guidance on certificates,
 including when you use a [CDN](/domains/cdn/_index.md).
 Check both the apex and the `www` domains to ensure they both point to your project.


### PR DESCRIPTION
https://github.com/platformsh/platformsh-docs/issues/4935


## Why

Closes #4935

https://github.com/platformsh/platformsh-docs/issues/4935

## What's changed

Updated URL for certificate checker tool, now hosted on Upsun.

## Where are changes

https://docs.upsun.com/domains/troubleshoot.html#verify-ssltls-encryption

Updates are for:

- [ x] upsun (`sites/upsun` templates)
