### PR TITLE
Upsun Fixed: Managed Fastly CDN - add link to community post

### DIFF
--- a/sites/platform/src/domains/cdn/managed-fastly.md
+++ b/sites/platform/src/domains/cdn/managed-fastly.md
@@ -93,5 +93,5 @@ typically located at `/mnt/shared/fastly_tokens.txt`.
 
 {{% /note %}}
 
-## Additional resources
-- [Working with {{% vendor/name %}} rate-limiting implementation](https://support.platform.sh/hc/en-us/community/posts/26091087795602-Working-with-platform-sh-rate-limiting-implementation-Fastly) (Upsun Community): Learn how to update a dynamic access control list (ACL) and apply rate limiting. 
+## Dynamic ACL and rate limiting
+For details about updating an access control list (ACL) and applying rate limiting, check out the [Working with {{% vendor/name %}} rate-limiting implementation](https://support.platform.sh/hc/en-us/community/posts/26091087795602-Working-with-platform-sh-rate-limiting-implementation-Fastly) article in the Upsun Community.


### PR DESCRIPTION

## Why

Closes #4704 



## What's changed
New heading "Dynamic ACL and rate limiting", which contains a link to an Upsun Community post. 


## Where are changes
https://docs.platform.sh/domains/cdn/managed-fastly.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
