### PR TITLE
Add syslogs to logs types

### DIFF
--- a/sites/platform/src/increase-observability/logs/access-logs.md
+++ b/sites/platform/src/increase-observability/logs/access-logs.md
@@ -136,7 +136,7 @@ See an example of [uploading logs to Amazon S3](https://gitlab.com/contextualcod
 | `nginx/error` | No             | All nginx startup log messages. Only useful when debugging possible nginx configuration errors. Not currently available using the `{{% vendor/cli %}} log` command. |
 | `php.access`  | No             | A record of all requests to the PHP service. See [PHP access record format](#php-access-record-format). |
 | `post-deploy` | No             | The output of the [`post_deploy` hook](/create-apps/hooks/hooks-comparison.md#post-deploy-hook). Only exists after a `post_deploy` hook has run. |
-| `syslog`      | Yes            | All SSH connection events.         |     
+| `syslog`      | Yes            | General system-wide logs.          |     
 
 #### PHP access record format
 

--- a/sites/upsun/src/increase-observability/logs/access-logs.md
+++ b/sites/upsun/src/increase-observability/logs/access-logs.md
@@ -136,7 +136,7 @@ See an example of [uploading logs to Amazon S3](https://gitlab.com/contextualcod
 | `nginx/error` | No             | All nginx startup log messages. Only useful when debugging possible nginx configuration errors. Not currently available using the `{{% vendor/cli %}} log` command. |
 | `php.access`  | No             | A record of all requests to the PHP service. See [PHP access record format](#php-access-record-format). |
 | `post-deploy` | No             | The output of the [`post_deploy` hook](../../create-apps/hooks/hooks-comparison.md#post-deploy-hook). Only exists after a `post_deploy` hook has run. |
-| `syslog`      | Yes            | All SSH connection events.         |  
+| `syslog`      | Yes            | General system-wide logs.          |  
 
 #### PHP access record format
 


### PR DESCRIPTION

## Why

Closes #4805 

## What's changed
Add syslogs to the list of available container logs. 

## Where are changes
https://docs.platform.sh/increase-observability/logs/access-logs.html#types-of-container-logs
https://docs.upsun.com/increase-observability/logs/access-logs.html#types-of-container-logs

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
