### PR TITLE
Document automatic environment deletion behavior for source integrations

### DIFF
--- a/sites/platform/src/integrations/source/bitbucket.md
+++ b/sites/platform/src/integrations/source/bitbucket.md
@@ -92,10 +92,28 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn't possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
-| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the Bitbucket repository. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
+| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn’t possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
+| `prune-branches` | `true`  | Whether to automatically delete {{% vendor/name %}} environments that don’t match any remote branch. **Important:** When first enabled, this immediately deletes all pre-existing environments that don’t have a corresponding remote branch. Only affects standard branch environments; pull request environments are not deleted. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
 | `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
 | `resync-pull-requests` | `false` | Whether to sync data from the parent environment on every push to a pull request. |
+
+{{< note theme="warning" title="Automatic environment deletion" >}}
+
+When you create or update a source integration with `prune-branches: true` (the default), the system automatically synchronizes your {{% vendor/name %}} environments with your remote repository branches.
+
+**This means:**
+- Pre-existing {{% vendor/name %}} environments that don’t match any remote branch are **automatically deleted** during the initial integration setup
+- Only environments with local deployment targets (standard branch environments) are affected
+- Pull request environments are **not affected** by this pruning
+- Environments matching remote branches are preserved and updated with `has_remote: true`
+- The master/main environment is always preserved if it exists remotely
+
+**To prevent automatic deletion:**
+Set `prune-branches: false` when creating the integration using the `--prune-branches=false` flag with the CLI, or disable the **Prune branches** option in the Console.
+
+This feature ensures your {{% vendor/name %}} environments stay in sync with your repository, automatically cleaning up stale branches. If you have many local environments that don’t match remote branches, consider reviewing or backing them up before enabling the integration.
+
+{{< /note >}}
 
 To [keep your repository clean](/learn/bestpractices/clean-repository.md) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 

--- a/sites/platform/src/integrations/source/github.md
+++ b/sites/platform/src/integrations/source/github.md
@@ -114,12 +114,30 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn't possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
-| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitHub repository. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
+| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn’t possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
+| `prune-branches` | `true`  | Whether to automatically delete {{% vendor/name %}} environments that don’t match any remote branch. **Important:** When first enabled, this immediately deletes all pre-existing environments that don’t have a corresponding remote branch. Only affects standard branch environments; pull request environments are not deleted. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
 | `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
 | `build-draft-pull-requests` | `true` | Whether to also track and build draft pull requests. Automatically disabled when pull requests aren’t built. |
 | `pull-requests-clone-parent-data` | `true` | 	Whether to clone data from the parent environment when creating a pull request environment. |
 | `build-pull-requests-post-merge`| `false` | Whether to build what would be the result of merging each pull request. Turning it on forces rebuilds any time something is merged to the target branch. |
+
+{{< note theme="warning" title="Automatic environment deletion" >}}
+
+When you create or update a source integration with `prune-branches: true` (the default), the system automatically synchronizes your {{% vendor/name %}} environments with your remote repository branches.
+
+**This means:**
+- Pre-existing {{% vendor/name %}} environments that don’t match any remote branch are **automatically deleted** during the initial integration setup
+- Only environments with local deployment targets (standard branch environments) are affected
+- Pull request environments are **not affected** by this pruning
+- Environments matching remote branches are preserved and updated with `has_remote: true`
+- The master/main environment is always preserved if it exists remotely
+
+**To prevent automatic deletion:**
+Set `prune-branches: false` when creating the integration using the `--prune-branches=false` flag with the CLI, or disable the **Prune branches** option in the Console.
+
+This feature ensures your {{% vendor/name %}} environments stay in sync with your repository, automatically cleaning up stale branches. If you have many local environments that don’t match remote branches, consider reviewing or backing them up before enabling the integration.
+
+{{< /note >}}
 
 To [keep your repository clean](/learn/bestpractices/clean-repository.md) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 

--- a/sites/platform/src/integrations/source/gitlab.md
+++ b/sites/platform/src/integrations/source/gitlab.md
@@ -101,11 +101,29 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn't possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
-| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitLab repository. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
+| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn’t possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
+| `prune-branches` | `true`  | Whether to automatically delete {{% vendor/name %}} environments that don’t match any remote branch. **Important:** When first enabled, this immediately deletes all pre-existing environments that don’t have a corresponding remote branch. Only affects standard branch environments; merge request environments are not deleted. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
 | `build-merge-requests` | `true` | Whether to track all merge requests and create active environments from them, which builds the merge request. |
 | `build-wip-merge-requests` | `true` | Whether to also track and build draft merge requests. Automatically disabled when merge requests aren’t built. |
 | `merge-requests-clone-parent-data` | `true` | Whether to clone data from the parent environment when creating a merge request environment. |
+
+{{< note theme="warning" title="Automatic environment deletion" >}}
+
+When you create or update a source integration with `prune-branches: true` (the default), the system automatically synchronizes your {{% vendor/name %}} environments with your remote repository branches.
+
+**This means:**
+- Pre-existing {{% vendor/name %}} environments that don’t match any remote branch are **automatically deleted** during the initial integration setup
+- Only environments with local deployment targets (standard branch environments) are affected
+- Merge request environments are **not affected** by this pruning
+- Environments matching remote branches are preserved and updated with `has_remote: true`
+- The master/main environment is always preserved if it exists remotely
+
+**To prevent automatic deletion:**
+Set `prune-branches: false` when creating the integration using the `--prune-branches=false` flag with the CLI, or disable the **Prune branches** option in the Console.
+
+This feature ensures your {{% vendor/name %}} environments stay in sync with your repository, automatically cleaning up stale branches. If you have many local environments that don’t match remote branches, consider reviewing or backing them up before enabling the integration.
+
+{{< /note >}}
 
 To [keep your repository clean](/learn/bestpractices/clean-repository.md) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 

--- a/sites/upsun/src/integrations/source/bitbucket.md
+++ b/sites/upsun/src/integrations/source/bitbucket.md
@@ -92,11 +92,29 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn't possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
-| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the Bitbucket repository. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
+| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn’t possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
+| `prune-branches` | `true`  | Whether to automatically delete {{% vendor/name %}} environments that don’t match any remote branch. **Important:** When first enabled, this immediately deletes all pre-existing environments that don’t have a corresponding remote branch. Only affects standard branch environments; pull request environments are not deleted. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
 | `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
 | `resync-pull-requests` | `false` | Whether to sync data from the parent environment on every push to a pull request. |
 | `resources-init` | `false` | To [specify a resource initialization strategy](/manage-resources/resource-init.md#first-deployment) for new containers. Once set, the strategy applies to **all** the deployments you launch through your source integration. See more information on [available resource initialization strategies](/manage-resources/resource-init.md#specify-a-resource-initialization-strategy). |
+
+{{< note theme="warning" title="Automatic environment deletion" >}}
+
+When you create or update a source integration with `prune-branches: true` (the default), the system automatically synchronizes your {{% vendor/name %}} environments with your remote repository branches.
+
+**This means:**
+- Pre-existing {{% vendor/name %}} environments that don’t match any remote branch are **automatically deleted** during the initial integration setup
+- Only environments with local deployment targets (standard branch environments) are affected
+- Pull request environments are **not affected** by this pruning
+- Environments matching remote branches are preserved and updated with `has_remote: true`
+- The master/main environment is always preserved if it exists remotely
+
+**To prevent automatic deletion:**
+Set `prune-branches: false` when creating the integration using the `--prune-branches=false` flag with the CLI, or disable the **Prune branches** option in the Console.
+
+This feature ensures your {{% vendor/name %}} environments stay in sync with your repository, automatically cleaning up stale branches. If you have many local environments that don’t match remote branches, consider reviewing or backing them up before enabling the integration.
+
+{{< /note >}}
 
 {{% note %}}
 

--- a/sites/upsun/src/integrations/source/github.md
+++ b/sites/upsun/src/integrations/source/github.md
@@ -114,13 +114,31 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn't possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
-| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitHub repository. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
+| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn’t possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
+| `prune-branches` | `true`  | Whether to automatically delete {{% vendor/name %}} environments that don’t match any remote branch. **Important:** When first enabled, this immediately deletes all pre-existing environments that don’t have a corresponding remote branch. Only affects standard branch environments; pull request environments are not deleted. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
 | `build-pull-requests` | `true` | Whether to track all pull requests and create active environments from them, which builds the pull request. |
 | `build-draft-pull-requests` | `true` | Whether to also track and build draft pull requests. Automatically disabled when pull requests aren’t built. |
 | `pull-requests-clone-parent-data` | `true` | 	Whether to clone data from the parent environment when creating a pull request environment. |
 | `build-pull-requests-post-merge`| `false` | Whether to build what would be the result of merging each pull request. Turning it on forces rebuilds any time something is merged to the target branch. |
 | `resources-init` | `false` | To [specify a resource initialization strategy](/manage-resources/resource-init.md#first-deployment) for new containers. Once set, the strategy applies to **all** the deployments you launch through your source integration. See more information on [available resource initialization strategies](/manage-resources/resource-init.md#specify-a-resource-initialization-strategy). |
+
+{{< note theme="warning" title="Automatic environment deletion" >}}
+
+When you create or update a source integration with `prune-branches: true` (the default), the system automatically synchronizes your {{% vendor/name %}} environments with your remote repository branches.
+
+**This means:**
+- Pre-existing {{% vendor/name %}} environments that don’t match any remote branch are **automatically deleted** during the initial integration setup
+- Only environments with local deployment targets (standard branch environments) are affected
+- Pull request environments are **not affected** by this pruning
+- Environments matching remote branches are preserved and updated with `has_remote: true`
+- The master/main environment is always preserved if it exists remotely
+
+**To prevent automatic deletion:**
+Set `prune-branches: false` when creating the integration using the `--prune-branches=false` flag with the CLI, or disable the **Prune branches** option in the Console.
+
+This feature ensures your {{% vendor/name %}} environments stay in sync with your repository, automatically cleaning up stale branches. If you have many local environments that don’t match remote branches, consider reviewing or backing them up before enabling the integration.
+
+{{< /note >}}
 
 To [keep your repository clean](/learn/bestpractices/clean-repository.md) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 

--- a/sites/upsun/src/integrations/source/gitlab.md
+++ b/sites/upsun/src/integrations/source/gitlab.md
@@ -101,12 +101,30 @@ In both the CLI and Console, you can choose from the following options:
 
 | CLI flag         | Default | Description                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------------- |
-| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn't possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
-| `prune-branches` | `true`  | Whether to delete branches from {{% vendor/name %}} that don’t exist in the GitLab repository. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
+| `fetch-branches` | `true`  | Whether to mirror and update branches on {{% vendor/name %}} and create inactive environments from them. When enabled, merging on an {{% vendor/name %}} environment isn’t possible. That is, merging environments must be done on the source repository rather than on the {{% vendor/name %}} project. See note below for details related to this flag and synchronizing code from a parent environment. |
+| `prune-branches` | `true`  | Whether to automatically delete {{% vendor/name %}} environments that don’t match any remote branch. **Important:** When first enabled, this immediately deletes all pre-existing environments that don’t have a corresponding remote branch. Only affects standard branch environments; merge request environments are not deleted. When enabled, branching (creating environments) must be done on the source repository rather than on the {{% vendor/name %}} project. Branches created on {{% vendor/name %}} that are not on the source repository will not persist and will be quickly pruned. Automatically disabled when fetching branches is disabled. |
 | `build-merge-requests` | `true` | Whether to track all merge requests and create active environments from them, which builds the merge request. |
 | `build-wip-merge-requests` | `true` | Whether to also track and build draft merge requests. Automatically disabled when merge requests aren’t built. |
 | `merge-requests-clone-parent-data` | `true` | Whether to clone data from the parent environment when creating a merge request environment. |
 | `resources-init` | `false` | To [specify a resource initialization strategy](/manage-resources/resource-init.md#first-deployment) for new containers. Once set, the strategy applies to **all** the deployments you launch through your source integration. See more information on [available resource initialization strategies](/manage-resources/resource-init.md#specify-a-resource-initialization-strategy).
+
+{{< note theme="warning" title="Automatic environment deletion" >}}
+
+When you create or update a source integration with `prune-branches: true` (the default), the system automatically synchronizes your {{% vendor/name %}} environments with your remote repository branches.
+
+**This means:**
+- Pre-existing {{% vendor/name %}} environments that don’t match any remote branch are **automatically deleted** during the initial integration setup
+- Only environments with local deployment targets (standard branch environments) are affected
+- Merge request environments are **not affected** by this pruning
+- Environments matching remote branches are preserved and updated with `has_remote: true`
+- The master/main environment is always preserved if it exists remotely
+
+**To prevent automatic deletion:**
+Set `prune-branches: false` when creating the integration using the `--prune-branches=false` flag with the CLI, or disable the **Prune branches** option in the Console.
+
+This feature ensures your {{% vendor/name %}} environments stay in sync with your repository, automatically cleaning up stale branches. If you have many local environments that don’t match remote branches, consider reviewing or backing them up before enabling the integration.
+
+{{< /note >}}
 
 To [keep your repository clean](/learn/bestpractices/clean-repository.md) and avoid performance issues, make sure you enable both the `fetch-branches` and `prune-branches` options.
 

--- a/themes/psh-docs/layouts/shortcodes/source-integration/sync-fetch-prune.md
+++ b/themes/psh-docs/layouts/shortcodes/source-integration/sync-fetch-prune.md
@@ -6,8 +6,14 @@ An integration from {{ $type }} to {{ .Site.Params.vendor.name }} establishes th
 - {{ .Site.Params.vendor.name }} is a mirror of that repository - provisioning infrastructure according to configuration, and orchestrating environments according to the branch structure of the {{ $type }} repository
 
 Actions that take place on {{ .Site.Params.vendor.name }} don't affect commits on {{ $type }}.
-Because of this, the {{ $type }} integration enables both `fetch-branches` (track branches on {{ $type }}) and `prune-branches` (delete branches that don't exist on {{ $type }}) by default.
+Because of this, the {{ $type }} integration enables both `fetch-branches` (track branches on {{ $type }}) and `prune-branches` (automatically delete {{ .Site.Params.vendor.name }} environments that don't exist on {{ $type }}) by default.
 You can change these settings but it is recommend to keep them.
+
+**Important:** When `prune-branches` is enabled, environment synchronization happens automatically during:
+- Initial integration setup (first fetch from {{ $type }})
+- Subsequent webhook triggers when branches are deleted on {{ $type }}
+
+This means that when you first create the integration, any pre-existing {{ .Site.Params.vendor.name }} environments without matching {{ $type }} branches are immediately deleted.
 
 When enabled by default, you are limited by design as to what actions can be performed within the context of a {{ .Site.Params.vendor.name }} project with a {{ $type }} integration:
 


### PR DESCRIPTION

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #5451 

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed
Add clear warnings to GitHub, GitLab, and Bitbucket integration docs explaining that when prune-branches is enabled (the default), pre-existing environments without matching remote branches are automatically deleted during initial integration setup. Updates include enhanced prune-branches descriptions in configuration tables, prominent warning sections detailing what gets deleted and how to prevent it, and improved sync-fetch-prune shortcode explaining when synchronization occurs.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)
