### PR TITLE
Remove tier gating dkim

### DIFF
--- a/sites/platform/src/development/email.md
+++ b/sites/platform/src/development/email.md
@@ -70,11 +70,6 @@ If you already have an SPF record, please add SendGrid into your existing record
 
 ## 3. (Optional) Validate your email
 
-{{< premium-features/tiered "Enterprise and Elite" >}}
-
-If you're on an Enterprise or Elite plan,
-you can request for DomainKeys Identified Mail (DKIM) to be enabled on your domain.
-
 DKIM improves your delivery rate as an email sender.
 Learn more about [how DKIM works](https://www.twilio.com/docs/sendgrid/glossary/dkim).
 


### PR DESCRIPTION
## Why

Having it tier gated causes more frustration from the customers and more work from support. Reasons and argumentation was discussed internally.

## What's changed

Removed the note that says this is tier gated to enterprise/elite
As discussed with @nicogommen 

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
