### PR TITLE
5298 activity log

### DIFF
--- a/sites/platform/src/administration/servers.md
+++ b/sites/platform/src/administration/servers.md
@@ -1,12 +1,14 @@
 ---
 title: Server upgrades
-description: Information about how {{% vendor/name %}} updates servers
+description: Information about how {{% vendor/name %}} upgrades servers
 weight: 10
 ---
 
-To ensure your projects get the latest features, improvements, and bug fixes, {{% vendor/name %}} updates the servers that deliver services. You can view these events in the [activity logs](/increase-observability/logs/access-logs.md#activity-logs) of any project or environment.
+To ensure your projects get the latest features, improvements, and bug fixes, {{% vendor/name %}} updates the servers that deliver services. 
 
 No action is needed on your part, and no downtime occurs for your projects. 
+
+To view these upgrade events, go to the [activity logs](../increase-observability/logs/access-logs.md#activity-logs) for any project or environment and then select **Upgrade** from the **Filter** list.
 
 ## Affected servers
 

--- a/sites/upsun/src/administration/servers.md
+++ b/sites/upsun/src/administration/servers.md
@@ -4,9 +4,11 @@ description: Information about how {{% vendor/name %}} updates servers
 weight: 10
 ---
 
-To ensure your projects get the latest features, improvements, and bug fixes, {{% vendor/name %}} updates the servers that deliver services. You can view these events in the [activity logs](../increase-observability/logs/access-logs.md#activity-logs) of any project or environment.
+To ensure your projects get the latest features, improvements, and bug fixes, {{% vendor/name %}} updates the servers that deliver services. 
 
 No action is needed on your part, and no downtime occurs for your projects. 
+
+To view these upgrade events, go to the [activity logs](../increase-observability/logs/access-logs.md#activity-logs) for any project or environment and then select **Upgrade** from the **Filter** list.
 
 ## Affected servers
 


### PR DESCRIPTION

## Why

Closes #5298

## What's changed

Upgrade activities are no longer included in activity logs.
Simplify the Administration > Server upgrade topic intro.

## Where are changes
https://fixed.docs.upsun.com/administration/servers.html
https://docs.upsun.com/administration/servers.html
Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
