### PR TITLE
Serve Redis Grid version statuses live, split out Dedicated Gen 2

### DIFF
--- a/sites/platform/src/add-services/redis.md
+++ b/sites/platform/src/add-services/redis.md
@@ -23,51 +23,52 @@ If you use one of the following frameworks, follow its guide:
 - [Spring](/guides/spring/redis.md)
 - [WordPress](/guides/wordpress/redis.md)
 
-## Supported versions
+## Grid versions
+
+### Active versions
+
+See [Image statuses](/learn/tutorials/upgrade-runtimes-services.md#image-statuses) for what Active means for Redis specifically.
+Some Active versions may be past their upstream end of life; {{% vendor/name %}} applies security updates only where upstream still provides them.
+Dedicated Gen 2 doesn't use this classification — see [Dedicated Gen 2 versions](#dedicated-gen-2-versions).
 
 You can select the major and minor version.
 
 Patch versions are applied periodically for bug fixes and the like. When you deploy your app, you always get the latest available patches.
 
-<table>
-    <thead>
-        <tr>
-            <th>Grid</th>
-            <th>Dedicated Gen 2</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{< image-versions image="redis" status="supported" environment="grid" >}}</td>
-            <td>{{< image-versions image="redis" status="supported" environment="dedicated-gen-2" >}}</thd>
-        </tr>
-    </tbody>
-</table>
+{{< image-versions-live image="redis" status="active" >}}
 
-### Deprecated versions
+### Sunset versions
 
-The following versions are [deprecated](/glossary.html#deprecated-versions).
-They're available, but they aren't receiving security updates from upstream and aren't guaranteed to work.
-They'll be removed in the future,
-so migrate to one of the [supported versions](#supported-versions).
+The following versions are still available in your projects, including code pushes, but new projects can't use them.
+These versions are decommissioned 180 calendar days after entering Sunset.
+The exact decommission date is shown on your project's Overview page and on the relevant activity in the **Activity** panel.
+[Upgrade](/learn/tutorials/upgrade-runtimes-services.md) to one of the [active versions](#active-versions) before that date.
 
-<table>
-    <thead>
-        <tr>
-            <th>Grid</th>
-            <th>Dedicated Gen 2</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{< image-versions image="redis" status="deprecated" environment="grid" >}}</td>
-            <td>{{< image-versions image="redis" status="deprecated" environment="dedicated-gen-2" >}}</thd>
-        </tr>
-    </tbody>
-</table>
+{{< image-versions-live image="redis" status="sunset" >}}
+
+### Decommissioned versions
+
+{{% vendor/name %}} no longer supports decommissioned versions.
+Existing projects using one continue to run as is, but all code pushes are blocked.
+[Upgrade](/learn/tutorials/upgrade-runtimes-services.md) to an [active version](#active-versions) to continue deploying.
+
+{{< image-versions-live image="redis" status="decommissioned" >}}
 
 Note that versions 3.0 and higher support up to 64 different databases per instance of the service,
 while Redis 2.8 only supports a single database.
+
+## Dedicated Gen 2 versions
+
+Dedicated Gen 2 doesn't use the Active/Sunset/Decommissioned lifecycle above.
+It still uses the [Supported/Deprecated classification](/learn/tutorials/upgrade-runtimes-services.md#image-statuses).
+
+### Supported versions
+
+{{< image-versions image="redis" status="supported" environment="dedicated-gen-2" >}}
+
+### Deprecated versions
+
+{{< image-versions image="redis" status="deprecated" environment="dedicated-gen-2" >}}
 
 ## Service types
 


### PR DESCRIPTION
## ⚠️ Depends on #5709 — do not merge before it

This PR's base branch is `infra/image-versions-live-shortcode` (#5709), not `main`. **Merge #5709 first.** Once it merges, GitHub should retarget this PR's base to `main` automatically; if not, retarget it manually before merging. This PR's diff will otherwise appear to include the shortcode file — that's expected until #5709 merges.

## Summary

Replaces the hand-maintained Grid Active/Sunset/Decommissioned version lists in `redis.md` with the `image-versions-live` shortcode (added in #5709), sourcing the data from `meta.upsun.com` instead of a static list that had to be updated by hand every time Redis's version lifecycle changed.

Also splits Dedicated Gen 2 into its own **"Dedicated Gen 2 versions"** section using the existing `image-versions` shortcode (`registry.json`-backed), since DG2 uses the Supported/Deprecated model, not Active/Sunset/Decommissioned. The previous single-table layout implied a Grid/DG2 parity that doesn't exist, and mislabeled DG2's "deprecated" versions as "sunset" — even though deprecated actually maps to *active* under the real classification (`internal_status: active` groups both `supported` and `deprecated`; only `retired` maps to `sunset`).

## Why this is split from the shortcode itself

The shortcode has no reason to exist without a consumer, and reviewing unused template logic in isolation is hard to validate — this PR is where the shortcode actually gets exercised and where its output was verified against real data. See #5709 for the infra-only review; this PR is where content review belongs.

## Verification

Local Hugo build (865 pages, no errors) confirms:
- Rendered Grid Active/Sunset/Decommissioned lists match `meta.upsun.com/images/redis` exactly
- All internal anchors resolve correctly (`#active-versions`, `#dedicated-gen-2-versions`, etc.) after the heading restructure
- No other page in the site links to the old anchors that moved

## Merge order

1. #5709 (infra) — merge first
2. **This PR** — merge once #5709 is in
3. #5711 — independent, can merge any time

## Test plan

- [ ] Confirm #5709 is merged before merging this
- [ ] Spot-check the rendered `redis.md` page in a preview/staging build
- [ ] Confirm Dedicated Gen 2's "Active" framing reads correctly now that it's a separate section from Grid's