### PR TITLE
feat(support url updates): Update Blackfire support page and landing page name

### DIFF
--- a/sites/platform/src/increase-observability/integrate-observability/blackfire.md
+++ b/sites/platform/src/increase-observability/integrate-observability/blackfire.md
@@ -196,7 +196,7 @@ If you're experiencing issues with Blackfire and [troubleshooting](#troubleshoot
 
 1. Retrieve [startup errors](#1-retrieve-startup-errors).
 2. Retrieve your [Blackfire logs](#2-retrieve-your-blackfire-logs).
-3. [Create a support ticket](https://support.upsun.com/hc/en-us/requests/new) to send this data to Blackfire Support.
+3. [Create a support ticket](https://support.blackfire.upsun.com/hc/en-us) to send this data to Blackfire Support.
 
 ### 1. Retrieve startup errors
 

--- a/sites/platform/src/learn/overview/get-support.md
+++ b/sites/platform/src/learn/overview/get-support.md
@@ -14,7 +14,7 @@ Open a support ticket to report infrastructure, application container, or build 
 
 1. [Open the Console]({{% vendor/urlraw "console" %}}).
 1. In the upper right corner, click **Help**, then select **Support**.
-1. On the {{% vendor/company_name %}} Community landing page, click **Create a new request**.
+1. On the {{% vendor/company_name %}} Help Center landing page, click **Create a new request**.
 1. On the "Submit a request" page, choose the request type, then complete and submit the form.
 
 **Shortcuts**


### PR DESCRIPTION

## Why

Related to #5707 


## What's changed

Updates name of the landing page Upsun Help Center, not Upsun Community.

## Where are changes

Updates are for:

- [x] platform (`sites/platform` templates)
- [ ] upsun (`sites/upsun` templates)
