### PR TITLE
Remove mention of the undocumented usage of unstable Nix channel

### DIFF
--- a/sites/platform/src/create-apps/app-reference/_index.md
+++ b/sites/platform/src/create-apps/app-reference/_index.md
@@ -24,7 +24,7 @@ You can add as many packages to your application container as you need.
 {{% note %}}
 
 {{% vendor/name %}} guarantees optimal user experience with the specific [set of packages](/create-apps/app-reference/composable-image.md#supported-nix-packages) it supports.
-You can use any other package available from the [Nix Packages collection](https://search.nixos.org/), including unstable ones,
+You can use any other package available from the [Nix Packages collection](https://search.nixos.org/),
 but NixOs is responsible for their support.
 
 {{% /note %}}

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -132,9 +132,7 @@ type: "composable:{{% latest composable %}}"
 
 {{% note %}}
 The Nix packages listed in the following table are officially supported by {{% vendor/name %}} to provide optimal user experience.</br>
-However, you can add any other packages from [the Nixpkgs collection](https://search.nixos.org/) to your `stack`.
-This includes packages from the ``unstable`` channel,
-like [FrankenPHP](https://search.nixos.org/packages?channel=unstable&show=frankenphp&from=0&size=50&sort=relevance&type=packages&query=frankenphp).</br>
+However, you can add any other packages from [the Nixpkgs collection](https://search.nixos.org/) to your `stack`.</br>
 While available for you to install, packages that aren't listed in the following table are supported by Nix itself, not {{% vendor/name %}}.
 {{% /note %}}
 

--- a/sites/upsun/src/create-apps/app-reference/_index.md
+++ b/sites/upsun/src/create-apps/app-reference/_index.md
@@ -24,7 +24,7 @@ You can add as many packages to your application container as you need.
 {{% note %}}
 
 {{% vendor/name %}} guarantees optimal user experience with the specific [set of packages](/create-apps/app-reference/composable-image.md#supported-nix-packages) it supports.
-You can use any other package available from the [Nix Packages collection](https://search.nixos.org/), including unstable ones,
+You can use any other package available from the [Nix Packages collection](https://search.nixos.org/),
 but NixOs is responsible for their support.
 
 {{% /note %}}

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -153,9 +153,7 @@ type: "composable:{{% latest composable %}}"
 
 {{% note %}}
 The Nix packages listed in the following table are officially supported by {{% vendor/name %}} to provide optimal user experience.</br>
-However, you can add any other packages from [the Nixpkgs collection](https://search.nixos.org/) to your `stack`.
-This includes packages from the ``unstable`` channel,
-like [FrankenPHP](https://search.nixos.org/packages?channel=unstable&show=frankenphp&from=0&size=50&sort=relevance&type=packages&query=frankenphp).</br>
+However, you can add any other packages from [the Nixpkgs collection](https://search.nixos.org/) to your `stack`.</br>
 While available for you to install, packages that aren't listed in the following table are supported by Nix itself, not {{% vendor/name %}}.
 {{% /note %}}
 


### PR DESCRIPTION
## Why

The Composable Image docs mention, but don't document, using unstable Nix channel.

It's indeed possible, but:
- we currently don't provide snippets explaining how to do it
- the mechanism currently in place is being refactored

Let redocument everything properly once the new config for Composable Image will be fully rolled out.

## Where are changes

Updates are for:

- [x ] Upsun fixed (`sites/platform` templates)
- [ x] Upsun flex (`sites/upsun` templates)
