### PR TITLE
fix(composable image): Update latest supported version

### DIFF
--- a/shared/data/composable_versions.yaml
+++ b/shared/data/composable_versions.yaml
@@ -1,7 +1,7 @@
 composable:
   versions:
     supported:
-      - "25.11"
+      - "26.05"
     available:
+      - "25.11"
       - "25.05"
-      - "24.05"


### PR DESCRIPTION

## Why

Update latest composable image version to 26.05 for parity with Flex docs.


## What's changed

In composable_versions.yaml: 
- Update latest supported version to 26.05
- Move 25.11 to available
- Remove 24.05

## Where are changes
https://fixed.docs.upsun.com/create-apps/app-reference/composable-image.html#supported-nix-channels

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
