### PR TITLE
image-properties folder: update format for topic titles

### DIFF
--- a/sites/platform/src/create-apps/image-properties/access.md
+++ b/sites/platform/src/create-apps/image-properties/access.md
@@ -1,5 +1,5 @@
 ---
-title: "`access`"
+title: "access"
 weight: 4
 description: An access dictionary that defines the access control for roles accessing app environments.
 ---

--- a/sites/platform/src/create-apps/image-properties/additional_hosts.md
+++ b/sites/platform/src/create-apps/image-properties/additional_hosts.md
@@ -1,5 +1,5 @@
 ---
-title: "`additional_hosts`"
+title: "additional_hosts"
 weight: 4
 description: An additional hosts dictionary that maps hostnames to IP addresses.
 ---

--- a/sites/platform/src/create-apps/image-properties/crons.md
+++ b/sites/platform/src/create-apps/image-properties/crons.md
@@ -1,5 +1,5 @@
 ---
-title: "`crons`"
+title: "crons"
 weight: 4
 description: A cron dictionary that defines scheduled tasks for the app.
 ---

--- a/sites/platform/src/create-apps/image-properties/disk.md
+++ b/sites/platform/src/create-apps/image-properties/disk.md
@@ -1,5 +1,5 @@
 ---
-title: "`disk`"
+title: "disk"
 weight: 4
 description: An `integer` (or `null`) that defines the disk space allocated (in MB) to an app.
 ---

--- a/sites/platform/src/create-apps/image-properties/firewall.md
+++ b/sites/platform/src/create-apps/image-properties/firewall.md
@@ -1,5 +1,5 @@
 ---
-title: "`firewall`"
+title: "firewall"
 weight: 4
 description: A firewall dictionary that defines the outbound firewall rules for the application.
 ---

--- a/sites/platform/src/create-apps/image-properties/hooks.md
+++ b/sites/platform/src/create-apps/image-properties/hooks.md
@@ -1,5 +1,5 @@
 ---
-title: "`hooks`"
+title: "hooks"
 weight: 4
 description: A hooks dictionary that defines which commands run at different stages in the build and deploy process.
 keywords:

--- a/sites/platform/src/create-apps/image-properties/mounts.md
+++ b/sites/platform/src/create-apps/image-properties/mounts.md
@@ -1,5 +1,5 @@
 ---
-title: "`mounts`"
+title: "mounts"
 weight: 4
 description: Defines the directories that are writable even after the app is built.
 ---
@@ -149,6 +149,5 @@ applications:
 
 The `service` mount type specifically exists to share data between instances of the same application, whereas `tmp` and `instance` are meant to restrict data to build time and runtime of a single application instance, respectively.
 These allowances are not compatible, and will result in an error if pushed.
-
 
 

--- a/sites/platform/src/create-apps/image-properties/relationships.md
+++ b/sites/platform/src/create-apps/image-properties/relationships.md
@@ -1,5 +1,5 @@
 ---
-title: "`relationships`"
+title: "relationships"
 weight: 4
 description: A dictionary of relationships that defines the connections to other services and apps.
 ---

--- a/sites/platform/src/create-apps/image-properties/size.md
+++ b/sites/platform/src/create-apps/image-properties/size.md
@@ -1,5 +1,5 @@
 ---
-title: "`size`"
+title: "size"
 weight: 4
 description: Defines the amount of resources to dedicate to the app. 
 keywords:

--- a/sites/platform/src/create-apps/image-properties/source.md
+++ b/sites/platform/src/create-apps/image-properties/source.md
@@ -1,5 +1,5 @@
 ---
-title: "`source`"
+title: "source"
 weight: 4
 description: Contains information about the app’s source code and operations that can be run on it.
 ---

--- a/sites/platform/src/create-apps/image-properties/variables.md
+++ b/sites/platform/src/create-apps/image-properties/variables.md
@@ -1,5 +1,5 @@
 ---
-title: "`variables`"
+title: "variables"
 weight: 4
 description: A variables dictionary that defines variables to control the environment.
 ---

--- a/sites/platform/src/create-apps/image-properties/web.md
+++ b/sites/platform/src/create-apps/image-properties/web.md
@@ -1,5 +1,5 @@
 ---
-title: "`web`"
+title: "web"
 weight: 4
 description: A web instance that defines how the web application is served.
 ---

--- a/sites/platform/src/create-apps/image-properties/workers.md
+++ b/sites/platform/src/create-apps/image-properties/workers.md
@@ -1,5 +1,5 @@
 ---
-title: "`workers`"
+title: "workers"
 weight: 4
 description: Defines the list of worker names, which are alternate copies of the application to run as background processes.
 ---

--- a/sites/upsun/src/create-apps/image-properties/access.md
+++ b/sites/upsun/src/create-apps/image-properties/access.md
@@ -1,5 +1,5 @@
 ---
-title: "`access`"
+title: "access"
 weight: 4
 description: An access dictionary that defines the access control for roles accessing app environments.
 ---

--- a/sites/upsun/src/create-apps/image-properties/additional_hosts.md
+++ b/sites/upsun/src/create-apps/image-properties/additional_hosts.md
@@ -1,5 +1,5 @@
 ---
-title: "`additional_hosts`"
+title: "additional_hosts"
 weight: 4
 description: An additional hosts dictionary that maps hostnames to IP addresses.
 ---

--- a/sites/upsun/src/create-apps/image-properties/container_profile.md
+++ b/sites/upsun/src/create-apps/image-properties/container_profile.md
@@ -1,5 +1,5 @@
 ---
-title: "`container_profile`"
+title: "container_profile"
 weight: 4
 description: Defines the container profile of the application.
 ---

--- a/sites/upsun/src/create-apps/image-properties/crons.md
+++ b/sites/upsun/src/create-apps/image-properties/crons.md
@@ -1,5 +1,5 @@
 ---
-title: "`crons`"
+title: "crons"
 weight: 4
 description: A cron dictionary that defines scheduled tasks for the app.
 ---

--- a/sites/upsun/src/create-apps/image-properties/firewall.md
+++ b/sites/upsun/src/create-apps/image-properties/firewall.md
@@ -1,5 +1,5 @@
 ---
-title: "`firewall`"
+title: "firewall"
 weight: 4
 description: A firewall dictionary that defines the outbound firewall rules for the application.
 ---

--- a/sites/upsun/src/create-apps/image-properties/hooks.md
+++ b/sites/upsun/src/create-apps/image-properties/hooks.md
@@ -1,5 +1,5 @@
 ---
-title: "`hooks`"
+title: "hooks"
 weight: 4
 description: A hooks dictionary that defines which commands run at different stages in the build and deploy process.
 keywords:

--- a/sites/upsun/src/create-apps/image-properties/mounts.md
+++ b/sites/upsun/src/create-apps/image-properties/mounts.md
@@ -1,5 +1,5 @@
 ---
-title: "`mounts`"
+title: "mounts"
 weight: 4
 description: Directories that are writable even after the app is built.
 ---

--- a/sites/upsun/src/create-apps/image-properties/relationships.md
+++ b/sites/upsun/src/create-apps/image-properties/relationships.md
@@ -1,5 +1,5 @@
 ---
-title: "`relationships`"
+title: "relationships"
 weight: 4
 description: A dictionary of relationships that defines the connections to other services and apps.
 ---

--- a/sites/upsun/src/create-apps/image-properties/source.md
+++ b/sites/upsun/src/create-apps/image-properties/source.md
@@ -1,5 +1,5 @@
 ---
-title: "`source`"
+title: "source"
 weight: 4
 description: Contains information about the app’s source code and operations that can be run on it.
 ---

--- a/sites/upsun/src/create-apps/image-properties/variables.md
+++ b/sites/upsun/src/create-apps/image-properties/variables.md
@@ -1,5 +1,5 @@
 ---
-title: "`variables`"
+title: "variables"
 weight: 4
 description: A variables dictionary that defines variables to control the environment.
 ---

--- a/sites/upsun/src/create-apps/image-properties/web.md
+++ b/sites/upsun/src/create-apps/image-properties/web.md
@@ -1,5 +1,5 @@
 ---
-title: "`web`"
+title: "web"
 weight: 4
 description: A web instance that defines how the web application is served.
 ---

--- a/sites/upsun/src/create-apps/image-properties/workers.md
+++ b/sites/upsun/src/create-apps/image-properties/workers.md
@@ -1,5 +1,5 @@
 ---
-title: "`workers`"
+title: "workers"
 weight: 4
 description: Defines the list of worker names, which are alternate copies of the application to run as background processes.
 ---

--- a/themes/psh-docs/assets/css/main.css
+++ b/themes/psh-docs/assets/css/main.css
@@ -28,6 +28,31 @@
   cursor: pointer;
 }
 
+.image-property-page__title {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d6dae1;
+  background: #f8f9fb;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-weight: 400;
+  color: #1c2434;
+  letter-spacing: -0.01em;
+}
+
+.dark .image-property-page__title {
+  border-color: #475569;
+  background: #101726;
+  color: #f8fafc;
+}
+
+.image-property-sidebar__link {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
 .code-block-wrapper {
   position: relative;
 }

--- a/themes/psh-docs/layouts/partials/page-content.html
+++ b/themes/psh-docs/layouts/partials/page-content.html
@@ -25,7 +25,15 @@
 
 <!-- Page title -->
 {{ if ne .context.Params.showTitle false }}
-<h1 class="font-black text-2xl mb-8 xl:text-4xl">{{ .context.Title | .context.RenderString }}</h1>
+  {{ $isImagePropertiesPage := in .context.RelPermalink "/create-apps/image-properties/" }}
+  {{ $titleClasses := "text-2xl mb-8 xl:text-4xl" }}
+  {{ if not $isImagePropertiesPage }}
+    {{ $titleClasses = printf "%s %s" $titleClasses "font-black" }}
+  {{ end }}
+  {{ if $isImagePropertiesPage }}
+    {{ $titleClasses = printf "%s %s" $titleClasses "image-property-page__title" }}
+  {{ end }}
+  <h1 class="{{ $titleClasses }}">{{ .context.Title | .context.RenderString }}</h1>
 {{ end }}
 
 <div class="grid md:grid-cols-[minmax(0,1fr),270px] md:gap-4 md:pr-4 print:block">

--- a/themes/psh-docs/layouts/partials/sidebar/list.html
+++ b/themes/psh-docs/layouts/partials/sidebar/list.html
@@ -73,6 +73,7 @@
     {{ if .Params.sidebarTitle }}
       {{ $itemTitle = .Params.sidebarTitle | .Page.RenderString }}
     {{ end }}
+    {{ $isImagePropertySidebarPage := in .RelPermalink "/create-apps/image-properties/" }}
     <!-- Create a machine readable ID with no dots (as in node.js) -->
     {{ $itemId := printf "%s-sidebar-id" ( replace ($itemTitle | urlize) "." "" ) }}
 
@@ -91,7 +92,7 @@
       {{ end }}
       <li x-data="{ secondExpanded: {{ $isCurrentSection }} }" data-engagement-id="sidebar-subsection-nested-{{ $itemTitle | htmlEscape }}">
         <div class="flex items-center pl-4 justify-between{{ if ne .Kind "section" }} py-2 pl-4 {{ end }}">
-          <a href="{{ .RelPermalink }}" destination="{{ .RelPermalink }}" {{ $getStartedAttribute | safeHTMLAttr }} class="hover:text-skye-dark focus:text-skye-dark{{ if $isCurrentSection }} text-skye-dark{{ end }}">
+          <a href="{{ .RelPermalink }}" destination="{{ .RelPermalink }}" {{ $getStartedAttribute | safeHTMLAttr }} class="hover:text-skye-dark focus:text-skye-dark{{ if $isCurrentSection }} text-skye-dark{{ end }}{{ if $isImagePropertySidebarPage }} image-property-sidebar__link{{ end }}">
               {{ $itemTitle }}
               {{ if .Params.premium }}{{ partial "premium-features/badge" }}{{ end }}
               {{ if .Params.newfeature }}{{ partial "newfeature/badge" }}{{ end }}
@@ -110,6 +111,7 @@
               <!-- Loop through children -->
               {{ range $levelTwoPages }}
 
+                {{ $isImagePropertySidebarChild := in .RelPermalink "/create-apps/image-properties/" }}
                 {{ if not ( .Params.sidebarIgnore )}}
                   <!-- Additional structure without expansion -->
                   {{ with .Params.sectionBefore }}
@@ -117,7 +119,7 @@
                   {{ end }}
                   <!-- SECOND LEVEL ITEM -->
                   <li class="border-l border-stone py-1 pl-4">
-                    <a href="{{ .RelPermalink }}" class="hover:text-skye-dark focus:text-skye-dark{{ if eq $currentPage . }} text-skye-dark{{ end }}">
+                    <a href="{{ .RelPermalink }}" class="hover:text-skye-dark focus:text-skye-dark{{ if eq $currentPage . }} text-skye-dark{{ end }}{{ if $isImagePropertySidebarChild }} image-property-sidebar__link{{ end }}">
                         {{ if isset .Params "sidebartitle" }}{{ .Params.sidebarTitle | .RenderString }}{{ else }}{{ .Title | .RenderString }}{{ end }}
                         {{ if .Params.premium }}{{ partial "premium-features/badge" }}{{ end }}
                         {{ if .Params.newfeature }}{{ partial "newfeature/badge" }}{{ end }}


### PR DESCRIPTION

## Why

Closes #{ISSUE_NUMBER}

## What's changed

For files in image-properties folders, removes <code></code> tags surrounding the property name

## Where are changes
Topics under image-properties. 

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
