### PR TITLE
Remove Rust banner

### DIFF
--- a/sites/platform/src/languages/rust.md
+++ b/sites/platform/src/languages/rust.md
@@ -1,10 +1,6 @@
 ---
 title: "Rust"
-description:
-banner:
-  title: Beta Feature
-  body: The Rust runtime is currently available in Beta.
-        To share your feedback so we can improve it, add a comment to the [Rust feature card](https://devcenter.upsun.com/posts/releases/ ).
+description: "{{% vendor/name %}} supports building and deploying applications written in Rust, using Cargo to manage dependencies."
 ---
 
 {{% vendor/name %}} supports building and deploying applications written in Rust.


### PR DESCRIPTION

## Why

Rust beta banner no longer needed. 

## What's changed

Remove frontmatter banner

## Where are changes
https://fixed.docs.upsun.com/languages/rust.html

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
