### PR TITLE
typo correction in guides, linkcheckerr config

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -33,3 +33,5 @@ ignoreerrors=
     ^https://docs\.pimcore\.com/.*$ ^403 Forbidden
     ^https://(?:www\.)?perplexity\.ai/.*$ ^403 Forbidden
     ^https:// ^ReadTimeout
+    ^https://qdrant\.tech/.*$ ^ConnectionError:
+    ^https://gatsbyjs\.com/.*$ ^ConnectionError:

--- a/sites/upsun/src/get-started/stacks/wordpress/composer.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/composer.md
@@ -75,7 +75,7 @@ applications:
           scripts: true
           allow: true
           rules:
-            ^/license\.text$:
+            ^/license\.txt$:
               allow: false
             ^/readme\.html$:
               allow: false

--- a/sites/upsun/src/get-started/stacks/wordpress/multisite.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/multisite.md
@@ -67,7 +67,7 @@ applications:
         "/":
           <snip>
           rules:
-            ^/license\.text$:
+            ^/license\.txt$:
               allow: false
             ^/readme\.html$:
               allow: false

--- a/sites/upsun/src/get-started/stacks/wordpress/vanilla.md
+++ b/sites/upsun/src/get-started/stacks/wordpress/vanilla.md
@@ -97,7 +97,7 @@ If you changed the name of the directory at step 4 you'll need to update the `pa
               scripts: true
               allow: true
               rules:
-                ^/license\.text$:
+                ^/license\.txt$:
                   allow: false
                 ^/readme\.html$:
                   allow: false


### PR DESCRIPTION
- Corrects typo in web.locations.rules section in WordPress getting started guides (`licenses.text` --> `license.txt`)
- adds qdrant.tech and gatsbyjs.com to linkchecker ignoreerror as they frequently have connection issues

## Why

Closes #5340 
Closes #5341 

