### PR TITLE
fixes broken link in mongodb

### DIFF
--- a/sites/platform/src/add-services/mongodb.md
+++ b/sites/platform/src/add-services/mongodb.md
@@ -30,7 +30,7 @@ Patch versions are applied periodically for bug fixes and the like. When you dep
 {{% note title="Premium Service" theme="info" %}}
 MongoDB Enterprise isn’t included in any {{< vendor/name >}} plan.
 You need to add it separately at an additional cost.
-To add MongoDB Enterprise, [contact Sales](https://https://upsun.com/contact-us/).
+To add MongoDB Enterprise, [contact Sales](https://upsun.com/contact-us/).
 {{% /note %}}
 
 <table>


### PR DESCRIPTION
## Why

Closes #5065

## What's changed

fixes broken link in mongodb service page

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
