### PR TITLE
Fix: repository-s3 plugin supported on DG2 only

### DIFF
--- a/sites/platform/src/add-services/elasticsearch.md
+++ b/sites/platform/src/add-services/elasticsearch.md
@@ -398,7 +398,7 @@ This is the complete list of official Elasticsearch plugins that can be enabled:
 | `mapper-attachments`    | Mapper attachments plugin for indexing common file types                                  | *   | *   |     |     |     |
 | `mapper-murmur3`        | Murmur3 mapper plugin for computing hashes at index-time                                  | *   | *   | *   | *   | *   |
 | `mapper-size`           | Size mapper plugin, enables the `_size` meta field                                        | *   | *   | *   | *   | *   |
-| `repository-s3`         | Support for using S3 as a repository for Snapshot/Restore (available on Dedicated Gen 2 only) |     | *   | *   | *   | *   |
+| `repository-s3`         | Support for using S3 as a repository for Snapshot/Restore (supported on Dedicated Gen 2 only) |     | *   | *   | *   | *   |
 | `transport-nio`         | Support for NIO transport                                                                 |     |     |     | *   | *   |
 
 ### Plugin removal

--- a/sites/platform/src/add-services/opensearch.md
+++ b/sites/platform/src/add-services/opensearch.md
@@ -366,7 +366,7 @@ This is the complete list of plugins that can be enabled:
 | `mapper-annotated-text` | Adds support for text fields with markup used to inject annotation tokens into the index  | *   | *  | *   |
 | `mapper-murmur3`        | Murmur3 mapper plugin for computing hashes at index-time                                  | *   | *  | *   |
 | `mapper-size`           | Size mapper plugin, enables the `_size` meta field                                        | *   | *  | *   |
-| `repository-s3`         | Support for using S3 as a repository for Snapshot/Restore (available on Dedicated Gen 2 only) | *   | *  | *   |
+| `repository-s3`         | Support for using S3 as a repository for Snapshot/Restore (supported on Dedicated Gen 2 only) | *   | *  | *   |
 
 
 


### PR DESCRIPTION


## Why

The repository-s3 plugin on both Elasticsearch and OpenSearch is not supported on Grid/GridHA/DG3 and only possible to configure on DG2.

## What's changed

Append info that indicates the plugin is supported on DG2 only. 

## Where are changes
https://fixed.docs.upsun.com/add-services/opensearch.html#available-plugins
https://fixed.docs.upsun.com/add-services/elasticsearch.html#available-plugins

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
