### PR TITLE
docs(solr): document configuration.modules for solr 9.9+

### DIFF
--- a/sites/platform/src/add-services/solr.md
+++ b/sites/platform/src/add-services/solr.md
@@ -432,6 +432,51 @@ solr:
 The default configuration is based on an older version of the Drupal 8 Search API Solr module that is no longer in use.
 You are strongly recommended to define your own configuration with a custom core and endpoint.
 
+### Bundled modules (Solr 9.9+)
+
+Solr 9.8 made [`<lib>` directives in `solrconfig.xml` opt-in](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-9-8), and Solr 10.0 ([SOLR-16781](https://issues.apache.org/jira/browse/SOLR-16781)) removed support for them entirely.
+As a result, bundled modules shipped under `/opt/solr/<VERSION>/modules/` (such as `extraction`, `analysis-extras`, `langid`, `ltr`, and `clustering`) are no longer auto-loaded from `<lib>` references in your configset.
+Instead, opt in by listing the modules you need via the `configuration.modules` field, which {{% vendor/name %}} renders into the upstream [`SOLR_MODULES` environment variable](https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html).
+
+By default, no bundled modules are loaded &mdash; only the modules you explicitly request are placed on the classpath.
+This keeps small instances from paying the memory cost of modules they don't use.
+
+```yaml {configFile="services"}
+services:
+  # The name of the service container. Must be unique within a project.
+  solr:
+    type: solr:{{% latest "solr" %}}
+    configuration:
+      modules:
+        - extraction
+        - analysis-extras
+        - langid
+        - ltr
+      cores:
+        mainindex:
+          conf_dir: !archive "core1-conf"
+      endpoints:
+        main:
+          core: mainindex
+```
+
+If you're upgrading from Solr 9.6 or earlier and your configset relies on `<lib>` directives (for example, the default Drupal [`search_api_solr`](https://www.drupal.org/project/search_api_solr) configset), add the matching modules to `configuration.modules` when you bump the version:
+
+```yaml {configFile="services"}
+services:
+  solr:
+    type: solr:9.9
+    configuration:
+      modules:
+        - extraction
+        - analysis-extras
+        - langid
+        - ltr
+```
+
+The `configuration.modules` field is supported only on Solr 9.9 and later.
+On Solr 9.6 and earlier, modules continue to load from `<lib>` directives in your configset, and no migration is required to keep your existing setup working.
+
 ### Limitations
 
 The recommended maximum size for configuration directories (zipped) is 2MB. These need to be monitored to ensure they don't grow beyond that. If the zipped configuration directories grow beyond this, performance declines and deploys become longer. The directory archives are compressed and string encoded. You could use this bash pipeline

--- a/sites/platform/src/add-services/solr.md
+++ b/sites/platform/src/add-services/solr.md
@@ -435,11 +435,9 @@ You are strongly recommended to define your own configuration with a custom core
 ### Bundled modules (Solr 9.9+)
 
 Solr 9.8 made [`<lib>` directives in `solrconfig.xml` opt-in](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-9-8), and Solr 10.0 ([SOLR-16781](https://issues.apache.org/jira/browse/SOLR-16781)) removed support for them entirely.
-As a result, bundled modules shipped under `/opt/solr/<VERSION>/modules/` (such as `extraction`, `analysis-extras`, `langid`, `ltr`, and `clustering`) are no longer auto-loaded from `<lib>` references in your configset.
-Instead, opt in by listing the modules you need via the `configuration.modules` field, which {{% vendor/name %}} renders into the upstream [`SOLR_MODULES` environment variable](https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html).
+As a result, bundled modules shipped under `/opt/solr/<VERSION>/modules/` (such as `extraction`, `analysis-extras`, `langid`, `ltr`, and `clustering`) are no longer auto-loaded from `<lib>` references in your configset. Instead, opt in by listing the modules you need via the `configuration.modules` field.
 
-By default, no bundled modules are loaded &mdash; only the modules you explicitly request are placed on the classpath.
-This keeps small instances from paying the memory cost of modules they don't use.
+By default, no bundled modules are loaded &mdash; only the modules you explicitly request are placed on the classpath. This keeps small instances from paying the memory cost of modules they don't use.
 
 ```yaml {configFile="services"}
 services:

--- a/sites/upsun/src/add-services/solr.md
+++ b/sites/upsun/src/add-services/solr.md
@@ -526,6 +526,51 @@ services:
 The default configuration is based on an older version of the Drupal 8 Search API Solr module that is no longer in use.
 You are strongly recommended to define your own configuration with a custom core and endpoint.
 
+### Bundled modules (Solr 9.9+)
+
+Solr 9.8 made [`<lib>` directives in `solrconfig.xml` opt-in](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-9-8), and Solr 10.0 ([SOLR-16781](https://issues.apache.org/jira/browse/SOLR-16781)) removed support for them entirely.
+As a result, bundled modules shipped under `/opt/solr/<VERSION>/modules/` (such as `extraction`, `analysis-extras`, `langid`, `ltr`, and `clustering`) are no longer auto-loaded from `<lib>` references in your configset.
+Instead, opt in by listing the modules you need via the `configuration.modules` field, which {{% vendor/name %}} renders into the upstream [`SOLR_MODULES` environment variable](https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html).
+
+By default, no bundled modules are loaded &mdash; only the modules you explicitly request are placed on the classpath.
+This keeps small instances from paying the memory cost of modules they don't use.
+
+```yaml {configFile="services"}
+services:
+  # The name of the service container. Must be unique within a project.
+  solr:
+    type: solr:{{% latest "solr" %}}
+    configuration:
+      modules:
+        - extraction
+        - analysis-extras
+        - langid
+        - ltr
+      cores:
+        mainindex:
+          conf_dir: !archive "core1-conf"
+      endpoints:
+        main:
+          core: mainindex
+```
+
+If you're upgrading from Solr 9.6 or earlier and your configset relies on `<lib>` directives (for example, the default Drupal [`search_api_solr`](https://www.drupal.org/project/search_api_solr) configset), add the matching modules to `configuration.modules` when you bump the version:
+
+```yaml {configFile="services"}
+services:
+  solr:
+    type: solr:9.9
+    configuration:
+      modules:
+        - extraction
+        - analysis-extras
+        - langid
+        - ltr
+```
+
+The `configuration.modules` field is supported only on Solr 9.9 and later.
+On Solr 9.6 and earlier, modules continue to load from `<lib>` directives in your configset, and no migration is required to keep your existing setup working.
+
 ### Limitations
 
 The recommended maximum size for configuration directories (zipped) is 2MB. These need to be monitored to ensure they don't grow beyond that. If the zipped configuration directories grow beyond this, performance declines and deploys become longer. The directory archives are compressed and string encoded. You could use this bash pipeline


### PR DESCRIPTION
Solr 9.8 made <lib> directives in solrconfig.xml opt-in (need `-Dsolr.config.lib.enabled=true`), and 10.0 ([SOLR-16781](https://issues.apache.org/jira/browse/SOLR-16781)) removed the handling code entirely. The replacement on 9.8+ is the `SOLR_MODULES` environment variable ([docs](https://solr.apache.org/guide/solr/latest/configuration-guide/solr-modules.html#installing-a-module)), which the Solr service agent now renders from a new customer-controlled configuration.modules field on the 9.9 and 10.0 manifests.

Document the new field on both the Platform.sh and Upsun Solr service pages so customers upgrading from 9.6 (most notably Drupal + search_api_solr users, who rely on bundled modules like extraction and analysis-extras) know exactly what to add to services.yaml. Pre-9.9 versions are unaffected and continue to load modules from <lib> directives, so customers staying on 9.6 do not need to change anything.

The new section sits between "Default configuration" and "Limitations" under "Solr 6 and later" rather than rewriting the existing "Available plugins" table, which describes the unconditional JTS and ICU4J classpath additions handled by the agent's post-install hook (a separate concern from the bundled-modules opt-in story).