### PR TITLE
DB config parms are MariaDB only, not Oracle

### DIFF
--- a/sites/platform/src/add-services/mysql/_index.md
+++ b/sites/platform/src/add-services/mysql/_index.md
@@ -689,7 +689,9 @@ Each has its own credentials you can use to connect to the given database.
 
 For MariaDB 10.1 and later, you can configure the database by adding the properties below to the `.services.<SERVICE_NAME>.configuration.properties` key. This method is equivalent to using a using a `my.cnf` file.
 
-**Note**: At this time, these properties can be configured on MariaDB/MySQL databases only. They cannot be configured for Oracle MySQL databases.  
+{{% note theme="info" %}} 
+**At this time, these properties can be configured on MariaDB/MySQL databases only.** They cannot be configured for Oracle MySQL databases.
+{{% /note %}}  
 
 | Name                                  | Type      | Default                                                      | Description                                                                                                                                                                           |
 |---------------------------------------|-----------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/sites/upsun/src/add-services/mysql/_index.md
+++ b/sites/upsun/src/add-services/mysql/_index.md
@@ -679,7 +679,9 @@ Each has its own credentials, prefixed with the relationship name, you can use t
 
 For MariaDB 10.1 and later, you can configure the database by adding the properties below to the `.services.<SERVICE_NAME>.configuration.properties` key. This method is equivalent to using a using a `my.cnf` file.
 
-**Note**: At this time, these properties can be configured on MariaDB/MySQL databases only. They cannot be configured for Oracle MySQL databases.  
+{{% note theme="info" %}} 
+**At this time, these properties can be configured on MariaDB/MySQL databases only.** They cannot be configured for Oracle MySQL databases.
+{{% /note %}}   
 
 | Name                                  | Type      | Default                                                      | Description                                                                                                                                                                           |
 |---------------------------------------|-----------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION


## Why

Closes #5419


## What's changed

At this time, the db configuration options listed are not configurable for Oracle MySQL.

## Where are changes
https://docs.upsun.com/add-services/mysql.html#configure-the-database
https://fixed.docs.upsun.com/add-services/mysql.html#configure-the-database

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
