### PR TITLE
domains.tls: fix a minor error

### DIFF
--- a/sites/platform/src/domains/steps/tls.md
+++ b/sites/platform/src/domains/steps/tls.md
@@ -23,8 +23,7 @@ To avoid switching to a default certificate,
 make sure you replace your custom certificate with an updated one
 more than seven days before its expiration date.
 
-Note that custom certificates aren't necessary for preview environments.
-Wildcard certificates that cover all `*.upsun.com` domains, including preview environments, are automatically provided.
+Note that custom certificates aren't necessary for preview environments as we provision Let's Encrypt certificates by default for them.
 
 ### Add a custom certificate
 

--- a/sites/upsun/src/domains/steps/tls.md
+++ b/sites/upsun/src/domains/steps/tls.md
@@ -23,8 +23,7 @@ To avoid switching to a default certificate,
 make sure you replace your custom certificate with an updated one
 more than seven days before its expiration date.
 
-Note that custom certificates aren't necessary for preview environments.
-Wildcard certificates that cover all `*.platform.sh` domains, including preview environments, are automatically provided.
+Note that custom certificates aren't necessary for preview environments as we provision Let's Encrypt certificates by default for them.
 
 ### Add a custom certificate
 


### PR DESCRIPTION

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->
The wildcard certificate that we use is for another domain (`*.<region>.platformsh.site), but either way, we provision individual LE certificates for each preview environment anyway.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
