### PR TITLE
Add default container profile size for Mercure and Valkey

### DIFF
--- a/sites/platform/src/create-apps/image-properties/size.md
+++ b/sites/platform/src/create-apps/image-properties/size.md
@@ -98,6 +98,7 @@ The following table shows which container profiles {{% vendor/name %}} applies w
 | Kafka                 | HIGH_MEMORY |
 | MariaDB               | HIGH_MEMORY |
 | Memcached             | BALANCED    |
+| Mercure               | BALANCED    |
 | MongoDB               | HIGH_MEMORY |
 | MongoDB Premium       | HIGH_MEMORY |
 | Network Storage       | HIGH_MEMORY |
@@ -113,6 +114,7 @@ The following table shows which container profiles {{% vendor/name %}} applies w
 | Ruby                  | HIGH_CPU    |
 | Rust                  | HIGH_CPU    |
 | Solr                  | HIGH_MEMORY |
+| Valkey                | BALANCED    |
 | Varnish               | HIGH_MEMORY |
 | Vault KMS             | HIGH_MEMORY |
 


### PR DESCRIPTION


## Why

Closes #5578 


## What's changed

Adds Mercure and Valkey to the default container profile size table.

## Where are changes
https://fixed.docs.upsun.com/create-apps/image-properties/size.html#container-profiles-cpu-and-memory

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
