### PR TITLE
updates the way we search for labels

### DIFF
--- a/.github/workflows/check-labels.yaml
+++ b/.github/workflows/check-labels.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Verify label exists
         shell: bash
         run: |
-          if [[ "${{ vars.LBL_MRKDWNPROSE }}" != $(gh label list --search "${{ vars.LBL_MRKDWNPROSE }}" --json name -q '.[] | .name') ]]; then
+          if [[ "${{ vars.LBL_MRKDWNPROSE }}" != $(gh label list --json name -q '.[] | select(.name | startswith("${{ vars.LBL_MRKDWNPROSE }}")) | .name') ]]; then
             echo "Label ${{ vars.LBL_MRKDWNPROSE }} doesn't exist so I need to create it."
             gh label create "${{ vars.LBL_MRKDWNPROSE }}"
           else


### PR DESCRIPTION
updates the way we search for the label given the change to the github label's api

## Why

Closes #{ISSUE_NUMBER}

`gh label list --search` is now doing a fuzzy search with no option to disable. This causes non-relevant labels to be returned in the list, breaking the workflow. 

## What's changed
retrieve all labels and use jq to filter for those we want. 


