### PR TITLE
Fix link and typo

### DIFF
--- a/sites/platform/src/development/ssh/_index.md
+++ b/sites/platform/src/development/ssh/_index.md
@@ -39,7 +39,7 @@ A certificate gets stored in your local SSH configuration.
 The certificate is automatically cycled every hour for a new certificate as long as your session is active.
 
 If you are inactive for an extended period,
-your certificate expires and you are asked to login again the next time you use a command that requires authentication.
+your certificate expires and you are asked to log in again the next time you use a command that requires authentication.
 
 You are now ready to run CLI commands and connect to an environment.
 
@@ -61,7 +61,7 @@ Once you've connected, you get a welcome message detailing which environment you
 
 Now you can interact with the environment as you want.
 Note that your app's file system is read-only,
-except for any [mounts you've defined]/create-apps/image-properties/mounts.md).
+except for any [mounts you've defined](/create-apps/image-properties/mounts.md).
 
 ## Connect to services
 

--- a/sites/upsun/src/development/ssh/_index.md
+++ b/sites/upsun/src/development/ssh/_index.md
@@ -38,7 +38,7 @@ A certificate gets stored in your local SSH configuration.
 The certificate is automatically cycled every hour for a new certificate as long as your session is active.
 
 If you are inactive for an extended period,
-your certificate expires and you are asked to login again the next time you use a command that requires authentication.
+your certificate expires and you are asked to log in again the next time you use a command that requires authentication.
 
 You are now ready to run CLI commands and connect to an environment.
 


### PR DESCRIPTION

## Why

Closes #5393



## What's changed

Add missing parenthesis in link; fix typo

## Where are changes
https://fixed.docs.upsun.com/development/ssh.html#2-connect-to-an-app-with-ssh
https://docs.upsun.com/development/ssh.html#2-connect-to-an-app-with-ssh. (typo only)



Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
