### PR TITLE
Upsun Flex: MariaDB/Postgresql-replica YAML fix

### DIFF
--- a/sites/upsun/src/add-services/mysql/mysql-readonly-replication.md
+++ b/sites/upsun/src/add-services/mysql/mysql-readonly-replication.md
@@ -61,9 +61,9 @@ services:
           default_schema: main
           privileges:
               main: admin
-          replicator:
-            privileges:
-              main: replication
+        replicator:
+          privileges:
+            main: replication
 
   db-replica1:
     type: mariadb-replica:<VERSION>
@@ -75,7 +75,7 @@ services:
           default_schema: main
           privileges:
             main: admin
-      relationships:
+    relationships:
       primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
 
   db-replica2:
@@ -88,7 +88,7 @@ services:
           default_schema: main
           privileges:
             main: admin
-      relationships:
+    relationships:
       primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
 ```
 


### PR DESCRIPTION

## Why

Closes #{ISSUE_NUMBER}


## What's changed

Upsun Flex topics: Fixes the YAML in the mariadb-replica and postgresql-replica YAML for parity with Fixed topic (delivered in PR #5391.

## Where are changes
https://docs.upsun.com/add-services/mysql/mysql-readonly-replication.html
https://docs.upsun.com/add-services/postgresql/postgresql-readonly-replication.html

Updates are for:

- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
