### PR TITLE
Add VENDOR=upsun to Upsun CLI install commands

### DIFF
--- a/sites/upsun/src/administration/cli/api-tokens.md
+++ b/sites/upsun/src/administration/cli/api-tokens.md
@@ -171,7 +171,7 @@ hooks:
   build: |
     set -e
     echo "Installing {{% vendor/name %}} CLI"
-    curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
 
     echo "Testing {{% vendor/name %}} CLI"
     {{% vendor/cli %}}

--- a/sites/upsun/src/create-apps/source-operations.md
+++ b/sites/upsun/src/create-apps/source-operations.md
@@ -257,7 +257,7 @@ applications:
       build: |
         set -e
         echo "Installing {{% vendor/name %}} CLI"
-        curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
+        curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
 
         echo "Testing {{% vendor/name %}} CLI"
         {{% vendor/cli %}}

--- a/sites/upsun/src/learn/tutorials/dependency-updates.md
+++ b/sites/upsun/src/learn/tutorials/dependency-updates.md
@@ -206,7 +206,7 @@ applications:
       build: |
         set -e
         echo "Installing {{% vendor/name %}} CLI"
-        curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
+        curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
 
         echo "Testing {{% vendor/name %}} CLI"
         {{% vendor/cli %}}


### PR DESCRIPTION

## Why

Closes #5412 

## What's changed

Adds VENDOR=upsun to the installation curl: 
curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash


## Where are changes
https://docs.upsun.com/administration/cli/api-tokens.html
https://docs.upsun.com/create-apps/source-operations.html
https://docs.upsun.com/learn/tutorials/dependency-updates.html#2-automate-your-dependency-updates-with-a-cron-job


Updates are for:

- [ ] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
