### PR TITLE
Update the tap user/organization name

### DIFF
--- a/sites/platform/src/domains/steps/_index.md
+++ b/sites/platform/src/domains/steps/_index.md
@@ -149,7 +149,7 @@ To configure your CDN and your domain name to point to your project:
 8. Optional: If you have multiple domains you want to be served by the same app, add a `CNAME` record for each of them.
    That includes the `www` subdomain if you are using it in your [routes configuration](/define-routes/_index.md).
 
-Adding a custom domain sets your site as [visible to search engines](/environments/search-engine-visibility.md#how-its-done).
+Adding a custom domain sets your site as [visible to search engines](/environments/search-engine-visibility.md#how-it-works).
 
 See how you can further [configure your CDN](/domains/cdn/_index.md).
 

--- a/themes/psh-docs/layouts/shortcodes/cli-installation.html
+++ b/themes/psh-docs/layouts/shortcodes/cli-installation.html
@@ -15,7 +15,7 @@ curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | 
 title=Homebrew
 highlight=bash
 +++
-brew install platformsh/tap/platformsh-cli
+brew install upsun/tap/platformsh-cli
 <--->
 +++
 title=Scoop
@@ -37,7 +37,7 @@ curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | 
 title=Homebrew
 highlight=bash
 +++
-brew install platformsh/tap/upsun-cli
+brew install upsun/tap/upsun-cli
 <--->
 +++
 title=Scoop


### PR DESCRIPTION

## Why

CLI installation command did not work as documented.

## What's changed

Updated the tap user/organization name to `upsun`, as in `upsun/tap/<name>-cli`.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
