### PR TITLE
feat: adjusted note in page

### DIFF
--- a/sites/platform/src/learn/overview/build-deploy.md
+++ b/sites/platform/src/learn/overview/build-deploy.md
@@ -111,7 +111,7 @@ When manual deployment is enabled in an environment, the following actions are q
 
 {{< note theme="info" >}}
 
-Note that development environments **always** use automatic deployment, while manual deployment is only available for staging and production environments.
+Manual deployment is available for **development**, **staging** and **production** environments. 
 
 {{< /note >}}
 

--- a/sites/platform/src/learn/overview/build-deploy.md
+++ b/sites/platform/src/learn/overview/build-deploy.md
@@ -87,7 +87,7 @@ After the deploy process is over, any commands in your `post_deploy` hook are ru
 
 ## Deployment types
 
-{{% vendor/name %}} supports two deployment types - automatic and manual. These types help to provide control over when changes are applied to staging and production environments.
+{{% vendor/name %}} supports two deployment types - automatic and manual. These types help to provide control over when changes are applied to development, staging and production environments.
 
 ### Automatic deployment (default)
 
@@ -118,7 +118,7 @@ Manual deployment is available for **development**, **staging** and **production
 
 ### Change deployment type
 
-You can adjust deployment behavior in your environment (staging or production only). 
+You can adjust deployment behavior in your environment. 
 
 {{< codetabs >}}
 

--- a/sites/upsun/src/learn/overview/build-deploy.md
+++ b/sites/upsun/src/learn/overview/build-deploy.md
@@ -111,7 +111,7 @@ When manual deployment is enabled in an environment, the following actions are q
 
 {{< note theme="info" >}}
 
-Note that development environments **always** use automatic deployment, while manual deployment is only available for staging and production environments.
+Manual deployment is available for **development**, **staging** and **production** environments. 
 
 {{< /note >}}
 

--- a/sites/upsun/src/learn/overview/build-deploy.md
+++ b/sites/upsun/src/learn/overview/build-deploy.md
@@ -87,7 +87,7 @@ After the deploy process is over, any commands in your `post_deploy` hook are ru
 
 ## Deployment types
 
-{{% vendor/name %}} supports two deployment types - automatic and manual. These types help to provide control over when changes are applied to staging and production environments.
+{{% vendor/name %}} supports two deployment types - automatic and manual. These types help to provide control over when changes are applied to development, staging and production environments.
 
 ### Automatic deployment (default)
 
@@ -118,7 +118,7 @@ Manual deployment is available for **development**, **staging** and **production
 
 ### Change deployment type
 
-You can adjust deployment behavior in your environment (staging or production only). 
+You can adjust deployment behavior in your environment. 
 
 {{< codetabs >}}
 


### PR DESCRIPTION
adjusted note on page to reflect that manual deployment is available in development environments too.

## Why

Closes #5010 

## What's changed

adjusted note on page to reflect that manual deployment is available in development environments too.

## Where are changes

/learn/overview/build-deploy.html#manual-deployment

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
