### PR TITLE
feat: adjusted landing page

### DIFF
--- a/sites/platform/config/_default/config.yaml
+++ b/sites/platform/config/_default/config.yaml
@@ -1,6 +1,6 @@
 # Basics
 # baseURL: /
-title: Upsun Fixed Documentation
+title: Upsun Fixed Docs
 author: Upsun.com
 description: Upsun Fixed User Documentation
 

--- a/sites/platform/src/_index.md
+++ b/sites/platform/src/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Upsun Fixed Docs
 showTitle: false
 editPage: false
 ---

--- a/themes/psh-docs/layouts/shortcodes/home.html
+++ b/themes/psh-docs/layouts/shortcodes/home.html
@@ -12,6 +12,8 @@
         href="/get-started/introduction.html" rel="noopener">Get started</a>
         <a class="info-cta font-semibold text-sm xl:text-base px-4 py-2 bg-skye rounded text-white hover:bg-skye-dark focus:bg-skye-dark"
         href="/learn/overview.html" rel="noopener">What is {{ .Site.Params.vendor.name }}?</a>
+        <a class="fixed-flex font-semibold text-sm xl:text-base px-4 py-2 bg-skye rounded text-white hover:bg-skye-dark focus:bg-skye-dark"
+        href="/administration/organizations.html#fixed-and-flex-organizations" rel="noopener">Fixed vs Flex</a>
     </div>
 
 
@@ -68,6 +70,22 @@
     }
     .info-cta:hover {
         background: #191C1E !important;
+        color: white !important;
+    }
+    .fixed-flex {
+        color: white !important;
+        text-decoration: none !important;
+        font-size: 16px !important;
+        font-weight: 700 !important;
+        letter-spacing: 0.48px !important;
+        background: #A190FF !important;
+        padding: 10px 16px !important;
+        border-radius: 80px !important;
+        display: inline-block !important;
+
+    }
+    .fixed-flex:hover {
+        background: #806BFF !important;
         color: white !important;
     }
 


### PR DESCRIPTION
Added fixed flex button to upsun landing page and adjusted docs landing page name on upsun fixed site - changed documentation to docs

## Why

Closes #4952 

## What's changed

Added fixed flex button to upsun landing page and adjusted docs landing page name on upsun fixed site - changed documentation to docs

## Where are changes

Both landing pages.

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
