### PR TITLE
corrects information related to .env files

### DIFF
--- a/sites/platform/src/development/variables/set-variables.md
+++ b/sites/platform/src/development/variables/set-variables.md
@@ -257,11 +257,10 @@ export APP_DATABASE_USER="$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq 
 
 This sets environment variables with names your app needs and the values from `PLATFORM_RELATIONSHIPS`.
 
-## Use `.env` files
+## When to use `.env` files {#use-env-files}
 
-Many applications use a `.env` file in the application root for configuration.
-These are useful for local development to set variables without needing them to be global across the development computer.
+Upsun does not read `.env files`, as conventionally they are not committed to Git. You can use these for local
+development, but they will not be sourced on any Upsun environment. Typically, you can add `.env` to your .gitignore
+file so that its contents can vary for different developers.
+
 Read more about [the use cases for `.env` files](https://upsun.com/blog/what-is-env-file/).
-
-You shouldn't need to use a `.env` file in production.
-Add it to your `.gitignore` file to avoid confusion as its values can vary for each local developer.

--- a/sites/upsun/src/development/variables/set-variables.md
+++ b/sites/upsun/src/development/variables/set-variables.md
@@ -280,11 +280,10 @@ and the values from [`{{% vendor/prefix %}}_RELATIONSHIPS` environment variable]
 
 {{< /codetabs >}}
 
-## Use `.env` files
+## When to use `.env` files {#use-env-files}
 
-Many applications use a `.env` file in the application root for configuration.
-These are useful for local development to set variables without needing them to be global across the development computer.
+Upsun does not read `.env files`, as conventionally they are not committed to Git. You can use these for local
+development, but they will not be sourced on any Upsun environment. Typically, you can add `.env` to your .gitignore
+file so that its contents can vary for different developers.
+
 Read more about [the use cases for `.env` files](https://upsun.com/blog/what-is-env-file/).
-
-You shouldn't need to use a `.env` file in production.
-Add it to your `.gitignore` file to avoid confusion as its values can vary for each local developer.


### PR DESCRIPTION
## Why

The information on .env files was not clear that Upsun does not read/parse their contents and that they are ignored in all environments. AI bots reading the docs then concluded that they _are_ read, but not in production environments. 

## What's changed

Clarified that `.env` files are never read/sourced in any Upsun environment. 

## Where are changes

Updates are for:

- [X] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
