### PR TITLE
5034 5035 broken links link checker

### DIFF
--- a/.github/actions/redirection-verification/index.js
+++ b/.github/actions/redirection-verification/index.js
@@ -210,7 +210,7 @@ const verify = async () => {
 
         // now finally check for fragments
         if (response && pshVerification && location.includes("#")) {
-          core.notice(`Fragment destination detected. Verifying element still exists at ${location}.`)
+          core.debug(`Fragment destination detected. Verifying element still exists at ${location}.`)
           fragmentVerification = await validateFragment(location)
           if(!fragmentVerification) {
             core.debug(`Error when verifying fragment destination for ${location} exists in PR environment!`)

--- a/.github/workflows/scheduled-check-links.yaml
+++ b/.github/workflows/scheduled-check-links.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           # default URLs we want to check
           # todo: replace this with a vars.VAL ?
-          urls="[\"https://docs.platform.sh\",\"https://docs.upsun.com\"]"
+          urls="[\"https://fixed.docs.upsun.com\",\"https://docs.upsun.com\"]"
           if [ "workflow_dispatch" = "${{ github.event_name }}" ]; then
             # make sure there's no extra spaces in what we were given
             inputURL=$(echo "${{ inputs.url }}" | xargs)

--- a/sites/upsun/src/create-apps/web/custom-headers.md
+++ b/sites/upsun/src/create-apps/web/custom-headers.md
@@ -132,6 +132,6 @@ unless you enable [HTTP Strict Transport Security (HSTS)](https://docs.platform.
 in your [routes configuration](../../define-routes/_index.md).
 
 Note that once HSTS is enabled, configuration capabilities depend
-on the [HSTS properties](https://fixed.upsun.docs/define-routes/https.html#enable-http-strict-transport-security-hsts)
+on the [HSTS properties](/define-routes/https.html#enable-http-strict-transport-security-hsts)
 set in your routes configuration.
 For example, the `max-age` value is set to `31536000` by {{% vendor/name %}} and can't be customized.

--- a/sites/upsun/src/get-started/stacks/drupal.md
+++ b/sites/upsun/src/get-started/stacks/drupal.md
@@ -142,7 +142,7 @@ routes:
         to: "https://{default}/"
 ```
 
-This configuration is similar to the deployment process for [Drupal on Upsun Fixed](https://fixed.docs.upsun.com/guides/drupal/deploy.html), however it is slightly updated for [Upsun's configuration](https://docs.upsun.com/learn/tutorials/migrating/from-psh.html).
+This configuration is similar to the deployment process for [Drupal on Upsun Fixed](https://fixed.docs.upsun.com/guides/drupal/deploy.html), however it is slightly updated for [Upsun's configuration](https://docs.upsun.com/learn/tutorials/migrating/from-fixed.html).
 ## Variables
 
 The `project:init` command created a `.environment` file containing environment variables for the two services (MariaDB and Redis). Now append the following Drush configuration to the bottom of that file:


### PR DESCRIPTION
## Why

Closes #5034 
Closes #5035 

## What's changed

- Fixes identified broken links in #5034 
- Updates link checker workflow to scan fixed.docs.upsun.com instead of docs.platform.sh
- Changes `notice` to `debug` in redirection check action for redirections where the destination is a fragment  

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
