### PR TITLE
Varnish: Add Deprecated versions section

### DIFF
--- a/sites/platform/src/add-services/varnish.md
+++ b/sites/platform/src/add-services/varnish.md
@@ -29,6 +29,27 @@ Patch versions are applied periodically for bug fixes and the like. When you dep
     </tbody>
 </table>
 
+## Deprecated versions
+
+You can select the major and minor version.
+
+Patch versions are applied periodically for bug fixes and the like. When you deploy your app, you always get the latest available patches.
+
+<table>
+    <thead>
+        <tr>
+            <th>Grid</th>
+            <th>Dedicated Gen 2</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{< image-versions image="varnish" status="deprecated" environment="grid" >}}</td>
+            <td>{{< image-versions image="varnish" status="deprecated" environment="dedicated-gen-2" >}}</td>
+        </tr>
+    </tbody>
+</table>
+
 ## How it works
 
 All incoming requests go through the [standard router](/define-routes/_index.md).

--- a/sites/upsun/src/add-services/varnish.md
+++ b/sites/upsun/src/add-services/varnish.md
@@ -17,6 +17,11 @@ When you deploy your app, you always get the latest available patches.
 
 {{< image-versions image="varnish" status="supported" environment="grid" >}}
 
+{{% deprecated-versions %}}
+
+{{< image-versions image="varnish" status="deprecated" environment="grid" >}}
+
+
 ## How it works
 
 All incoming requests go through the [standard router](../define-routes/_index.md).


### PR DESCRIPTION

## Why

Closes #5218


## What's changed

Adds a "Deprecated versions" section for Fixed and Flex Varnish topics.

## Where are changes
https://docs.upsun.com/add-services/varnish.html
https://fixed.docs.upsun.com/add-services/varnish.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
