### PR TITLE
Explain calculation of max_connections

### DIFF
--- a/sites/platform/src/add-services/mysql/troubleshoot.md
+++ b/sites/platform/src/add-services/mysql/troubleshoot.md
@@ -95,7 +95,7 @@ This information applies to DG3 and Professional/Grid {{% vendor/name %}} projec
 For DG2 projects, [contact Support](/learn/overview/get-support.md) to configure the `max_connections` property.
 {{% /note %}}
 
-You cannot configure `max_connections` in {{% vendor/name %}} service configurations, nor can it be influenced by any other config. It is calculated automatically based on actual available container memory. Increasing the max_connections happens automatically if the container size increases. 
+You cannot configure `max_connections` in {{% vendor/name %}} service configurations, nor can it be influenced by any other config. It is calculated automatically based on actual available container memory and increases automatically when the container size increases. 
 
 ### How it works
 

--- a/sites/platform/src/add-services/mysql/troubleshoot.md
+++ b/sites/platform/src/add-services/mysql/troubleshoot.md
@@ -88,213 +88,41 @@ Alternatively, if your worker is idle for too long it can self-terminate.
 
 You may get the following [error message](https://mariadb.com/kb/en/e1040/): `Error 1040: Too many connections`.
 A common way to solve this issue is to increase the `max_connections` property in your MariaDB service configuration.
-However, on {{% vendor/name %}}, you **cannot** configure `max_connections` directly.
-
-### Quick fix
+However, on {{% vendor/name %}}, you **cannot** configure `max_connections`, this is done automatically for you based on memory.
 
 {{% note theme="info"%}}
 This information applies to DG3 and Professional/Grid {{% vendor/name %}} projects.</br>
 For DG2 projects, [contact Support](/learn/overview/get-support.md) to configure the `max_connections` property.
 {{% /note %}}
 
-You cannot configure `max_connections` directly in {{% vendor/name %}} service configurations.
-However, to solve `Error 1040`, you can increase `max_connections` indirectly.
-
-For example, in the following service configuration for MariaDB, `max_connections` is `188` as [set by {{% vendor/name %}}](#how-it-works):
-
-```yaml {configFile="services"}
-# The name of the service container. Must be unique within a project.
-mariadb:
-  type: mariadb:{{% latest "mariadb" %}}
-  disk: 2048
-  size: L
-  configuration:
-    properties:
-      max_allowed_packet: 16
-```
-
-To **increase** `max_connections`, you can **either**:
-
-- **decrease** `max_allowed_packet` (for example, `16` → `15` results in `max_connections=201`)
-- or **increase** `size` (for example, `L` → `XL` results in `max_connections=356`)
+You cannot configure `max_connections` in {{% vendor/name %}} service configurations, nor can it be influenced by any other config. It is calculated automatically based on actual available container memory. Increasing the max_connections happens automatically if the container size increases. 
 
 ### How it works
 
-Behind the scenes, `max_connections` (for Professional and DG3 projects) is calculated from values that you _can_ change:
+To determine the max_connections that best fit the container, this is the calculation used:
 
-1. **`max_allowed_packet`**: `max_allowed_packet` is [directly configurable](/add-services/mysql/_index.md#configure-the-database)
-   in your `.platform/services.yaml` file with an integer value.
-   The default value of `16` is shown below to illustrate:
+```
+        avg_memory_per_connection_mb = 4
+        free = container_memory - (50 + container_memory * 0.70)
+        max_connections = int(free // avg_memory_per_connection_mb)
+```
 
-   ```yaml {configFile="services"}
-   # The name of the service container. Must be unique within a project.
-   mariadb:
-     type: mariadb:{{% latest "mariadb" %}}
-     disk: 2048
-     configuration:
-       properties:
-          max_allowed_packet: 16
-    ```
+The memory for a given container from its `size` depends on its [container profile](/create-apps/image-properties/size.html#container-profiles-cpu-and-memory).
 
-1. **The memory available to the service**: Resources are distributed across the containers
-   in a cluster based on your {{% vendor/name %}} [plan size](/administration/pricing/_index.md).
-   The _strategy_ for how resources are distributed can either be determined for you by {{% vendor/name %}} (equivalent to setting `size: AUTO`) or by setting a container size explicitly:
-
-    ```yaml {configFile="services"}
-    # The name of the service container. Must be unique within a project.
-    mariadb:
-      type: mariadb:{{% latest "mariadb" %}}
-      disk: 2048
-      size: L
-      configuration:
-        properties:
-          max_allowed_packet: 16
-    ```
-
-    The memory for a given container from its `size` depends on its [container profile](/create-apps/image-properties/size.html#container-profiles-cpu-and-memory).
-
-    For example, [MariaDB](/create-apps/image-properties/size.md#container-profile-reference) has a [`HIGH_MEMORY` container profile](/create-apps/image-properties/size.html#container-profiles-cpu-and-memory).
-    For `size: L`, it means 0.40 CPU and 1280 MB of memory.
+For example, [MariaDB](/create-apps/image-properties/size.md#container-profile-reference) has a [`HIGH_MEMORY` container profile](/create-apps/image-properties/size.html#container-profiles-cpu-and-memory).
+For `size: L`, it means 0.40 CPU and 1280 MB of memory.
 
 If we assume the configuration above, where:
+- `mariadb.size: L`, which we know is 1280 MB, the calculation becomes:
 
-- `mariadb.size: L`, which we know is 1280 MB, referred to below as `application_size`
-- `mariadb.configuration.properties.max_allowed_packet: 16`
-
-`max_allowed_packet` is `188`, which is determined by {{% vendor/name %}} according to:
-
-\begin{aligned}
-\texttt{max_connections} = \text{int}\Biggl[ \min \left( \frac{\texttt{FREE_MEMORY}}{\texttt{max_allowed_packet}}, 500 \right) \Biggr]
-\end{aligned}
-
-This calculation uses three additional calculations:
-
-\begin{aligned}
-\texttt{FREE_MEMORY} = \texttt{AVAILABLE_MEMORY} - \left( 50 + \texttt{innodb_buffer_pool_size} \right) \newline \newline
-\texttt{AVAILABLE_MEMORY} = (\texttt{application_size} * 2) + 512 \newline \newline
-\texttt{innodb_buffer_pool_size} = \frac{\text{int}\left( 0.75 \cdot \texttt{application_size} \right)}{1024^{2}}
-\end{aligned}
-
-So for our current example, where:
-
-\begin{aligned}
-\texttt{application_size} = 1280 \newline
-\texttt{max_allowed_packet} = 16
-\end{aligned}
-
-You get:
-
-\begin{aligned}
-\texttt{innodb_buffer_pool_size} = \frac{\text{int}\left( 0.75 \cdot \texttt{application_size} \right)}{1024^{2}} = \frac{\text{int}\left( 0.75 \cdot \texttt{1280} \right)}{1024^{2}} \approx 9.155 \times 10^{-4}
-\end{aligned}
-
-\begin{aligned}
-\texttt{AVAILABLE_MEMORY} = (\texttt{application_size} * 2) + 512 = (1280 * 2) + 512 = 3072
-\end{aligned}
-
-\begin{aligned}
-\texttt{FREE_MEMORY} = \texttt{AVAILABLE_MEMORY} - \left( 50 + \texttt{innodb_buffer_pool_size} \right) \newline \newline
-\texttt{FREE_MEMORY} = 3072 - \left( 50 + 0.0009155... \right) = 3021.999084
-\end{aligned}
-
-\begin{aligned}
-\texttt{max_connections} = \text{int}\Biggl[ \min \left( \frac{\texttt{FREE_MEMORY}}{\texttt{max_allowed_packet}}, 500 \right) \Biggr] = \text{int}\Biggl[ \min \left( \frac{3021.999084}{16}, 500 \right) \Biggr] = \text{int}\Biggl[ 188.87... \Biggr]
-\end{aligned}
-
-\begin{aligned}
-\texttt{max_connections} = 188
-\end{aligned}
-
-The following table provides additional example calculations of `max_connections` for all `size` settings
-and for a number of `max_allow_packet` settings.
-
-<div class="table_component" role="region" tabindex="0">
-<table>
-    <tbody>
-        <tr>
-            <td rowspan="2" align="center"><b>MariaDB <code>max_connections</code> <br/> for common combinations <br/> of <code>size</code> & <br/> <code>max_allow_packet</code></b></td>
-            <td colspan="6" align="center"><b><code>application_size</code><br><br><code>size</code> (memory in MB)</b></td>
-        </tr>
-        <tr align="center">
-            <td><b>S (128 MB)</b></td>
-            <td><b>M (288 MB)</b></td>
-            <td><b>L (1280 MB)</b></td>
-            <td><b>XL (2624 MB)</b></td>
-            <td><b>2XL (5248 MB)</b></td>
-            <td><b>4XL (10496 MB)</b></td>
-        </tr>
-        <tr align="center">
-            <td><b>1<br>(min)</b></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-        </tr>
-        <tr align="center">
-            <td><b>2</b></td>
-            <td>358</td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-        </tr>
-        <tr align="center">
-            <td><b>8</b></td>
-            <td>89</td>
-            <td>129</td>
-            <td>377</td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-        </tr>
-        <tr align="center">
-            <td><b>16<br>(default)</b></td>
-            <td>44</td>
-            <td>64</td>
-            <td>188</td>
-            <td>356</td>
-            <td><i>500</i></td>
-            <td><i>500</i></td>
-        </tr>
-        <tr align="center">
-            <td><b>32</b></td>
-            <td>22</td>
-            <td>32</td>
-            <td>94</td>
-            <td>178</td>
-            <td>342</td>
-            <td><i>500</i></td>
-        </tr>
-        <tr align="center">
-            <td><b>64</b></td>
-            <td>11</td>
-            <td>16</td>
-            <td>47</td>
-            <td>89</td>
-            <td>171</td>
-            <td>335</td>
-        </tr>
-        <tr align="center">
-            <td><b>100<br>(max)</b></td>
-            <td>7</td>
-            <td>10</td>
-            <td>30</td>
-            <td>57</td>
-            <td>109</td>
-            <td>214</td>
-        </tr>
-    </tbody>
-</table>
-</div>
+```
+        avg_memory_per_connection_mb = 4
+        free = 1280 - (50 + 1280 * 0.70) # 1280 - 946 = 334
+        max_connections = int(free // avg_memory_per_connection_mb) # 334 / 4 = 83.5 -> max_connections = 83
+```
 
 {{% note%}}
-The maximum value for `max_connections` is 500, indicated with italicized integers in the table.
-
-Also, you can **increase** `max_connections` in your environments by either:
-
-- **decreasing** the `max_allow_packet` value in your service configuration
-- or **increasing** your plan `size`
+Additionally, `max_connections` has a minimum of 15 and a maximum of 500. 
+If the calculation comes out at less than 15. It will be 15. 
+If the calculation comes out at more than 500. It will be 500. 
 {{% /note%}}

--- a/sites/platform/src/add-services/mysql/troubleshoot.md
+++ b/sites/platform/src/add-services/mysql/troubleshoot.md
@@ -88,7 +88,7 @@ Alternatively, if your worker is idle for too long it can self-terminate.
 
 You may get the following [error message](https://mariadb.com/kb/en/e1040/): `Error 1040: Too many connections`.
 A common way to solve this issue is to increase the `max_connections` property in your MariaDB service configuration.
-However, on {{% vendor/name %}}, you **cannot** configure `max_connections`, this is done automatically for you based on memory.
+However, on {{% vendor/name %}}, you **cannot** configure `max_connections` — this is done automatically for you based on memory.
 
 {{% note theme="info"%}}
 This information applies to DG3 and Professional/Grid {{% vendor/name %}} projects.</br>


### PR DESCRIPTION
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

The explanation is wrong. We don't include max_allowed_packet in the calculation. This has changed a few weeks ago in the code. 

## What's changed
I removed the max_allowed_packet advice, given it is not used at all. And explained how the calculation actually works

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [x] upsun (`sites/upsun` templates)

Also needs a change on mintlify that is similar.