### PR TITLE
Remove 24.05 from list of supported channels

### DIFF
--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -111,11 +111,10 @@ A Nix channel represents a curated, tested snapshot of the Nixpkgs repository, w
 
 Using the latest stable Nix channel ensures that you get stable, verified packages (not all `git` commits are heavily tested before being merged into the `master` branch).
 
-Upsun typically supports only the most recent channel, but sometimes support for a previous channel is extended.
+<!-- Uncomment if later we support multiple channels: Upsun typically supports only the most recent channel, but sometimes support for a previous channel is extended. 
+The following channels are supported: -->
+At this time, channel `25.05` is supported.
 
-The following channels are supported:
-- `25.05`
-- `24.05`
 
 ### Configure Nix channels
 

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -132,11 +132,9 @@ A Nix channel represents a curated, tested snapshot of the Nixpkgs repository, w
 
 Using the latest stable Nix channel ensures that you get stable, verified packages (not all `git` commits are heavily tested before being merged into the `master` branch).
 
-Upsun typically supports only the most recent channel, but sometimes support for a previous channel is extended.
-
-The following channels are supported:
-- `25.05`
-- `24.05`
+<!-- Uncomment if later we support multiple channels: Upsun typically supports only the most recent channel, but sometimes support for a previous channel is extended. 
+The following channels are supported: -->
+At this time, channel `25.05` is supported.
 
 ### Configure Nix channels
 


### PR DESCRIPTION

## Why

Closes #4996


## What's changed

Removed channel 24.05 from the list of supported Nix channels.

## Where are changes

https://fixed.docs.upsun.com/create-apps/app-reference/composable-image.html
https://docs.upsun.com/create-apps/app-reference/composable-image.html


Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
