### PR TITLE
[5219] Updates logic in the shortcode "latest" 

### DIFF
--- a/sites/upsun/src/get-started/stacks/magento.md
+++ b/sites/upsun/src/get-started/stacks/magento.md
@@ -3,14 +3,14 @@ title: Deploy Magento on {{% vendor/name %}}
 sidebarTitle: Magento
 # sectionBefore: PHP
 #layout: single
-weight: -62 
+weight: -62
 description: |
     Complete these steps to successfully deploy Magento on {{% vendor/name %}}.
 ---
 
-Before attempting to deploy Magento on Upsun, you **must complete the [Getting started guide](/get-started/here)**. 
+Before attempting to deploy Magento on Upsun, you **must complete the [Getting started guide](/get-started/here)**.
 
-You can also **check out the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project)** and [Resource configuration guide](https://docs.upsun.com/manage-resources/adjust-resources.html). These provide all of the core concepts and common commands you need to easily follow this Magento guide. 
+You can also **check out the [{{% vendor/name %}} demo app](https://console.upsun.com/projects/create-project)** and [Resource configuration guide](https://docs.upsun.com/manage-resources/adjust-resources.html). These provide all of the core concepts and common commands you need to easily follow this Magento guide.
 
 {{% guides/requirements name="Drupal" %}}
 
@@ -29,7 +29,7 @@ We will be using the [Upsun Magento example project](https://github.com/platform
 - Automatic TLS certificates
 - Composer-based build
 
-The example also features an [Upsun config.yaml](https://github.com/platformsh-templates/magentoCE24/blob/main/.upsun/config.yaml) file. Below is a **shortened example** of the config.yaml file: 
+The example also features an [Upsun config.yaml](https://github.com/platformsh-templates/magentoCE24/blob/main/.upsun/config.yaml) file. Below is a **shortened example** of the config.yaml file:
 
 ```yaml {filename=".upsun/config.yaml"}
 applications:
@@ -74,7 +74,7 @@ Copy and run the following command in command line:
 You will then have to make the following selections:
 
 - Select an organization to create the project under
-- Select a title for your project 
+- Select a title for your project
 - Select a [region to deploy from](https://docs.upsun.com/development/regions.html#regions)
 - Select your default branch
 - Select whether you would like to set your new project as the remote for any existing repositories that have been detected under your organization
@@ -87,29 +87,29 @@ When your project is created, you will be provided with the following details to
 - `Project ID`
 - `Project title`
 - `Project URL`
-- `Git URL` 
+- `Git URL`
 
 ## Configure resources
 
 Copy the Project URL into your browser. You should see your newly created project in the Upsun console. For example, if you had named your Magento project `Mage`, you would see something similar to the screenshot below:
 
-![Your magento project in the Upsun console](/images/guides/magento/mage-console-1.png) 
+![Your magento project in the Upsun console](/images/guides/magento/mage-console-1.png)
 
-You will be prompted to configure your resources. At this stage you can select the CPU, RAM, instances and disk size for your Magento project. 
+You will be prompted to configure your resources. At this stage you can select the CPU, RAM, instances and disk size for your Magento project.
 
-![Configure the resources for your Magento project in the Upsun console](/images/guides/magento/configure-mage-resources.png) 
+![Configure the resources for your Magento project in the Upsun console](/images/guides/magento/configure-mage-resources.png)
 
 ### Recommended configurations
 
 You will see that the `container_profile` for the app container is using the `BALANCED` profile by default. The standard CPU & RAM recommendation for your app container is a minimum of `0.5 CPU, 1088MB RAM`. Please see the table below for all **recommended minimum settings for your app container**:
 
 | CPU & RAM            | Instances  | Disk/storage |
-| ---------------------| ---------- | ------------ | 
+| ---------------------| ---------- | ------------ |
 | `0.5 CPU, 1088MB RAM`| No minimum | `256MB`      |
 
 All other services will be using their [default container profiles](/manage-resources/adjust-resources.html#advanced-container-profiles) and therefore can be set to `0.1 CPU`, so the above values only apply as recommended minimums for your app container.
 
-Once your project is deployed, you may need to [adjust your resources](/manage-resources/adjust-resources.html) and [adjust the container profiles](/manage-resources/adjust-resources.html#adjust-a-container-profile) of your other services. 
+Once your project is deployed, you may need to [adjust your resources](/manage-resources/adjust-resources.html) and [adjust the container profiles](/manage-resources/adjust-resources.html#adjust-a-container-profile) of your other services.
 
 
 {{< note title="Note" theme="info" >}}
@@ -118,11 +118,11 @@ Please note that the deployment after configuring resources may take up to 25 mi
 
 {{< /note >}}
 
-## View your log 
+## View your log
 
 Now that your resources have been configured, you can view a log of how Upsun creates your project. In the recents section, click the three dots to the right of the activity about your `updated resource allocation on Main`.
 
-![Navigate to the log to see your Magento project being created](/images/guides/magento/log-console-1.png) 
+![Navigate to the log to see your Magento project being created](/images/guides/magento/log-console-1.png)
 
 Below is a **shortened example** of what your log would look like:
 
@@ -139,10 +139,10 @@ Below is a **shortened example** of what your log would look like:
    Setting 'indexer' disk to 256MB.
    Setting 'queue' resources to 0.1 CPU, 448MB RAM.
    Setting 'queue' disk to 256MB.
- 
+
  Building application 'app' (runtime type: php:{{% latest "php" %}}, tree: 392d8f3)
    Generating runtime configuration.
-   
+
    Installing build dependencies...
 
     ...
@@ -151,35 +151,35 @@ Below is a **shortened example** of what your log would look like:
      app (type: php:{{% latest "php" %}}, cpu: 0.1, memory: 64, disk: 1024)
      db (type: mariadb:{{% latest "mariadb" %}}, cpu: 0.1, memory: 448, disk: 256)
      cache (type: redis:{{% latest "redis" %}}, cpu: 0.1, memory: 352)
-     session (type: redis-persistent:{{% latest "redis-persistent" %}}, cpu: 0.1, memory: 352, disk: 256)
+     session (type: redis-persistent:{{% latest "redis" %}}, cpu: 0.1, memory: 352, disk: 256)
      indexer (type: opensearch:{{% latest "opensearch" %}}, cpu: 0.1, memory: 448, disk: 256)
      queue (type: rabbitmq:{{% latest "rabbitmq" %}}, cpu: 0.1, memory: 448, disk: 256)
- 
+
    Environment routes
      http://main-bvxea6i-g7baduaayq63y.eu-5.platformsh.site/ redirects to https://main-bvxea6i-g7baduaayq63y.eu-5.platformsh.site/
      http://main-bvxea6i-g7baduaayq63y.eu-5.platformsh.site/static/ redirects to https://main-bvxea6i-g7baduaayq63y.eu-5.platformsh.site/static/
      https://main-bvxea6i-g7baduaayq63y.eu-5.platformsh.site/ is served by application `app`
      https://main-bvxea6i-g7baduaayq63y.eu-5.platformsh.site/static/ is served by application `app`
- 
+
 ```
 
 ## Preview your Magento project
 
 Now that your Magento project has been successfully created, you will see the standard Magento layout when you navigate to your preview link:
 
-![Your magento project in preview mode](/images/guides/magento/preview-mage.png) 
+![Your magento project in preview mode](/images/guides/magento/preview-mage.png)
 
-## Fetch your Magento project locally 
+## Fetch your Magento project locally
 
 First, get your project ID by clicking the three dots in the upper right hand of your console, next to the settings cog wheel. Your project ID will appear in a drop down menu.
 
-![Your project ID in console](/images/guides/magento/project-id-mage-1.png) 
+![Your project ID in console](/images/guides/magento/project-id-mage-1.png)
 
-Copy the following command into your command line. 
+Copy the following command into your command line.
 
 ```upsun get <projectid>```
 
-Make sure to replace `<projectid>` with the Project ID you just copied from console. Once you run the command in command line, you will be asked if you want to set the remote project for any existing repositories to your project. You will also need to specify a directory for your project to be stored in when downloaded. 
+Make sure to replace `<projectid>` with the Project ID you just copied from console. Once you run the command in command line, you will be asked if you want to set the remote project for any existing repositories to your project. You will also need to specify a directory for your project to be stored in when downloaded.
 
 Once your project has successfully downloaded, you will be able to access it locally by navigating to the directory you chose.
 

--- a/themes/psh-docs/layouts/shortcodes/latest.html
+++ b/themes/psh-docs/layouts/shortcodes/latest.html
@@ -1,4 +1,25 @@
 {{- $arg := .Get 0 -}}
 {{- $data := cond (eq $arg "composable") .Site.Data.composable_versions .Site.Data.registry -}}
 {{- $supported := index $data $arg "versions" "supported" -}}
-{{- index $supported 0 -}}
+
+{{- $latest := index $supported 0 -}}
+
+{{- range $supported -}}
+  {{- $current := . -}}
+  {{- $currentParts := split $current "." -}}
+  {{- $latestParts := split $latest "." -}}
+
+  {{- $currentMajor := int (index $currentParts 0) -}}
+  {{- $currentMinor := int (index $currentParts 1) -}}
+  {{- $latestMajor := int (index $latestParts 0) -}}
+  {{- $latestMinor := int (index $latestParts 1) -}}
+
+  {{- if gt $currentMajor $latestMajor -}}
+    {{- $latest = $current -}}
+  {{- else if and (eq $currentMajor $latestMajor) (gt $currentMinor $latestMinor) -}}
+    {{- $latest = $current -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $latest -}}
+


### PR DESCRIPTION
## Why
Closes #5219

## What's changed

- Updates logic in the shortcode "latest" to sort versions by version number to ensure we are returning the "latest" version
- Updates magento page to call latest redis version as we dont have a redis-persistent specific image

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
