### PR TITLE
Fix (composable): Adjust wording to remove implication that container profile can be se…

### DIFF
--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -251,9 +251,9 @@ To discover which PHP extensions and Python packages are available for these run
 
 ## Resources (CPU, memory, disk space) {#resources}
 
-By default, {{% vendor/name %}} assigns a container profile and container size to each application and service on the first deployment of a project. <br>
+{{% vendor/name %}} assigns a container profile and container size to each application and service on the first deployment of a project. <br>
 
-The container _profile_ defines and enforces a specific CPU-to-memory ratio. The default container profile for an app or service in a composable image is ``HIGH_CPU``.
+The container _profile_ defines and enforces a specific CPU-to-memory ratio. For an app or service in a composable image, the container profile is always `HIGH_CPU` and can't be changed.
 
 To change the container _size_, which is a **vertical‑scaling** action, you must [change your plan size](/administration/pricing.md#plans). When you redeploy, the container runs with the CPU‑to‑memory ratio defined by its profile, so it enforces the size you specified.
 

--- a/sites/platform/src/create-apps/image-properties/size.md
+++ b/sites/platform/src/create-apps/image-properties/size.md
@@ -36,13 +36,13 @@ The total resources allocated across all apps and services cannnot exceed what's
 
 ### Container profiles: CPU and memory
 
-By default, {{% vendor/name %}} allocates a container profile to each app and service depending on:
+{{% vendor/name %}} allocates a container profile to each app and service depending on:
 
 - The range of resources it’s expected to need
 - Your [plan size](/administration/pricing/_index.md), as resources are distributed across containers.
   Ideally you want to give databases the biggest part of your memory, and apps the biggest part of your CPU.
 
-The container profile and the [size of the container](#sizes) determine
+The container profile and the [container size](#sizes) determine
 how much CPU and memory (in [MB](/glossary/_index.md#mb)) the container gets.
 
 There are three container profiles available: ``HIGH_CPU``, ``BALANCED``, and ``HIGH_MEMORY``.


### PR DESCRIPTION

## Why

Adjust wording to remove implication that container profile can be set for composable images.

## What's changed

Current wording in composable-image.md implies the container-profile can be set by the user, but it cannot. Adjusted the wording to state that it cannot be set.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
