### PR TITLE
Switch WordPress Composer guides from WPackagist to WP Packages and roots/wordpress

### DIFF
--- a/sites/platform/src/guides/wordpress/composer/_index.md
+++ b/sites/platform/src/guides/wordpress/composer/_index.md
@@ -33,13 +33,13 @@ Through Composer you can add and update dependencies to your project, and then l
 Through Composer, themes and modules are then treated the same as any other PHP dependency. You can, for example, add the [Neve](https://wordpress.org/themes/neve/) theme to your project by using `composer require`
 
 ```bash
-composer require wpackagist-theme/neve
+composer require wp-theme/neve
 ```
 
 or add the [cache-control](https://wordpress.org/plugins/cache-control-by-cacholong/) plugin:
 
 ```bash
-composer require wpackagist-plugin/cache-control
+composer require wp-plugin/cache-control
 ```
 
 These commands will add the packages to your `composer.json` file, and then lock the exact version to `composer.lock`. Just push those updates to your project on {{% vendor/name %}}, and enable them through the administration panel as you would normally.
@@ -52,11 +52,11 @@ For more information, see the following {{% vendor/name %}} community post: [How
 
 ### Installing WordPress core with Composer
 
-In the same way, using Composer makes it unnecessary for you to commit all of WordPress to your repository, since you can add it as a dependency. There are several ways to do this (i.e. [Bedrock](https://github.com/platformsh-templates/wordpress-bedrock)) depending on how many assumptions you want to be made for your configuration and project structure. The simplest one uses the [John Bloch Composer fork](https://github.com/johnpbloch/wordpress) to add an installer to your builds for WordPress:
+In the same way, using Composer makes it unnecessary for you to commit all of WordPress to your repository, since you can add it as a dependency. There are several ways to do this (i.e. [Bedrock](https://github.com/platformsh-templates/wordpress-bedrock)) depending on how many assumptions you want to be made for your configuration and project structure. The simplest one uses the [`roots/wordpress`](https://github.com/roots/wordpress) meta-package to install WordPress core via Composer:
 
 ```bash
-composer require johnpbloch/wordpress-core-installer
-composer require johnpbloch/wordpress-core
+composer require roots/wordpress-core-installer
+composer require roots/wordpress
 ```
 
 ### Updates

--- a/sites/platform/src/guides/wordpress/composer/_index.md
+++ b/sites/platform/src/guides/wordpress/composer/_index.md
@@ -55,7 +55,6 @@ For more information, see the following {{% vendor/name %}} community post: [How
 In the same way, using Composer makes it unnecessary for you to commit all of WordPress to your repository, since you can add it as a dependency. There are several ways to do this (i.e. [Bedrock](https://github.com/platformsh-templates/wordpress-bedrock)) depending on how many assumptions you want to be made for your configuration and project structure. The simplest one uses the [`roots/wordpress`](https://github.com/roots/wordpress) meta-package to install WordPress core via Composer:
 
 ```bash
-composer require roots/wordpress-core-installer
 composer require roots/wordpress
 ```
 

--- a/sites/platform/src/guides/wordpress/composer/migrate.md
+++ b/sites/platform/src/guides/wordpress/composer/migrate.md
@@ -85,8 +85,8 @@ To install WordPress with Composer, complete the following steps:
    To download WordPress itself, run the following commands:
 
    ```bash
-   $ composer require johnpbloch/wordpress-core-installer
-   $ composer require johnpbloch/wordpress-core
+   $ composer require roots/wordpress-core-installer
+   $ composer require roots/wordpress
    ```
 
    The two dependencies are now listed in your `composer.json` file:
@@ -94,8 +94,8 @@ To install WordPress with Composer, complete the following steps:
    ```json
     {
         "require": {
-            "johnpbloch/wordpress-core-installer": "^2.0",
-            "johnpbloch/wordpress-core": "^6.0"
+            "roots/wordpress-core-installer": "^4.0",
+            "roots/wordpress": "^6.0"
         }
     }
    ```
@@ -113,27 +113,27 @@ To install WordPress with Composer, complete the following steps:
 Just like with WordPress core, you can install themes and plugins with the `composer require` command.
 To do so, complete the following steps:
 
-1. Configure the WPackagist repository.
+1. Configure the WP Packages repository.
 
    By default, when you download dependencies using Composer, you retrieve them through [Packagist](https://packagist.org),
    which is the primary Composer repository for public PHP packages.
    Some themes and plugins for WordPress are also on Packagist,
-   but most of them are accessible through a similar service specific to WordPress called [WPackagist](https://wpackagist.org).
+   but most of them are accessible through a similar service specific to WordPress called [WP Packages](https://wp-packages.org).
 
-   To allow Composer to download packages from the WPackagist repository, run the following command:
+   To allow Composer to download packages from the WP Packages repository, run the following command:
 
    ```bash
-   $ composer config repositories.wppackagist composer https://wpackagist.org
+   $ composer config repositories.wp-packages composer https://repo.wp-packages.org
    ```
 
-   WPackagist is now listed in your `composer.json` file:
+   WP Packages is now listed in your `composer.json` file:
 
    ```json
     {
         "repositories": {
-            "wppackagist": {
+            "wp-packages": {
                 "type": "composer",
-                "url": "https://wpackagist.org"
+                "url": "https://repo.wp-packages.org"
             }
         }
     }
@@ -170,14 +170,14 @@ To do so, complete the following steps:
 
 3. Launch the installation of plugins and themes with Composer.
 
-   To search for themes and plugins in [WPackagist](https://wpackagist.org) and install them through Composer, run a `composer require` command:
+   To search for themes and plugins in [WP Packages](https://wp-packages.org) and install them through Composer, run a `composer require` command:
 
    ```bash
    # Plugin
-   $ composer require wpackagist-plugin/wordpress-seo
+   $ composer require wp-plugin/wordpress-seo
 
    # Theme
-   $ composer require wpackagist-theme/hueman
+   $ composer require wp-theme/hueman
    ```
 
    The two dependencies are now listed in your `composer.json` file.

--- a/sites/platform/src/guides/wordpress/composer/migrate.md
+++ b/sites/platform/src/guides/wordpress/composer/migrate.md
@@ -82,23 +82,23 @@ To install WordPress with Composer, complete the following steps:
 
    Now that you have made your WordPress site into a Composer project, you can download packages via Composer.
 
-   To download WordPress itself, run the following commands:
+   To download WordPress itself, run the following command:
 
    ```bash
-   $ composer require roots/wordpress-core-installer
    $ composer require roots/wordpress
    ```
 
-   The two dependencies are now listed in your `composer.json` file:
+   The dependency is now listed in your `composer.json` file:
 
    ```json
     {
         "require": {
-            "roots/wordpress-core-installer": "^4.0",
             "roots/wordpress": "^6.0"
         }
     }
    ```
+
+   `roots/wordpress` is a meta-package that pulls in `roots/wordpress-core-installer` automatically.
 
 5. Complete the installation:
 

--- a/sites/platform/src/guides/wordpress/deploy/customize.md
+++ b/sites/platform/src/guides/wordpress/deploy/customize.md
@@ -187,13 +187,13 @@ Next, having placed `wp-config.php` in the root of your repository, you need to 
   },
 ```
 
-Since you're likely using [WPPackagist](https://wpackagist.org/) to download plugins and themes with Composer, you also need to add `wpackagist.org` as a repository in `composer.json`.
+Since you're likely using [WP Packages](https://wp-packages.org/) to download plugins and themes with Composer, you also need to add `repo.wp-packages.org` as a repository in `composer.json`.
 
 ```json
   "repositories": [
     {
       "type": "composer",
-      "url": "https://wpackagist.org"
+      "url": "https://repo.wp-packages.org"
     }
   ]
 ```

--- a/sites/platform/src/guides/wordpress/deploy/next-steps.md
+++ b/sites/platform/src/guides/wordpress/deploy/next-steps.md
@@ -28,13 +28,13 @@ so you need to copy and re-copy accordingly.
 
 ## Adding public plugins and themes via Composer
 
-Adding a plugin or theme from WPPackagist is the same as downloading a package through Composer:
+Adding a plugin or theme from WP Packages is the same as downloading a package through Composer:
 
 ```bash
 # Plugin
-$ composer require wpackagist-plugin/cache-control
+$ composer require wp-plugin/cache-control
 # Theme
-$ composer require wpackagist-theme/neve
+$ composer require wp-theme/neve
 ```
 
 This updates your `composer.json` and `composer.lock` files.
@@ -56,14 +56,14 @@ Push those changes on a new environment and configure your store through the adm
 
 ## Adding private plugins and themes via Composer
 
-If your plugins aren't accessible from WPPackagist or Packagist, but are still valid packages,
+If your plugins aren't accessible from WP Packages or Packagist, but are still valid packages,
 you can use them in your project by defining local `repositories` for them in your `composer.json` file.
 
 ```json
 "repositories":[
     {
        "type":"composer",
-       "url":"https://wpackagist.org"
+       "url":"https://repo.wp-packages.org"
     },
     {
       "type": "path",

--- a/sites/platform/src/guides/wordpress/redis.md
+++ b/sites/platform/src/guides/wordpress/redis.md
@@ -58,7 +58,7 @@ title=WP Redis
 highlight=bash
 +++
 
-composer require "wpackagist-plugin/wp-redis":"^1.1.4"
+composer require "wp-plugin/wp-redis":"^1.1.4"
 
 <--->
 
@@ -67,7 +67,7 @@ title=Redis Object Cache
 highlight=bash
 +++
 
-composer require "wpackagist-plugin/redis-cache":"^2.0.23"
+composer require "wp-plugin/redis-cache":"^2.0.23"
 
 {{< /codetabs >}}
 


### PR DESCRIPTION
This PR updates Platform.sh's WordPress Composer guides to use WP Packages (instead of WPackagist) and `roots/wordpress` (instead of `johnpbloch/wordpress-core`).

**Disclosure: I maintain WP Packages and Bedrock.** The tables below try to be even-handed — flag anything that reads as biased and I'll fix it.

### WPackagist vs WP Packages

| | WPackagist | WP Packages |
|---|---|---|
| Launched | 2012 | 2025 |
| Operator | WP Engine (acquired March 2026, previously Outlandish) | Roots / community-funded via GitHub Sponsors |
| Track record | 12+ years | New, less battle-tested |
| Composer v2 `metadata-url` | No | Yes |
| Update frequency | ~1.5 hours | 5 minutes |
| Cold Composer resolve | baseline | ~17× faster ([benchmarks](https://wp-packages.org/wp-packages-vs-wpackagist)) |
| Source publication | Application code only | Application + infrastructure + deployment |
| Untagged plugin installs | Mutable trunk zips | Pinned SVN revisions |
| Closed plugins | Continues serving | Removed in lockstep with wp.org |

### `johnpbloch/wordpress-core` vs `roots/wordpress`

| | `johnpbloch/wordpress-core` | `roots/wordpress` |
|---|---|---|
| Started | 2013 | 2014 |
| Maintainer | John P Bloch | Roots org |
| Track record | 10+ years | 10+ years |
| Build flavors | Single package | Meta-package family: `roots/wordpress`, `-full`, `-no-content` |
| Beta/RC releases | No | Yes (via `roots/wordpress-full`) |
| Companion installer | Required as separate dep (`johnpbloch/wordpress-core-installer ^2.0`) | Pulled in transitively by `roots/wordpress` (no separate require needed) |
| Ecosystem | Standalone | Pairs with Bedrock, Sage, Trellis |

### Files intentionally left alone

These reference Platform.sh's `platformsh-templates/wordpress-composer` template (and `upsun/snippets/wordpress-composer`), which use `johnpbloch` internally. I left them as-is to avoid documenting one stack while pointing readers at a different one — but worth flagging that **`platformsh-templates/wordpress-composer` is now marked "no longer maintained"** (same as `wordpress-bedrock`). If those templates are being sunset, these guides may want their own pass to either point at maintained alternatives or use upstream Bedrock directly (the approach the Upsun bedrock guide already takes):

- `sites/platform/src/guides/wordpress/deploy/_index.md` — heavily template-bound; explicitly documents the `wordpress-composer` template's structure
- `shared/data/templates.yaml` L602 — template metadata
- `sites/upsun/src/get-started/stacks/wordpress/composer.md` — references the upsun snippets WordPress Composer example

### Bedrock-flavored guides already in sync

The Upsun bedrock guide (`sites/upsun/src/get-started/stacks/wordpress/bedrock.md`) delegates to upstream Bedrock via `composer create-project roots/bedrock`, which already uses WP Packages and dropped `roots/wp-password-bcrypt` (current Bedrock removed it after WP 6.8 shipped native bcrypt). No changes needed there — flagging for completeness.

### Companion PRs

Even though the two template repos are marked "no longer maintained," I've also opened community-contribution PRs to refresh them — in case those templates aren't fully sunset and/or for the benefit of anyone forking them:

- [`platformsh-templates/wordpress-composer#470`](https://github.com/platformsh-templates/wordpress-composer/pull/470) — switches the template from `johnpbloch/wordpress-core` to `roots/wordpress` and from WPackagist to WP Packages
- [`platformsh-templates/wordpress-bedrock#1010`](https://github.com/platformsh-templates/wordpress-bedrock/pull/1010) — syncs the template with current upstream Bedrock (drops `wp-password-bcrypt`, adopts WP Packages, modernizes `config/application.php`)

Open to feedback on framing. Happy to close if it's not the direction you want.
