### PR TITLE
Use the correct Upsun Fixed pricing URL

### DIFF
--- a/shared/data/banners.yaml
+++ b/shared/data/banners.yaml
@@ -28,7 +28,7 @@ beta:
 tiered-feature: 
     title: Tier availability
     body: This feature is available for Upsun Fixed **Elite** and **Enterprise** customers. 
-        [Compare the Upsun Fixed tiers](https://upsun.com/fixed-pricing/) on our pricing page, 
+        [Compare the Upsun Fixed tiers](https://upsun.com/pricing-fixed/) on our pricing page, 
         or [contact our Sales team](https://upsun.com/contact-us/) for more information.
 
 observability-suite:

--- a/sites/platform/src/administration/payment-faq.md
+++ b/sites/platform/src/administration/payment-faq.md
@@ -13,7 +13,7 @@ You'll also find important details about billing cycles, invoice eligibility, an
 
 This page is _not_ meant to be your primary resource for the exact costs of certain features.
 
-The official {{% vendor/name %}} [Pricing page](https://upsun.com/fixed-pricing/) should always be considered the primary source of pricing details.
+The official {{% vendor/name %}} [Pricing page](https://upsun.com/pricing-fixed/) should always be considered the primary source of pricing details.
 
 {{< /note >}}
 
@@ -91,7 +91,7 @@ The **billing cycle** refers to the period between invoices. You will be billed 
 ## Further resources
 
 ### Pricing
-- [{{% vendor/name %}} prices](https://upsun.com/fixed-pricing/)
+- [{{% vendor/name %}} prices](https://upsun.com/pricing-fixed/)
 
 ### Terms and conditions
 - [Legal terms of service](https://upsun.com/trust-center/legal/tos/)

--- a/sites/platform/src/administration/pricing/_index.md
+++ b/sites/platform/src/administration/pricing/_index.md
@@ -7,7 +7,7 @@ layout: single
 
 {{% vendor/name %}} offers a variety of plans to fit your needs, including a free trial.
 
-Full pricing information is available at https://upsun.com/fixed-pricing/.
+Full pricing information is available at https://upsun.com/pricing-fixed/.
 The resources listed there are for [production environments](#production-environments).
 
 You can switch between plans freely, adding or removing resources, including [extras](#extras).
@@ -41,7 +41,7 @@ Production environments are the live environments available to your users.
 Each Production plan has one Production environment that can be mapped to a [custom domain name](/domains/steps/_index.md).
 
 The production environment has more resources than the project's preview environments.
-See the main [pricing page](https://upsun.com/fixed-pricing/) for the resources available per plan for Production environments.
+See the main [pricing page](https://upsun.com/pricing-fixed/) for the resources available per plan for Production environments.
 
 ### Preview environments
 

--- a/sites/platform/src/dedicated-environments/dedicated-gen-2/overview.md
+++ b/sites/platform/src/dedicated-environments/dedicated-gen-2/overview.md
@@ -12,7 +12,7 @@ Dedicated Generation 2 consists of two parts: a development environment and a De
 
 ### Key features
 
--   **High Availability:** 99.99% SLA (service-level agreement) with [Enterprise or Elite](https://upsun.com/fixed-pricing/)
+-   **High Availability:** 99.99% SLA (service-level agreement) with [Enterprise or Elite](https://upsun.com/pricing-fixed/)
 -   **Dedicated hosts:** Each DG2 cluster is provisioned with 3 dedicated hosts as the typical configuration
 -   **Headless architecture:** Seamless headless architecture with multi-app support
 -   **Isolation:** On DG2, services run as processes on the base operating system (OS)
@@ -49,7 +49,7 @@ Much of the tooling used on Grid is used for DG2, but there are still some diffe
 | **Cron tasks interrupted by deploys**                  | Yes: a deploy will terminate a running Cron task                                      | No: a running Cron task will block a deployment until it is complete                  |
 | **Log exports**                                        | Managed by Upsun Fixed with Rsyslog exports and Fastly log exports                    | Log forwarding feature and Fastly log export also available                           |
 | **Sync and merge functionalities**                     | Only on development environments                                                      | Yes on all branches                                                                   |
-| **SLA**                                                | 99.99% with [Enterprise or Elite](https://upsun.com/fixed-pricing/)                   | 99.9% with [Enterprise or Elite](https://upsun.com/fixed-pricing/)                    |
+| **SLA**                                                | 99.99% with [Enterprise or Elite](https://upsun.com/pricing-fixed/)                   | 99.9% with [Enterprise or Elite](https://upsun.com/pricing-fixed/)                    |
 | **Infrastructure**                                     | Dedicated 3 node cluster                                                              | Containers with dedicated resources on top of a shared redundant infrastructure       |
 | **Functioning**                                        | 3 nodes are running all applications and services and are replicated                  | A single container is deployed per runtimes and per services                          |
 | **Resources allocation**                               | Resources deployed on 3 nodes                                                         | Resources are spread through the container with fixed sizes after deployment          |
@@ -59,7 +59,7 @@ Much of the tooling used on Grid is used for DG2, but there are still some diffe
 | **Split Architecture**                                 | Yes                                                                                   | No                                                                                    |
 | **Storage**                                            | Local disks are accessed either locally or via glusterfs                              | 100 GB self service max (can be extended upon request)                                |
 | **Automated backup**                                   | Yes                                                                                   | Yes                                                                                   |
-| **Custom domains name**                                | On all branches for [Enterprise or Elite](https://upsun.com/fixed-pricing/) customers | On all branches for [Enterprise or Elite](https://upsun.com/fixed-pricing/) customers |
+| **Custom domains name**                                | On all branches for [Enterprise or Elite](https://upsun.com/pricing-fixed/) customers | On all branches for [Enterprise or Elite](https://upsun.com/pricing-fixed/) customers |
 | **MongoDB**                                            | Yes                                                                                   | Standalone service container                                                          |
 | **web.commands.post_start**                            | No                                                                                    | Self-service via YAML config files                                                    |
 

--- a/sites/platform/src/dedicated-environments/dedicated-gen-3/overview.md
+++ b/sites/platform/src/dedicated-environments/dedicated-gen-3/overview.md
@@ -21,7 +21,7 @@ If you need more information, have any questions, or you think you have the perf
 
 ### Key features
 
--   **High Availability:** 99.99% SLA (service-level agreement) with [Enterprise or Elite](https://upsun.com/fixed-pricing/)
+-   **High Availability:** 99.99% SLA (service-level agreement) with [Enterprise or Elite](https://upsun.com/pricing-fixed/)
 -   **Dedicated hosts:** Each DG3 cluster is provisioned with 3 dedicated hosts as the typical configuration
 -   **Headless architecture:** Seamless headless architecture with multi-app support
 -   **Self-service:** Customers may edit their application and service YAML files and push changes. Customers can also take advantage of MariaDB Galera multi-leader and adding, upgrading or removing services on their own
@@ -68,7 +68,7 @@ Much of the tooling used on Grid is used for DG3, but there are still some diffe
 | **Storage increase responsibility** | Shared responsibility with Upsun Fixed | Self-service |
 | **Cron tasks interrupted by deploys** | No: a running Cron task will block a deployment until it is complete | No: a running Cron task will block a deployment until it is complete |
 | **Sync and merge functionalities** | Yes on all branches | Yes on all branches |
-| **SLA** | 99.99% with [Enterprise or Elite](https://upsun.com/fixed-pricing/) | 99.9% with [Enterprise or Elite](https://upsun.com/fixed-pricing/)|
+| **SLA** | 99.99% with [Enterprise or Elite](https://upsun.com/pricing-fixed/) | 99.9% with [Enterprise or Elite](https://upsun.com/pricing-fixed/)|
 | **Infrastructure** | Dedicated 3 node cluster | Containers with dedicated resources on top of a shared redundant infrastructure |
 | **Functioning** | 3 nodes are running all applications and services are replicated across all 3| A single container is deployed per runtimes and per services |
 | **Resources allocation** | Resources are deployed on all 3 nodes | Resources are spread through one container with fixed sizes after deployment |
@@ -79,7 +79,7 @@ Much of the tooling used on Grid is used for DG3, but there are still some diffe
 | **Automated backup** | Yes | Yes |
 | **Elasticsearch premium**  | Yes | Yes |
 | **SFTP password access** | Yes | No |
-| **Custom domains name** | On all branches for [Enterprise or Elite](https://upsun.com/fixed-pricing/) customers | On all branches for [Enterprise or Elite](https://upsun.com/fixed-pricing/) customers |
+| **Custom domains name** | On all branches for [Enterprise or Elite](https://upsun.com/pricing-fixed/) customers | On all branches for [Enterprise or Elite](https://upsun.com/pricing-fixed/) customers |
 
 #### Available services
 
@@ -143,7 +143,7 @@ Dedicated Gen 3 gives you both the high availability of Dedicated Gen 2 and the 
 | **Automated backup** | Yes | Yes  |
 | **Elasticsearch premium**  | Yes | Yes |
 | **SFTP password access** | Yes | Yes |
-| **Custom domains name** | Available only on Dedicated Environments for [Enterprise or Elite](https://upsun.com/fixed-pricing/) customers | On all branches for [Enterprise or Elite](https://upsun.com/fixed-pricing/) customers |
+| **Custom domains name** | Available only on Dedicated Environments for [Enterprise or Elite](https://upsun.com/pricing-fixed/) customers | On all branches for [Enterprise or Elite](https://upsun.com/pricing-fixed/) customers |
 | **On-demand backup** | Not supported | Same as grid |
 
 #### Optional features

--- a/sites/platform/src/dedicated-environments/overview.md
+++ b/sites/platform/src/dedicated-environments/overview.md
@@ -38,8 +38,8 @@ Whether you choose a Grid or Dedicated Environment depends on the needs you have
 
 | FEATURE | GRID | DEDICATED |
 | --- | --- | --- |
-| **Availability** | All support tiers | Just with [Enterprise or Elite](https://upsun.com/fixed-pricing/) |
-| **Uptime SLA** | 99.9% (Advanced Uptime SLA) with [Enterprise or Elite](https://upsun.com/fixed-pricing/)| 99.99% (Premium Uptime SLA) with [Enterprise or Elite](https://upsun.com/fixed-pricing/) |
+| **Availability** | All support tiers | Just with [Enterprise or Elite](https://upsun.com/pricing-fixed/) |
+| **Uptime SLA** | 99.9% (Advanced Uptime SLA) with [Enterprise or Elite](https://upsun.com/pricing-fixed/)| 99.99% (Premium Uptime SLA) with [Enterprise or Elite](https://upsun.com/pricing-fixed/) |
 | **Infrastructure** | Containers with dedicated resources on top of a shared redundant infrastructure| Dedicated 3 node clusters|
 | **Functioning** | A single container is deployed per runtime and per service| At least 3 nodes are running all applications and services are replicated across all of them |
 | **Resource Allocation** | Resources are spread through one container with fixed sizes after deployment| Resources are deployed across a least 3 nodes

--- a/sites/platform/src/development/submodules.md
+++ b/sites/platform/src/development/submodules.md
@@ -103,7 +103,7 @@ title= Automated update
 {{< note theme="warning" title="Tier availability" version="1" >}}
 
 This feature is available for **Elite** and **Enterprise** customers.
-[Compare the {{% vendor/name %}} tiers](https://upsun.com/fixed-pricing/) on our pricing page,
+[Compare the {{% vendor/name %}} tiers](https://upsun.com/pricing-fixed/) on our pricing page,
 or [contact our Sales team](https://upsun.com/contact-us/) for more information.
 
 {{< /note >}}

--- a/sites/platform/src/environments/_index.md
+++ b/sites/platform/src/environments/_index.md
@@ -212,7 +212,7 @@ If you're on a development plan,
 all your environments are preview environments that can be paused automatically.
 This includes your future production environment.
 To prevent your production environment from being paused automatically,
-[upgrade to a non-development plan](https://upsun.com/fixed-pricing/).
+[upgrade to a non-development plan](https://upsun.com/pricing-fixed/).
 
 {{< /note >}}
 

--- a/sites/platform/src/environments/backup.md
+++ b/sites/platform/src/environments/backup.md
@@ -75,7 +75,7 @@ The number of available backups for Production environments depends on your sche
 
 Note that [backup retention](/security/data-retention.md#grid-backups) also depends on your schedule.
 
-The schedules available to you depend on your [tier](https://upsun.com/fixed-pricing/).
+The schedules available to you depend on your [tier](https://upsun.com/pricing-fixed/).
 
 | Tier             | Default schedule | Possible upgrade |
 | ---------------- | ---------------- | ---------------- |
@@ -118,7 +118,7 @@ Automated backups are only available for production environments.
 If you're on a [development plan](/administration/pricing/_index.md#development-plans),
 all your environments are [development environments](/glossary/_index.md#environment-type).
 This includes your future production environment.
-If you want to enable automated backups for it, [upgrade to a non-development plan](https://upsun.com/fixed-pricing/).
+If you want to enable automated backups for it, [upgrade to a non-development plan](https://upsun.com/pricing-fixed/).
 
 {{< /note >}}
 

--- a/sites/platform/src/increase-observability/metrics/grid.md
+++ b/sites/platform/src/increase-observability/metrics/grid.md
@@ -39,7 +39,7 @@ Note that resources are spread across all containers within the project.
 So the resources you see for a given container don't equal the total resources for the project.
 
 This reference project has a single app, two services (PostgreSQL and Redis), and two workers.
-The plan size for this project is [Medium](https://upsun.com/fixed-pricing/).
+The plan size for this project is [Medium](https://upsun.com/pricing-fixed/).
 The appropriate resources have been [allocated automatically](/create-apps/image-properties/size.md) for each container
 based on the number and type of containers for this plan size.
 The graphs show the current average usage in relation to the allocated resources.

--- a/sites/platform/src/increase-observability/metrics/http-metrics.md
+++ b/sites/platform/src/increase-observability/metrics/http-metrics.md
@@ -69,4 +69,4 @@ Note that the following data retention limits apply when using the HTTP metrics 
 - **8-hour retention** for standard customers (without Observability Suite).
 - **24-hour retention** for Observability Suite customers (Enterprise and Elite tiers).
 
-For more information about the different tiers for standard and Observability Suite customers, visit the [Pricing page](https://upsun.com/fixed-pricing/).
+For more information about the different tiers for standard and Observability Suite customers, visit the [Pricing page](https://upsun.com/pricing-fixed/).

--- a/sites/platform/src/learn/bestpractices/oneormany.md
+++ b/sites/platform/src/learn/bestpractices/oneormany.md
@@ -71,7 +71,7 @@ In a clustered application, you can have one of the following configurations:
 
 {{< note >}}
 
-Note that a clustered application requires at least a [{{< partial "plans/multiapp-plan-name" >}} plan](https://upsun.com/fixed-pricing/).
+Note that a clustered application requires at least a [{{< partial "plans/multiapp-plan-name" >}} plan](https://upsun.com/pricing-fixed/).
 
 {{< /note >}}
 

--- a/sites/upsun/src/development/submodules.md
+++ b/sites/upsun/src/development/submodules.md
@@ -115,7 +115,7 @@ title= Automated update
 {{< note theme="warning" title="Tier availability" version="1" >}}
 
 This feature is available for **Elite** and **Enterprise** customers.
-[Compare the {{% vendor/name %}} tiers](https://upsun.com/fixed-pricing/) on our pricing page,
+[Compare the {{% vendor/name %}} tiers](https://upsun.com/pricing-fixed/) on our pricing page,
 or [contact our Sales team](https://upsun.com/contact-us/) for more information.
 
 {{< /note >}}

--- a/themes/psh-docs/layouts/partials/tiered-features/body.html
+++ b/themes/psh-docs/layouts/partials/tiered-features/body.html
@@ -19,6 +19,6 @@
   {{- else -}}
     <strong>{{ index $tiers 0 }}</strong>
   {{- end -}}
-  &nbsp;customers. <a href="https://upsun.com/fixed-pricing/" target="_blank">Compare the {{ .Site.Params.vendor.name }} tiers</a> on our pricing page, or <a href="https://upsun.com/contact-us/
+  &nbsp;customers. <a href="https://upsun.com/pricing-fixed/" target="_blank">Compare the {{ .Site.Params.vendor.name }} tiers</a> on our pricing page, or <a href="https://upsun.com/contact-us/
   " target="_blank">contact our sales team</a> for more information.</p>
 </div>


### PR DESCRIPTION

## Why

Closes #5421


## What's changed

Replace https://upsun.com/fixed-pricing/ with https://upsun.com/pricing-fixed/

## Where are changes
Several files in the Fixed docs stream. 

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
