### PR TITLE
add grpc to PHP 8.4

### DIFF
--- a/shared/data/php_extensions.yaml
+++ b/shared/data/php_extensions.yaml
@@ -1536,6 +1536,7 @@ grid:
       - gettext
       - gnupg
       - gmp
+      - grpc
       - http
       - iconv
       - igbinary


### PR DESCRIPTION

## Why

Closes #5226 


Add grpc to  8.4 please extensions. 
## Where are changes
https://docs.upsun.com/languages/php/extensions.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
