### PR TITLE
chore: add supported clickhouse 25.8

### DIFF
--- a/sites/upsun/src/add-services/clickhouse.md
+++ b/sites/upsun/src/add-services/clickhouse.md
@@ -19,6 +19,7 @@ For more information, see the [ClickHouse documentation](https://ClickHouse.com/
 
 ## Supported versions
 
+- 25.8
 - 25.3
 - 24.3
 - 23.8
@@ -59,7 +60,7 @@ CLICKHOUSE_HOSTNAME=azertyuiopqsdfghjklm.clickhouse.service._.eu-1.{{< vendor/ur
 CLICKHOUSE_EPOCH=0
 CLICKHOUSE_REL=clickhouse
 CLICKHOUSE_SCHEME=https/http
-CLICKHOUSE_TYPE=clickhouse:25.3
+CLICKHOUSE_TYPE=clickhouse:25.8
 CLICKHOUSE_PUBLIC=false
 ```
 
@@ -91,7 +92,7 @@ The structure of the `PLATFORM_RELATIONSHIPS` environment variable can be obtain
   "epoch": 0,
   "rel": "clickhouse",
   "scheme": "https",
-  "type": "clickhouse:25.3",
+  "type": "clickhouse:25.8",
   "public": false
 }
 ```
@@ -228,7 +229,7 @@ applications:
 services:
   # The name of the service container. Must be unique within a project.
   clickhouse:
-    type: clickhouse:25.3
+    type: clickhouse:25.8
 ```
 
 <--->
@@ -254,7 +255,7 @@ applications:
 services:
   # The name of the service container. Must be unique within a project.
   clickhouse:
-    type: clickhouse:25.3
+    type: clickhouse:25.8
 ```
 
 <--->
@@ -280,7 +281,7 @@ applications:
 services:
   # The name of the service container. Must be unique within a project.
   clickhouse:
-    type: clickhouse:25.3
+    type: clickhouse:25.8
 ```
 
 If you want to change the ``clickhouse`` endpoint to ``clickhouse-http``, you need to use explicit endpoint definition as it defaults to ``clickhouse`` endpoint when using default endpoint (aka. {{% variable "SERVICE_NAME" %}} as relationship definition).
@@ -311,7 +312,7 @@ applications:
         endpoint: importer
 services:
   clickhouse:
-    type: clickhouse:25.3
+    type: clickhouse:25.8
     configuration:
       databases:
         - main


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes [IMG-2624](https://linear.app/platformsh/issue/IMG-2624/update-public-docs) (Linear)

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

- Add clickhouse 25.8 to its list of supported versions.
- Update examples to use the latest version.

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
