### PR TITLE
Add image-versions-live shortcode for live version-status data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,10 @@ For how that structure is applied to different types of docs in this project, se
   - [Table of contents](#table-of-contents)
   - [Adding new pages](#adding-new-pages)
     - [Adding security reports](#adding-security-reports)
+  - [Version-status data for runtimes and services](#version-status-data-for-runtimes-and-services)
   - [Commit messages](#commit-messages)
   - [Review process](#review-process)
+    - [Splitting pull requests](#splitting-pull-requests)
     - [Review comment style](#review-comment-style)
     - [Checks](#checks)
 
@@ -75,6 +77,30 @@ Instead, prefer redirects that return 301 codes (Moved Permanently).
 Set them up in the [routes configuration](./.platform/routes.yaml).
 For more information, see how to [redirect routes](https://docs.platform.sh/define-routes/redirects.html).
 
+## Version-status data for runtimes and services
+
+Two shortcodes render version lists for a runtime or service, reading from different sources:
+
+- `image-versions` reads `shared/data/registry.json` (git-committed, refreshed daily by an
+  external bot). Statuses: `supported`/`deprecated`. Supports `environment=` (`grid`,
+  `dedicated-gen-2`, `dedicated-gen-3`).
+- `image-versions-live` fetches `https://meta.upsun.com/images/<id>` live at Hugo build time
+  (`resources.GetRemote`, no authentication needed). Statuses: `active`/`sunset`/`decommissioned`
+  (the `upsun.internal_status` field). It doesn't support `environment=` — the API returns one
+  flat list with no Grid/Dedicated breakdown; `?platform=`/`?environment=` query params are
+  silently ignored.
+
+The two classification systems aren't a 1:1 mapping: `internal_status: active` groups
+*both* `supported` and `deprecated` together; only `retired` maps to `sunset`. See
+[Image statuses](/learn/tutorials/upgrade-runtimes-services.md#image-statuses) for the canonical
+explainer, and link to it rather than re-describing the statuses inline on a new page.
+
+This is a phased migration: only Redis (Grid) uses Active/Sunset/Decommissioned today, and
+everything else still uses Supported/Deprecated. When another service migrates, mirror
+`redis.md`'s structure: a Grid-scoped section using `image-versions-live`, kept separate from
+any Dedicated Gen 2/3 section, which stays on `image-versions` until, or unless, that data
+becomes available too.
+
 ## Commit messages
 
 To help understand why changes happened and not repeat work already done,
@@ -116,6 +142,13 @@ To speed the process along, we may merge small changes such as spelling and form
 into your branch.
 Otherwise, we make suggestions and work with you to finalize the changes.
 <!-- vale Platform.first-person = YES -->
+
+### Splitting pull requests
+
+New Hugo shortcode infrastructure and the content that consumes it go in separate pull requests,
+even when tightly coupled: the infra PR merges first, and the content PR is stacked on it and
+rebased onto the default branch afterward. Independent changes, such as unrelated copy edits, get
+their own PR too rather than being bundled in.
 
 ### Review comment style
 

--- a/themes/psh-docs/layouts/shortcodes/image-versions-live.html
+++ b/themes/psh-docs/layouts/shortcodes/image-versions-live.html
@@ -1,0 +1,39 @@
+{{/*
+  Lists image versions matching a given Upsun internal_status (active, sunset, or
+  decommissioned), fetched live from the public Upsun meta API. Unlike
+  `image-versions`, this reads no local data file — it queries
+  https://meta.upsun.com/images/<image> at build time.
+
+  Params:
+    image  - registry image key, e.g. "redis"
+    status - one of "active", "sunset", "decommissioned"
+*/}}
+{{ $image := .Get "image" }}
+{{ $status := .Get "status" }}
+{{ $url := printf "https://meta.upsun.com/images/%s" $image }}
+
+{{ with resources.GetRemote $url }}
+  {{ with .Err }}
+    {{ errorf "image-versions-live: error fetching %s: %s" $url . }}
+  {{ else }}
+    {{ $data := . | transform.Unmarshal }}
+    {{ $matches := slice }}
+    {{ range $name, $v := $data.versions }}
+      {{ if eq $v.upsun.internal_status $status }}
+        {{ $matches = $matches | append (dict "name" $name "sortKey" (float $name)) }}
+      {{ end }}
+    {{ end }}
+    {{ $sorted := sort $matches "sortKey" "desc" }}
+    {{ if eq (len $sorted) 0 }}
+None available
+    {{ else }}
+<ul>
+{{ range $sorted }}
+  <li>{{ .name }}</li>
+{{ end }}
+</ul>
+    {{ end }}
+  {{ end }}
+{{ else }}
+  {{ errorf "image-versions-live: could not fetch %s" $url }}
+{{ end }}

--- a/themes/psh-docs/layouts/shortcodes/image-versions-live.html
+++ b/themes/psh-docs/layouts/shortcodes/image-versions-live.html
@@ -10,6 +10,14 @@
 */}}
 {{ $image := .Get "image" }}
 {{ $status := .Get "status" }}
+
+{{ if not $image }}
+  {{ errorf "image-versions-live: missing required param %q" "image" }}
+{{ end }}
+{{ if not (in (slice "active" "sunset" "decommissioned") $status) }}
+  {{ errorf "image-versions-live: invalid status %q (expected active, sunset, or decommissioned) for image %q" $status $image }}
+{{ end }}
+
 {{ $url := printf "https://meta.upsun.com/images/%s" $image }}
 
 {{ with resources.GetRemote $url }}
@@ -20,7 +28,14 @@
     {{ $matches := slice }}
     {{ range $name, $v := $data.versions }}
       {{ if eq $v.upsun.internal_status $status }}
-        {{ $matches = $matches | append (dict "name" $name "sortKey" (float $name)) }}
+        {{ $parts := split $name "." }}
+        {{ $major := ((index $parts 0) | replaceRE "[^0-9]" "" | default "0" | int) }}
+        {{ $minor := 0 }}
+        {{ $patch := 0 }}
+        {{ if ge (len $parts) 2 }}{{ $minor = ((index $parts 1) | replaceRE "[^0-9]" "" | default "0" | int) }}{{ end }}
+        {{ if ge (len $parts) 3 }}{{ $patch = ((index $parts 2) | replaceRE "[^0-9]" "" | default "0" | int) }}{{ end }}
+        {{ $sortKey := add (add (mul $major 1000000) (mul $minor 1000)) $patch }}
+        {{ $matches = $matches | append (dict "name" $name "sortKey" $sortKey) }}
       {{ end }}
     {{ end }}
     {{ $sorted := sort $matches "sortKey" "desc" }}


### PR DESCRIPTION
## Summary

Adds a new Hugo shortcode, `image-versions-live`, that fetches an image's version data live from `meta.upsun.com` at build time and lists versions matching a given Upsun `internal_status` (`active`, `sunset`, or `decommissioned`).

Unlike the existing `image-versions` shortcode, this reads no local data file (`shared/data/registry.json`) — it queries `https://meta.upsun.com/images/<image>` directly, so it can serve the Active/Sunset/Decommissioned classification for images the docs registry pipeline doesn't yet track.

**No content in this repo calls the shortcode yet.** It's added standalone here so it can be reviewed on its own merits, independent of any page that adopts it. See #5710 for the first (and currently only) consumer.

## Why a live fetch, not the existing data pipeline

`shared/data/registry.json` only tracks `supported`/`deprecated` per image — it has no equivalent to Upsun's `internal_status` (active/sunset/decommissioned) field. Getting that data into the static registry would require changes to an external tool (`meta-version-updater`) that we don't own. The public `meta.upsun.com/images/:id` endpoint already returns `internal_status` today, unauthenticated, for every image — so this shortcode reads it directly instead.

## Manual verification

This repo has no existing pattern for testing a shortcode in isolation (no `exampleSite`, no fixture pages), so this was verified manually against real data:

- `curl https://meta.upsun.com/images/redis` confirmed the endpoint is public and returns `upsun.status`/`upsun.internal_status` per version.
- A local Hugo build against a scratch test page rendered:
  - **Active**: 8.8, 8.0, 7.2, 6.2
  - **Sunset**: 7.0, 6.0, 5.0
  - **Decommissioned**: 4.0, 3.2, 3.0, 2.8
  
  — matching the real API data exactly, correctly sorted descending.
- Cold-cache build adds ~730ms (one live HTTP round trip, deduped across repeated calls to the same URL within a build); warm-cache (Hugo's local resource cache) is ~25ms.

## Trade-offs worth knowing about (for reviewers)

- **Build-time network dependency**: every build of a page using this shortcode needs network access to `meta.upsun.com`. If that endpoint is down or slow during CI, the build could fail or hang, depending on timeout config.
- **No PR-review checkpoint for content changes**: every other version-status list on this site is git-committed and reviewed via a PR (`shared/data/registry.json`, refreshed by a daily bot). A page using this shortcode can change its rendered content on every rebuild with no corresponding diff to review.
- **Grid-only**: the public API has no per-environment (Grid vs. Dedicated Gen 2/3) breakdown — confirmed by testing `?platform=` and `?environment=` query params, which are silently ignored. This shortcode can only ever answer for the flat/Grid-equivalent classification.

## Merge order

This is the first of three related PRs. **Merge this one first** — the content PR depends on it.

1. **This PR** (infra) — merge first
2. #5710 — stacked on this branch, adds the shortcode's first real usage in `redis.md`
3. #5711 — independent, no dependency on the other two, can merge any time

## Test plan

- [ ] Confirm `security.http` config in `sites/platform/config/_default/config.yaml` permits the `GET` request to `meta.upsun.com` in CI (not just locally)
- [ ] Local `hugo` build succeeds with no template errors