### PR TITLE
feat: adjusted pages

### DIFF
--- a/sites/upsun/src/increase-observability/application-metrics/cont-prof.md
+++ b/sites/upsun/src/increase-observability/application-metrics/cont-prof.md
@@ -19,7 +19,13 @@ ensuring the smooth running of software in live environments.
 ## Continuous profiling on {{% vendor/name %}}
 
 {{< vendor/name >}} Continuous Profiling is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly from the Console under the `Profiling` tab of your environments.
+
+To access Continuous Profiling in the Console:
+
+1. Open your project in the Console.
+2. Select **Apps and Services**.
+3. Select your **app**.
+4. Click **Profiling**.
 
 The Continuous Profiling dashboard lets you visualize the profiling data of a specific application.
 It is composed of several views: flame graph, table view, and a split view combining the flame graph and table views.

--- a/sites/upsun/src/increase-observability/application-metrics/go.md
+++ b/sites/upsun/src/increase-observability/application-metrics/go.md
@@ -10,7 +10,7 @@ weight: 30
 ## Continuous profiling on {{% vendor/name %}}
 
 {{< vendor/name >}} [Continuous Profiler](/increase-observability/application-metrics/cont-prof.md) is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly from the Console under the `Profiling` tab of your environments.
+It is available in the Console under **Apps and Services → your app → Profiling**.
 
 The GO continuous profiling is currently made across 6 dimensions:
 - **Allocations**: Number of objects allocated

--- a/sites/upsun/src/increase-observability/application-metrics/java.md
+++ b/sites/upsun/src/increase-observability/application-metrics/java.md
@@ -6,7 +6,7 @@ weight: 30
 ---
 
 {{< vendor/name >}} [Continuous Profiler](/increase-observability/application-metrics/cont-prof.md) is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly the [Console](/administration/web/_index.md), under the **Profiling** tab of your environments.
+It is available directly the [Console](/administration/web/_index.md), under **Apps and Services → your app → Profiling**.
 
 The Java continuous profiling is currently made across 3 dimensions:
 - **CPU Time**:  Time spent running on the CPU

--- a/sites/upsun/src/increase-observability/application-metrics/nodejs.md
+++ b/sites/upsun/src/increase-observability/application-metrics/nodejs.md
@@ -10,7 +10,7 @@ weight: 30
 ## Continuous profiling on {{% vendor/name %}}
 
 {{< vendor/name >}} Continuous Profiling is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly from the Console under the `Profiling` tab of your environments.
+It is available in the Console under **Apps and Services → your app → Profiling**.
 
 The Node.js continuous profiling is currently made across 3 dimensions:
 - **CPU Time**:  Time spent running on the CPU

--- a/sites/upsun/src/increase-observability/application-metrics/php.md
+++ b/sites/upsun/src/increase-observability/application-metrics/php.md
@@ -8,7 +8,7 @@ weight: 30
 {{< partial "continuous-profiling-sellable/body.md" >}}
 
 {{< vendor/name >}} [Continuous Profiler](/increase-observability/application-metrics/cont-prof.md) is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly the [Console](/administration/web/_index.md), under the **Profiling** tab of your environments.
+It is available directly the [Console](/administration/web/_index.md), under **Apps and Services → your app → Profiling**.
 
 The PHP continuous profiling is currently made across 4 dimensions:
 - **CPU Time**:  Time spent running on the CPU

--- a/sites/upsun/src/increase-observability/application-metrics/python.md
+++ b/sites/upsun/src/increase-observability/application-metrics/python.md
@@ -8,7 +8,7 @@ weight: 30
 {{< partial "continuous-profiling-sellable/body.md" >}}
 
 {{< vendor/name >}} [Continuous Profiler](/increase-observability/application-metrics/cont-prof.md) is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly from the [Console](/administration/web/_index.md), under the **Profiling** tab of your environments.
+It is available directly from the [Console](/administration/web/_index.md), under **Apps and Services → your app → Profiling**.
 
 The PHP continuous profiling is currently made across 4 dimensions:
 - **CPU Time**:  Time spent running on the CPU

--- a/sites/upsun/src/increase-observability/application-metrics/ruby.md
+++ b/sites/upsun/src/increase-observability/application-metrics/ruby.md
@@ -6,7 +6,7 @@ weight: 30
 ---
 
 {{< vendor/name >}} [Continuous Profiler](/increase-observability/application-metrics/cont-prof.md) is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly the [Console](/administration/web/_index.md), under the **Profiling** tab of your environments.
+It is available directly the [Console](/administration/web/_index.md), under **Apps and Services → your app → Profiling**.
 
 The Ruby continuous profiling is currently made across 3 dimensions:
 - **CPU Time**:  Time spent running on the CPU

--- a/sites/upsun/src/increase-observability/application-metrics/rust.md
+++ b/sites/upsun/src/increase-observability/application-metrics/rust.md
@@ -6,7 +6,7 @@ weight: 30
 ---
 
 {{< vendor/name >}} [Continuous Profiler](/increase-observability/application-metrics/cont-prof.md) is powered by [Blackfire](../../../increase-observability/application-metrics/blackfire.md).
-It is available directly the [Console](/administration/web/_index.md), under the **Profiling** tab of your environments.
+It is available directly the [Console](/administration/web/_index.md), under **Apps and Services → your app → Profiling**.
 
 The Rust continuous profiling is currently made across 3 dimensions:
 - **CPU Time**:  Time spent running on the CPU

--- a/sites/upsun/src/increase-observability/application-metrics/understanding.md
+++ b/sites/upsun/src/increase-observability/application-metrics/understanding.md
@@ -7,7 +7,7 @@ description: Understanding the differences between deterministic and probabilist
 Multiple application observability features are available for your {{% vendor/name %}} projects.
 
 A full access to [Blackfire](https://www.blackfire.io/) is bundled with all your PHP and Python projects.
-The continuous profiling of your NodeJS, Go, Ruby and Rust applications is available directly from the Console under the `Profiling` tab of your environments.
+The continuous profiling of your NodeJS, Go, Ruby and Rust applications is available directly from the Console under **Apps and Services → your app → Profiling**..
 
 ## Blackfire: Deterministic observability for PHP and Python
 


### PR DESCRIPTION
adjusted pages that have profiling location in console

## Why

Closes #5474 

## What's changed
adjusted pages that have profiling location in console

## Where are changes
All profiling pages

Updates are for:

- [ ] platform (`sites/platform` templates)
- [X] upsun (`sites/upsun` templates)
