### PR TITLE
automerge workflow for API docs updates

### DIFF
--- a/.github/workflows/auto-merge-api-doc-updates.yaml
+++ b/.github/workflows/auto-merge-api-doc-updates.yaml
@@ -54,7 +54,6 @@ jobs:
                 console.log('No pull_requests in workflow_run payload, attempting commit lookup')
                 // Fallback: Get PR associated with the workflow run's head SHA
                 const headSha = context.payload.workflow_run.head_sha;
-                const headBranch = context.payload.workflow_run.head_branch;
                 console.log(`Head SHA: ${headSha}`)
 
                 const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({


### PR DESCRIPTION
adds verification branches match as criterion in addition to the PR being opened. adds annotation to workflow run to indicate when a PR has not met the criterion.
