### PR TITLE
Add example.com to the linkcheckerrc ignore list

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -18,6 +18,8 @@ ignore=
     https://www.microsoft.com/en-us/trust-center/privacy/data-management
     http://localhost:1337/*
     https://platform.openai.com/docs*
+    https://example.com*
+    
 
 [output]
 warnings=0


### PR DESCRIPTION

## Why

Closes #5477


## What's changed

Adds `https://example.com*` to the list of URLs to ignore during the scheduled-check-links workflow.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
