### PR TITLE
feat: New replica-admin permission

### DIFF
--- a/sites/platform/src/add-services/mysql/_index.md
+++ b/sites/platform/src/add-services/mysql/_index.md
@@ -459,7 +459,7 @@ For each endpoint you add, you can define the following properties:
 | `default_schema` | `string`                 |          | Which of the defined schemas to default to. If not specified, the `path` property of the relationship is `null` and so tools such as the {{< vendor/name >}} CLI can't access the relationship. |
 | `privileges`     | A permissions dictionary |          | For each of the defined schemas, what permissions the given endpoint has. |
 
-Possible permissions:
+Available permissions:
 
 | Name        | Type          | Description                                                                                                                                                                                |
 | ----------- | ------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -467,6 +467,7 @@ Possible permissions:
 | Read-write  | `rw`          | In addition to read-only permissions, can also insert, update, delete, manage and execute events, execute routines, create and drop indexes, manage and execute triggers, and lock tables. |
 | Admin       | `admin`       | In addition to read-write permissions, can also create, drop, and alter tables; create views; and create and alter routines.                                                               |
 | Replication | `replication` | For [replicating databases](/add-services/mysql/mysql-replication.md). In addition to read-only permissions, can also lock tables.                                                         |
+| Replication admin | `replication-admin` | For managing replicas across projects; can run statements such as SHOW REPLICA STATUS, CHANGE MASTER TO, START REPLICA, and so on (see this related [DevCenter article](https://devcenter.upsun.com/posts/connect-multiple-projects-applications-or-services-together/)). |
 
 ### Restrict access to database replicas only
 

--- a/sites/upsun/src/add-services/mysql/_index.md
+++ b/sites/upsun/src/add-services/mysql/_index.md
@@ -572,16 +572,17 @@ For each endpoint you add, you can define the following properties:
 | Name             | Type                     | Required | Description |
 | ---------------- | ------------------------ | -------- | ----------- |
 | `default_schema` | `string`                 |          | Which of the defined schemas to default to. If not specified, the `path` property of the relationship is `null` and so tools such as the {{< vendor/name >}} CLI can't access the relationship. |
-| `privileges`     | A permissions dictionary |          | For each of the defined schemas, what permissions the given endpoint has. |
+| `privileges`     | A permissions dictionary |          | For each defined schema, specifies the permissions of the endpoint. |
 
-Possible permissions:
+Available permissions:
 
-| Name        | Type          | Description                                         |
-| ----------- | ------------- | --------------------------------------------------- |
-| Read-only   | `ro`          | Can select, create temporary tables, and see views. |
-| Read-write  | `rw`          | In addition to read-only permissions, can also insert, update, delete, manage and execute events, execute routines, create and drop indexes, manage and execute triggers, and lock tables. |
-| Admin       | `admin`       | In addition to read-write permissions, can also create, drop, and alter tables; create views; and create and alter routines. |
-| Replication | `replication` | For [replicating databases](/add-services/mysql/mysql-replication.md). In addition to read-only permissions, can also lock tables. |
+| Name              | Type                | Description                                         |
+| ----------------- | ------------------- | --------------------------------------------------- |
+| Read-only         | `ro`                | Can select, create temporary tables, and see views. |
+| Read-write        | `rw`                | In addition to read-only permissions, can also insert, update, delete, manage and execute events, execute routines, create and drop indexes, manage and execute triggers, and lock tables.        |
+| Admin             | `admin`             | In addition to read-write permissions, can also create, drop, and alter tables; create views; and create and alter routines. |
+| Replication       | `replication`       | For [replicating databases](/add-services/mysql/mysql-replication.md). In addition to read-only permissions, can also lock tables. |
+| Replication admin | `replication-admin` | For managing replicas across projects; can run statements such as SHOW REPLICA STATUS, CHANGE MASTER TO, START REPLICA, and so on (see this related [DevCenter article](https://devcenter.upsun.com/posts/connect-multiple-projects-applications-or-services-together/)). |
 
 ## Multiple databases
 


### PR DESCRIPTION

## Why

Closes #5029 

## What's changed

New replica-admin privilege for managing cross-project db replicas.

## Where are changes
https://fixed.docs.upsun.com/add-services/mysql.html#define-permissions
https://docs.upsun.com/add-services/mysql.html#define-permissions


Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
