### PR TITLE
Add composable 25.11 and update runtimes

### DIFF
--- a/shared/data/composable_versions.yaml
+++ b/shared/data/composable_versions.yaml
@@ -1,6 +1,7 @@
 composable:
   versions:
     supported:
-      - "25.05"
+      - "25.11"
     available:
+      - "25.05"
       - "24.05"

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -201,15 +201,15 @@ Security and other patches are applied automatically.
 | **Language**                                 | **Nix package** | **Supported version(s)**                        |
 |----------------------------------------------|-----------------|-------------------------------------------------|
 | [Clojure](https://clojure.org/)              | `clojure`       | 1                                               |
-| [Elixir](/languages/elixir.html)             | `elixir`        | 1.18<br/>1.15<br/>1.14                          |
-| [Go](/languages/go.html)                     | `golang`        | 1.22<br/>1.21                                   |
-| [Java](/languages/java.html)                 | `java`          | 22<br/>21                                       |
+| [Elixir](/languages/elixir.html)             | `elixir`        | 1.19<br/>1.18<br/>1.17                          |
+| [Go](/languages/go.html)                     | `golang`        | 1.25<br/>1.24                                   |
+| [Java](/languages/java.html)                 | `java`          | 25                                       |
 | [Javascript/Bun](https://bun.sh/)            | `bun`           | 1                                               |
-| [JavaScript/Node.js](/languages/nodejs.html) | `nodejs`        | 24<br/>22<br/>20<br/>18                         |
+| [JavaScript/Node.js](/languages/nodejs.html) | `nodejs`        | 24<br/>22<br/>20                         |
 | [Perl](https://www.perl.org/)                | `perl`          | 5                                               |
-| [PHP](/languages/php.html)                   | `php`           | 8.4<br/>8.3<br/>8.2<br/>8.1                     |
-| [Python](/languages/python.html)             | `python`        | 3.13<br/>3.12<br/>3.11<br/>3.10<br/>3.9<br/>2.7 |
-| [Ruby](/languages/ruby.html)                 | `ruby`          | 3.4<br/>3.3<br/>3.2<br/>3.1                     |
+| [PHP](/languages/php.html)                   | `php`           | 8.4<br/>8.3<br/>8.2                     |
+| [Python](/languages/python.html)             | `python`        | 3.13<br/>3.12<br/>3.11 |
+| [Ruby](/languages/ruby.html)                 | `ruby`          | 3.4<br/>3.3                     |
 
 
 ### PHP extensions and Python packages {#php-extensions-and-python-packages}

--- a/sites/upsun/src/create-apps/app-reference/composable-image.md
+++ b/sites/upsun/src/create-apps/app-reference/composable-image.md
@@ -197,15 +197,15 @@ Security and other patches are applied automatically.
 | **Language**                                 | **Nix package** | **Supported version(s)**                        |
 |----------------------------------------------|-----------------|-------------------------------------------------|
 | [Clojure](https://clojure.org/)              | `clojure`       | 1                                               |
-| [Elixir](/languages/elixir.html)             | `elixir`        | 1.18<br/>1.15<br/>1.14                          |
-| [Go](/languages/go.html)                     | `golang`        | 1.22<br/>1.21                                   |
-| [Java](/languages/java.html)                 | `java`          | 22<br/>21                                       |
+| [Elixir](/languages/elixir.html)             | `elixir`        | 1.19<br/>1.18<br/>1.17                          |
+| [Go](/languages/go.html)                     | `golang`        | 1.25<br/>1.24                                   |
+| [Java](/languages/java.html)                 | `java`          | 25                                       |
 | [Javascript/Bun](https://bun.sh/)            | `bun`           | 1                                               |
-| [JavaScript/Node.js](/languages/nodejs.html) | `nodejs`        | 24<br/>22<br/>20<br/>18                         |
+| [JavaScript/Node.js](/languages/nodejs.html) | `nodejs`        | 24<br/>22<br/>20                         |
 | [Perl](https://www.perl.org/)                | `perl`          | 5                                               |
-| [PHP](/languages/php.html)                   | `php`           | 8.4<br/>8.3<br/>8.2<br/>8.1                     |
-| [Python](/languages/python.html)             | `python`        | 3.13<br/>3.12<br/>3.11<br/>3.10<br/>3.9<br/>2.7 |
-| [Ruby](/languages/ruby.html)                 | `ruby`          | 3.4<br/>3.3<br/>3.2<br/>3.1                     |
+| [PHP](/languages/php.html)                   | `php`           | 8.4<br/>8.3<br/>8.2                     |
+| [Python](/languages/python.html)             | `python`        | 3.13<br/>3.12<br/>3.11 |
+| [Ruby](/languages/ruby.html)                 | `ruby`          | 3.4<br/>3.3                     |
 
 
 ### PHP extensions and Python packages {#php-extensions-and-python-packages}


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

composable 25.11 released

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

Supported version is now 25.11

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
