### PR TITLE
adds type property to activemq-artemis and elasticsearch-enterprise

### DIFF
--- a/shared/data/registry.json
+++ b/shared/data/registry.json
@@ -1378,6 +1378,7 @@
     }
   },
   "activemq-artemis": {
+    "type": "activemq-artemis",
     "versions": {
       "deprecated": [],
       "supported": [
@@ -1391,6 +1392,7 @@
     }
   },
   "elasticsearch-enterprise": {
+    "type": "elasticsearch-enterprise",
     "versions": {
       "deprecated": [],
       "supported": [


### PR DESCRIPTION
## Why

`activemq-artemis` and `elasticsearch-enterprise` entries in registry.json are missing the `type` property. [Registry parser](https://www.npmjs.com/package/pshregistry-parser) uses `type` to generate the files in `sites/(platform|upsun)/src/registry` which are used in console. This is causing errors in console. 

## What's changed

Adds the `type` property to both entries so the registry parser can generate the files correctly.

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
