### PR TITLE
solve update regions issue

### DIFF
--- a/.github/workflows/update-regions-locations.yaml
+++ b/.github/workflows/update-regions-locations.yaml
@@ -26,8 +26,26 @@ jobs:
 
       - name: Download latest regions_location.json
         run: |
-          # TODO: Replace the following line with your actual curl command
-          platform api:curl regions | jq '[ .regions[] | select(.available and .private == false) |  {"name": .id, "provider": .provider.name, "zone": .zone,"timezone": .timezone} ] | sort_by(.name)' > ./shared/data/regions_location.json
+          regions_response="$(mktemp)"
+          trap 'rm -f "${regions_response}"' EXIT
+
+          for attempt in {1..5}; do
+            if platform api:curl regions > "${regions_response}"; then
+              break
+            fi
+
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::Unable to retrieve regions after ${attempt} attempts."
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 30))
+            echo "::warning::Unable to retrieve regions. Retrying in ${sleep_seconds}s. Attempt ${attempt} of 5 failed."
+            platform clear-cache || true
+            sleep "${sleep_seconds}"
+          done
+
+          jq '[ .regions[] | select(.available and .private == false) |  {"name": .id, "provider": .provider.name, "zone": .zone,"timezone": .timezone} ] | sort_by(.name)' "${regions_response}" > ./shared/data/regions_location.json
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
Following this [downloading issue](https://github.com/platformsh/platformsh-docs/actions/runs/27799668257/job/82267045016) in updating region workflow, add a retry to avoid [emptying regions_location.json](https://github.com/platformsh/platformsh-docs/pull/5637)
<!--
Thanks for contributing to the Platform.sh docs!

If you haven't contributed before, see our [contributing guide](../CONTRIBUTING.md),
including its links to our style and formatting guides.
-->

## Why

Closes #{ISSUE_NUMBER}

<!--
  If there's an existing issue for your change, please link to it.
  If there's not an existing issue, please describe the reason for the change in detail.
-->

## What's changed

<!--
  Give an overview of the changes you made.
  Make it clear what's in scope for the review (so reviewers know what to look for).
-->

## Where are changes

Updates are for:

- [ ] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
