### PR TITLE
add container size to the resources example

### DIFF
--- a/sites/platform/src/create-apps/flexible-resources.md
+++ b/sites/platform/src/create-apps/flexible-resources.md
@@ -38,6 +38,7 @@ When the `resources` key is set, the CPU sizes come from the following table:
 So you might have the `resources` set as follows:
 
 ```yaml {configFile="app"}
+size: S # when using 'resources', it's best to explicitly set a size because the memory_ratio relies on the vCPU given by the container size.
 resources:
   base_memory: 128
   memory_ratio: 180
@@ -48,7 +49,7 @@ If you change the `size` to `L`, it gets 488&nbsp;MB of memory: `128 + (2 * 180)
 
 {{< note >}}
 
-If you need even more control of your app's resources, take a look at the [Upsun Flex Organization](https://docs.upsun.com/administration/organizations.html#what-is-a-upsun-flex-organization) option. 
+The amount of flexibility here is limited. If your use case requires changing memory and cpu allocations with greater control, [Upsun Flex Organization](https://docs.upsun.com/administration/organizations.html#what-is-a-upsun-flex-organization) is a much better option. 
 
 {{< /note >}}
 


### PR DESCRIPTION
Clarify resource allocation details and suggest Upsun Flex Organization for advanced control.

<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The example didn't explictly set a `size`. Which is a problem when you realize the `resources` key uses the vCPU from the container size. I keep recommending to customers to explicitly set it, after it breaks things. But it might be better to just have this correct in the docs.

## What's changed

added `size` key in example. 

Also made a slight change in the wording of the upsun flex advert. 

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
