### PR TITLE
feat: replaced link

### DIFF
--- a/sites/platform/src/domains/cdn/managed-fastly.md
+++ b/sites/platform/src/domains/cdn/managed-fastly.md
@@ -94,4 +94,4 @@ typically located at `/mnt/shared/fastly_tokens.txt`.
 {{% /note %}}
 
 ## Dynamic ACL and rate limiting
-For details about updating an access control list (ACL) and applying rate limiting, check out the [Working with {{% vendor/name %}} rate-limiting implementation](https://support.platform.sh/hc/en-us/community/posts/26091087795602-Working-with-platform-sh-rate-limiting-implementation-Fastly) article in the Upsun Community.
+For details about updating an access control list (ACL) and applying rate limiting, check out the [Working with {{% vendor/name %}} rate-limiting implementation](https://support.platform.sh/hc/en-us/articles/29528777071890-Upsun-Fastly-Rate-Limiting-How-it-works-how-to-tune-it) article in the Upsun Community.


### PR DESCRIPTION
**Replaced link with updated one**

## Why
Closes #5234 

## What's changed

Link in the page has been updated to a new article from support team.

## Where are changes
In the managed fastly page with the CDN section of the Fixed documentation.

Updates are for:

- [X] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
