### PR TITLE
reads value for hugo version from application.yaml

### DIFF
--- a/.github/workflows/pr-check-links.yaml
+++ b/.github/workflows/pr-check-links.yaml
@@ -42,7 +42,7 @@ jobs:
             export siteName="docs"
           fi
 
-          hugoVersion=$(  yq '.[] | select(.name == env(siteName)) | .variables.env.HUGOVERSION' .platform/applications.yaml)
+          hugoVersion=$(yq '.[] | select(.name == env(siteName)) | .variables.env.HUGOVERSION' .platform/applications.yaml)
 
           echo "hugov=${hugoVersion}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
reads value for hugo version from application.yaml to ensure we're using the same version everywhere

## Why

Closes #5116 

## What's changed
adds job to pr-check-links workflow to retrieve the Hugo version from the `.platform/application.yaml` file to ensure the hugo versions match 
