### PR TITLE
Network Storage version updates

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -632,10 +632,10 @@
     "type": "network-storage",
     "versions": {
       "deprecated": [
-        "1.0"
+        "2.0"
       ],
       "supported": [
-        "2.0"
+        "1.0"
       ]
     },
     "versions-dedicated-gen-3": {


### PR DESCRIPTION

## Why

Closes #5016 

## What's changed

v1.0 is the supported version; v2.0 is deprecated.

## Where are changes

https://docs.upsun.com/add-services/network-storage.html
https://fixed.docs.upsun.com/add-services/network-storage.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
