### PR TITLE
Deprecate node.js v18 

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -662,6 +662,7 @@
     "type": "nodejs",
     "versions": {
       "deprecated": [
+        "18",
         "16",
         "14",
         "12",
@@ -675,17 +676,16 @@
       "supported": [
         "24",
         "22",
-        "20",
-        "18"
+        "20"
       ]
     },
     "versions-dedicated-gen-2": {
       "supported": [
         "20",
-        "19",
-        "18"
+        "19"
       ],
       "deprecated": [
+        "18",
         "16",
         "14",
         "12",


### PR DESCRIPTION

## Why
Node.js v18 was EOL 30 Apr 2025.

Closes #5106


## What's changed

Updated registry.json, adding v18 to list of deprecated node.js versions

## Where are changes
https://docs.upsun.com/languages/nodejs.html#deprecated-versions
https://fixed.docs.upsun.com/languages/nodejs.html#deprecated-versions

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
