### PR TITLE
Broken links: Update Gunicorn links

### DIFF
--- a/sites/platform/src/languages/python/server.md
+++ b/sites/platform/src/languages/python/server.md
@@ -144,9 +144,9 @@ web:
 ### Gunicorn workers
 
 These examples define four worker processes with `-w 4`.
-For more details on what you can configure, see the [Gunicorn documentation](https://docs.gunicorn.org/en/stable/faq.html#worker-processes).
+For more details on what you can configure, see the [Gunicorn documentation](https://gunicorn.org/faq/?h=worker+processes#worker-processes).
 
-Workers can also be defined with a custom [worker class](https://docs.gunicorn.org/en/latest/settings.html#worker-class),
+Workers can also be defined with a custom [worker class](https://gunicorn.org/asgi/?h=worker+class#worker-class),
 such as [Uvicorn](https://www.uvicorn.org/#running-with-gunicorn), [gevent](https://www.gevent.org/),
 or [Tornado](https://www.tornadoweb.org/).
 

--- a/sites/upsun/src/languages/python/server.md
+++ b/sites/upsun/src/languages/python/server.md
@@ -144,9 +144,9 @@ web:
 ### Gunicorn workers
 
 These examples define four worker processes with `-w 4`.
-For more details on what you can configure, see the [Gunicorn documentation](https://docs.gunicorn.org/en/stable/faq.html#worker-processes).
+For more details on what you can configure, see the [Gunicorn documentation](https://gunicorn.org/faq/?h=worker+processes#worker-processes).
 
-Workers can also be defined with a custom [worker class](https://docs.gunicorn.org/en/latest/settings.html#worker-class),
+Workers can also be defined with a custom [worker class](https://gunicorn.org/asgi/?h=worker+class#worker-class),
 such as [Uvicorn](https://www.uvicorn.org/#running-with-gunicorn), [gevent](https://www.gevent.org/),
 or [Tornado](https://www.tornadoweb.org/).
 


### PR DESCRIPTION


## Why

Closes #5403


## What's changed

Update links to Gunicorn worker-processes and worker-class info to fix broken link issues.

## Where are changes

https://docs.upsun.com/languages/python/server.html
https://fixed.docs.upsun.com/languages/python/server.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
