### PR TITLE
Remove a bad example from the cron definition

### DIFF
--- a/sites/platform/src/create-apps/image-properties/crons.md
+++ b/sites/platform/src/create-apps/image-properties/crons.md
@@ -299,7 +299,6 @@ applications:
         commands:
           start: |
             if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
-              {{% vendor/cli %}} backup:create --yes --no-wait
               {{% vendor/cli %}} source-operation:run update --no-wait --yes
             fi
 ```


### PR DESCRIPTION
Having people run a backup in a cron is not great. It's been 6 years since this was needed. We now do this for them as part of the backup scheduling system

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why
Because giving customers an example of how to do something that isn't recommended is going to cause extra support work cleaning it up. 

## What's changed

Removed a single line

## Where are changes
See commit

Updates are for:

- [ x ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
