### PR TITLE
Add Ory to accepted terms list

### DIFF
--- a/contributing/styles/config/vocabularies/Platform/accept.txt
+++ b/contributing/styles/config/vocabularies/Platform/accept.txt
@@ -129,6 +129,7 @@ OPcache
 Opigno
 Opsgenie
 optipng
+Ory
 overutilize
 OVHcloud
 Packagist


### PR DESCRIPTION

## Why

Closes #5142



## What's changed

Add "Ory" to the accepted terms list

## Where are changes
/contributing/config/vocabularies/Platform/accept.txt

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
