### PR TITLE
Network storage: Update note about delay and add polling caveat

### DIFF
--- a/sites/platform/src/add-services/network-storage.md
+++ b/sites/platform/src/add-services/network-storage.md
@@ -9,10 +9,7 @@ Your apps can use any combination of `local` and `service` mounts.
 
 {{< note >}}
 
-Writing to network mounts is slightly slower than to local mounts, though the difference 
-is usually negligible. The slower performance becomes more noticeable during high-volume 
-sequential file creation, such as rapidly creating many small files. In such cases, a 
-local mount is more effective.
+Writing to network mounts is slightly slower than to local mounts, most noticeably during high-volume sequential file creation — in that case, a local mount is more effective. Applications polling network mounts for a new file may not immediately detect it even though it exists.
 
 {{< /note >}}
 

--- a/sites/platform/src/add-services/network-storage.md
+++ b/sites/platform/src/add-services/network-storage.md
@@ -9,7 +9,9 @@ Your apps can use any combination of `local` and `service` mounts.
 
 {{< note >}}
 
-Writing to network mounts is slightly slower than to local mounts, most noticeably during high-volume sequential file creation — in that case, a local mount is more effective. Applications polling network mounts for a new file may not immediately detect it even though it exists.
+Writing to network mounts is slightly slower than to local mounts, most noticeably during high-volume sequential file creation — in that case, a local mount is more effective. Applications polling network mounts for a new file may not immediately detect it even though it exists. 
+
+Detection can be delayed by approximately 30 seconds, so polling logic should account for this delay and not treat a missing file as an error until that window has passed.
 
 {{< /note >}}
 


### PR DESCRIPTION

## Why

Closes #5587


## What's changed

Rewrite the note to include a caveat stating applications polling for new files might not immediately detect them.

## Where are changes
https://fixed.docs.upsun.com/add-services/network-storage.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
