### PR TITLE
Fix YAML config examples to follow Fixed convention (remove applications:/services:/routes: wrapper keys)

### DIFF
--- a/sites/platform/src/add-services/mercure.md
+++ b/sites/platform/src/add-services/mercure.md
@@ -155,15 +155,14 @@ title=Using default endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  <APP_NAME>:
-    # Relationships enable access from this app to a given service.
-    # The example below shows simplified configuration leveraging a default service
-    # (identified from the relationship name) and a default endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      <SERVICE_NAME>: 
+# The name of the app container. Must be unique within a project.
+name: <APP_NAME>
+# Relationships enable access from this app to a given service.
+# The example below shows simplified configuration leveraging a default service
+# (identified from the relationship name) and a default endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
+  <SERVICE_NAME>: 
 ```
 
 You can define `<SERVICE_NAME>` as you like, so long as it's unique between all defined services
@@ -184,16 +183,15 @@ title=Using explicit endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  <APP_NAME>:
-    # Relationships enable access from this app to a given service.
-    # The example below shows configuration with an explicitly set service name and endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      <RELATIONSHIP_NAME>:
-        service: <SERVICE_NAME>
-        endpoint: mercure
+# The name of the app container. Must be unique within a project.
+name: <APP_NAME>
+# Relationships enable access from this app to a given service.
+# The example below shows configuration with an explicitly set service name and endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
+  <RELATIONSHIP_NAME>:
+    service: <SERVICE_NAME>
+    endpoint: mercure
 ```
 
 You can define ``<SERVICE_NAME>`` and ``<RELATIONSHIP_NAME>`` as you like, so long as it's unique between all defined services and relationships

--- a/sites/platform/src/add-services/mysql/_index.md
+++ b/sites/platform/src/add-services/mysql/_index.md
@@ -511,17 +511,17 @@ For example, if you define a `mariadb` database as follows:
 mariadb:
   type: mariadb:{{% latest "mariadb" %}}
   disk: 2048
-    configuration:
-      schemas:
-        - main
-    endpoints:
-      admin:
-        default_schema: main
-        privileges:
-          main: admin
-      reporter:
-        privileges:
-          main: ro
+  configuration:
+    schemas:
+      - main
+  endpoints:
+    admin:
+      default_schema: main
+      privileges:
+        main: admin
+    reporter:
+      privileges:
+        main: ro
 ```
 
 To create a replica of the `mariadb` database and allow your app to connect to it

--- a/sites/platform/src/add-services/mysql/mysql-readonly-replication.md
+++ b/sites/platform/src/add-services/mysql/mysql-readonly-replication.md
@@ -54,49 +54,48 @@ Be sure to:
 - **Important:** Use `replicator` as the endpoint name when you define the replica service. This is a special endpoint name that the replica service uses to connect to the database.
 
 ```yaml {configFile="services"}
-services:
-  db:
-    type: mariadb:<VERSION>
-    disk: <SIZE>
-    configuration:
-      schemas:
-        - main
-      endpoints:
-        main:
-          default_schema: main
-          privileges:
-              main: admin
-        replicator:
-          privileges:
-            main: replication
-
-  db-replica1:
-    type: mariadb-replica:<VERSION>
-    disk: <SIZE>
-    configuration:
-      schemas:
-        - main
-      endpoints:
-        main:
-          default_schema: main
-          privileges:
+db:
+  type: mariadb:<VERSION>
+  disk: <SIZE>
+  configuration:
+    schemas:
+      - main
+    endpoints:
+      main:
+        default_schema: main
+        privileges:
             main: admin
-    relationships:
-      primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
+      replicator:
+        privileges:
+          main: replication
 
-  db-replica2:
-    type: mariadb-replica:<VERSION>
-    disk: <SIZE>
-    configuration:
-      schemas:
-        - main
-      endpoints:
-        main:
-          default_schema: main
-          privileges:
-            main: admin
-    relationships:
-      primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
+db-replica1:
+  type: mariadb-replica:<VERSION>
+  disk: <SIZE>
+  configuration:
+    schemas:
+      - main
+    endpoints:
+      main:
+        default_schema: main
+        privileges:
+          main: admin
+  relationships:
+    primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
+
+db-replica2:
+  type: mariadb-replica:<VERSION>
+  disk: <SIZE>
+  configuration:
+    schemas:
+      - main
+    endpoints:
+      main:
+        default_schema: main
+        privileges:
+          main: admin
+  relationships:
+    primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
 ```
 
 ### How it works

--- a/sites/platform/src/add-services/postgresql/postgresql-readonly-replication.md
+++ b/sites/platform/src/add-services/postgresql/postgresql-readonly-replication.md
@@ -45,40 +45,39 @@ Be sure to:
 - **Important:** Use `replicator` as the endpoint name when you define the replica service. This is a special endpoint name that the replica service uses to connect to the database.
 
 ```yaml {configFile="services"}
-services:
-  db:
-    type: postgresql:<VERSION>
-    disk: <SIZE>
-    configuration:
-      extensions:
-        - postgis
-      endpoints:
-        replicator:
-          replication: true
+db:
+  type: postgresql:<VERSION>
+  disk: <SIZE>
+  configuration:
+    extensions:
+      - postgis
+    endpoints:
+      replicator:
+        replication: true
 
-  db-replica1:
-    type: postgres-replica:<VERSION>
-    disk: <SIZE>
-    configuration:
-      endpoints:
-        postgresql:
-          default_database: main
-      extensions:
-        - postgis
-    relationships: 
-      primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
+db-replica1:
+  type: postgres-replica:<VERSION>
+  disk: <SIZE>
+  configuration:
+    endpoints:
+      postgresql:
+        default_database: main
+    extensions:
+      - postgis
+  relationships: 
+    primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
 
-  db-replica2:
-    type: postgres-replica:<VERSION>
-    disk: <SIZE>
-    configuration:
-      endpoints:
-        postgresql:
-          default_database: main
-      extensions:
-        - postgis
-    relationships: 
-      primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
+db-replica2:
+  type: postgres-replica:<VERSION>
+  disk: <SIZE>
+  configuration:
+    endpoints:
+      postgresql:
+        default_database: main
+    extensions:
+      - postgis
+  relationships: 
+    primary: db:replicator # Do not change the name `primary`. The service expects to receive this name.
 ```
 
 ### How it works

--- a/sites/platform/src/add-services/redis.md
+++ b/sites/platform/src/add-services/redis.md
@@ -738,7 +738,7 @@ web:
   locations:
     '/':
       root: 'web'
-        passthru: '/index.php'
+      passthru: '/index.php'
 ```
 
 <--->

--- a/sites/platform/src/add-services/solr.md
+++ b/sites/platform/src/add-services/solr.md
@@ -440,36 +440,34 @@ As a result, bundled modules shipped under `/opt/solr/<VERSION>/modules/` (such 
 By default, no bundled modules are loaded &mdash; only the modules you explicitly request are placed on the classpath. This keeps small instances from paying the memory cost of modules they don't use.
 
 ```yaml {configFile="services"}
-services:
-  # The name of the service container. Must be unique within a project.
-  solr:
-    type: solr:{{% latest "solr" %}}
-    configuration:
-      modules:
-        - extraction
-        - analysis-extras
-        - langid
-        - ltr
-      cores:
-        mainindex:
-          conf_dir: !archive "core1-conf"
-      endpoints:
-        main:
-          core: mainindex
+# The name of the service container. Must be unique within a project.
+solr:
+  type: solr:{{% latest "solr" %}}
+  configuration:
+    modules:
+      - extraction
+      - analysis-extras
+      - langid
+      - ltr
+    cores:
+      mainindex:
+        conf_dir: !archive "core1-conf"
+    endpoints:
+      main:
+        core: mainindex
 ```
 
 If you're upgrading from Solr 9.6 or earlier and your configset relies on `<lib>` directives (for example, the default Drupal [`search_api_solr`](https://www.drupal.org/project/search_api_solr) configset), add the matching modules to `configuration.modules` when you bump the version:
 
 ```yaml {configFile="services"}
-services:
-  solr:
-    type: solr:9.9
-    configuration:
-      modules:
-        - extraction
-        - analysis-extras
-        - langid
-        - ltr
+solr:
+  type: solr:9.9
+  configuration:
+    modules:
+      - extraction
+      - analysis-extras
+      - langid
+      - ltr
 ```
 
 The `configuration.modules` field is supported only on Solr 9.9 and later.

--- a/sites/platform/src/add-services/valkey.md
+++ b/sites/platform/src/add-services/valkey.md
@@ -160,15 +160,14 @@ title=Using default endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  <APP_NAME>:
-    # Relationships enable access from this app to a given service.
-    # The example below shows simplified configuration leveraging a default service
-    # (identified from the relationship name) and a default endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      <SERVICE_NAME>:
+# The name of the app container. Must be unique within a project.
+name: <APP_NAME>
+# Relationships enable access from this app to a given service.
+# The example below shows simplified configuration leveraging a default service
+# (identified from the relationship name) and a default endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
+  <SERVICE_NAME>:
 ```
 
 You can define `<SERVICE_NAME>` as you like, so long as it’s unique between all defined services and matches in both the application and services configuration.
@@ -186,16 +185,15 @@ title=Using explicit endpoints
 +++
 
 ```yaml {configFile="services"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  <APP_NAME>:
-    # Relationships enable access from this app to a given service.
-    # The example below shows configuration with an explicitly set service name and endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      <RELATIONSHIP_NAME>:
-        service: <SERVICE_NAME>
-        endpoint: valkey
+# The name of the app container. Must be unique within a project.
+name: <APP_NAME>
+# Relationships enable access from this app to a given service.
+# The example below shows configuration with an explicitly set service name and endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
+  <RELATIONSHIP_NAME>:
+    service: <SERVICE_NAME>
+    endpoint: valkey
 ```
 
 You can define ``<SERVICE_NAME>`` and ``<RELATIONSHIP_NAME>`` as you like, so long as it's unique between all defined services and relationships
@@ -219,19 +217,18 @@ title=Using default endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  <APP_NAME>:
-    # PHP extensions.
-    runtime:
-      extensions:
-        - redis
-    # Relationships enable access from this app to a given service.
-    # The example below shows simplified configuration leveraging a default service
-    # (identified from the relationship name) and a default endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      <SERVICE_NAME>:
+# The name of the app container. Must be unique within a project.
+name: <APP_NAME>
+# PHP extensions.
+runtime:
+  extensions:
+    - redis
+# Relationships enable access from this app to a given service.
+# The example below shows simplified configuration leveraging a default service
+# (identified from the relationship name) and a default endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
+  <SERVICE_NAME>:
 ```
 
 <--->
@@ -241,20 +238,19 @@ title=Using explicit endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  <APP_NAME>:
-    # PHP extensions.
-    runtime:
-      extensions:
-          - redis
-    # Relationships enable access from this app to a given service.
-    # The example below shows configuration with an explicitly set service name and endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      <RELATIONSHIP_NAME>:
-        service: <SERVICE_NAME>
-        endpoint: valkey
+# The name of the app container. Must be unique within a project.
+name: <APP_NAME>
+# PHP extensions.
+runtime:
+  extensions:
+      - redis
+# Relationships enable access from this app to a given service.
+# The example below shows configuration with an explicitly set service name and endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
+  <RELATIONSHIP_NAME>:
+    service: <SERVICE_NAME>
+    endpoint: valkey
 ```
 
 {{< /codetabs >}}
@@ -581,37 +577,37 @@ title=Using default endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  myapp:
-    source:
-      root: "myapp"
+# The name of the app container. Must be unique within a project.
+name: myapp
+source:
+  root: "myapp"
 
-    type: "php:{{% latest "php" %}}"
+type: "php:{{% latest "php" %}}"
 
-    # PHP extensions.
-    runtime:
-      extensions:
-        - redis
+# PHP extensions.
+runtime:
+  extensions:
+    - redis
 
-    relationships:
-      valkeysession:
-
-    variables:
-      php:
-        session.save_handler: valkey
-        session.save_path: "tcp://{{< variable "HOSTNAME" >}}:{{< variable "PORT" >}}"
-
-    web:
-      locations:
-        '/':
-          root: 'web'
-          passthru: '/index.php'
-
-services:
-  # The name of the service container. Must be unique within a project.
+relationships:
   valkeysession:
-    type: "valkey-persistent:{{% latest "valkey" %}}"
+
+variables:
+  php:
+    session.save_handler: valkey
+    session.save_path: "tcp://{{< variable "HOSTNAME" >}}:{{< variable "PORT" >}}"
+
+web:
+  locations:
+    '/':
+      root: 'web'
+      passthru: '/index.php'
+```
+
+```yaml {configFile="services"}
+# The name of the service container. Must be unique within a project.
+valkeysession:
+  type: "valkey-persistent:{{% latest "valkey" %}}"
 ```
 
 <--->
@@ -621,42 +617,42 @@ title=Using explicit endpoints
 +++
 
 ```yaml {configFile="app"}
-applications:
-  # The name of the app container. Must be unique within a project.
-  myapp:
-    source:
-      root: "myapp"
+# The name of the app container. Must be unique within a project.
+name: myapp
+source:
+  root: "myapp"
 
-    type: "php:{{% latest "php" %}}"
+type: "php:{{% latest "php" %}}"
 
-    # PHP extensions.
-    runtime:
-      extensions:
-        - redis
+# PHP extensions.
+runtime:
+  extensions:
+    - redis
 
-    # Relationships enable access from this app to a given service.
-    # The example below shows configuration with an explicitly set service name and endpoint.
-    # See the Application reference for all options for defining relationships and endpoints.
-    relationships:
-      valkeysession:
-        service: valkeysession
-        endpoint: valkey
-
-    variables:
-      php:
-        session.save_handler: valkey
-        session.save_path: "tcp://{{< variable "HOSTNAME" >}}:{{< variable "PORT" >}}"
-
-    web:
-      locations:
-        '/':
-          root: 'web'
-          passthru: '/index.php'
-
-services:
-  # The name of the service container. Must be unique within a project.
+# Relationships enable access from this app to a given service.
+# The example below shows configuration with an explicitly set service name and endpoint.
+# See the Application reference for all options for defining relationships and endpoints.
+relationships:
   valkeysession:
-    type: "valkey-persistent:{{% latest "valkey" %}}"
+    service: valkeysession
+    endpoint: valkey
+
+variables:
+  php:
+    session.save_handler: valkey
+    session.save_path: "tcp://{{< variable "HOSTNAME" >}}:{{< variable "PORT" >}}"
+
+web:
+  locations:
+    '/':
+      root: 'web'
+      passthru: '/index.php'
+```
+
+```yaml {configFile="services"}
+# The name of the service container. Must be unique within a project.
+valkeysession:
+  type: "valkey-persistent:{{% latest "valkey" %}}"
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/add-services/valkey.md
+++ b/sites/platform/src/add-services/valkey.md
@@ -140,10 +140,9 @@ For example:
 To define the service, use the `valkey-persistent` endpoint:
 
 ```yaml {configFile="services"}
-services:
-  # The name of the service container. Must be unique within a project.
-  <SERVICE_NAME>:
-    type: valkey-persistent:<VERSION>
+# The name of the service container. Must be unique within a project.
+<SERVICE_NAME>:
+  type: valkey-persistent:<VERSION>
 ```
 
 Note that changing the name of the service replaces it with a brand new service and all existing data is lost.
@@ -501,12 +500,11 @@ When Valkey reaches its memory limit, it triggers a cache cleanup.
 To customize those cache cleanups, set up an eviction policy such as the following:
 
 ```yaml {configFile="services"}
-services:
-  # The name of the service container. Must be unique within a project.
-  valkey:
-    type: "valkey:{{% latest "valkey" %}}"
-    configuration:
-      maxmemory_policy: allkeys-lfu
+# The name of the service container. Must be unique within a project.
+valkey:
+  type: "valkey:{{% latest "valkey" %}}"
+  configuration:
+    maxmemory_policy: allkeys-lfu
 ```
 
 The following table presents the possible values:

--- a/sites/platform/src/create-apps/app-reference/composable-image.md
+++ b/sites/platform/src/create-apps/app-reference/composable-image.md
@@ -28,7 +28,9 @@ You can also skip directly to this [comprehensive example](/create-apps/_index.m
 
 ## Top-level properties
 
-All application configuration takes place in a `{{< vendor/configfile "app" >}}` file, with each application configured under a unique key beneath the top-level `applications` key.
+All application configuration takes place in a `{{< vendor/configfile "app" >}}` file.
+For a single app, its properties sit directly at the top level of the file.
+For multiple apps, each application is configured under a unique key at the top level of `{{< vendor/configfile "apps" >}}`.
 
 The following table presents all of the properties available to each unique application `name`.
 
@@ -71,9 +73,8 @@ Required for all applications that use the composable image. Defines the version
 For example, to specify the Nix channel `{{% latest composable %}}` for `{{< variable "APP_NAME" >}}`, use the following syntax:
 
 ```yaml {configFile="apps"}
-applications:
-  {{% variable "APP_NAME" %}}:
-      type: "composable:{{% latest composable %}}"
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
 ```
 
 ### Supported Nix channels
@@ -129,33 +130,32 @@ The `{{< vendor/configfile "app" >}}` file excerpt below shows the following `st
   - `python313Packages.jupyterlab` (with config) and `wkhtmltopdf` from the `unstable` channel
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    stack:
-      runtimes:
-        - "php@8.4":
-            extensions:
-              - apcu
-              - pdo_sqlite
-              - facedetect
-              - sodium
-              - xsl
-              - name: blackfire   # php@8.4 extension
-                configuration:    # extension subkeys
-                    server_id: {{% variable "SERVER_ID" %}}
-                    server_token: {{% variable "SERVER_TOKEN" %}}
-            disabled_extensions:
-              - gd
-        - "nodejs@{{% latest "nodejs" %}}"
-        - "python@{{% latest "python" %}}"
-      packages:
-        - yarn                      # Package manager
-        - python313Packages.yq      # Python package
-        - package: python313Packages.jupyterlab
-          channel: unstable
-        - package: wkhtmltopdf      # Conversion tool
-          channel: unstable
+name: {{% variable "APP_NAME" %}}
+type: "composable:{{% latest composable %}}"
+stack:
+  runtimes:
+    - "php@8.4":
+        extensions:
+          - apcu
+          - pdo_sqlite
+          - facedetect
+          - sodium
+          - xsl
+          - name: blackfire   # php@8.4 extension
+            configuration:    # extension subkeys
+                server_id: {{% variable "SERVER_ID" %}}
+                server_token: {{% variable "SERVER_TOKEN" %}}
+        disabled_extensions:
+          - gd
+    - "nodejs@{{% latest "nodejs" %}}"
+    - "python@{{% latest "python" %}}"
+  packages:
+    - yarn                      # Package manager
+    - python313Packages.yq      # Python package
+    - package: python313Packages.jupyterlab
+      channel: unstable
+    - package: wkhtmltopdf      # Conversion tool
+      channel: unstable
 ```
 
 {{% note theme=warning title="Warning" %}}
@@ -257,7 +257,7 @@ The container _profile_ defines and enforces a specific CPU-to-memory ratio. For
 
 To change the container _size_, which is a **vertical‑scaling** action, you must [change your plan size](/administration/pricing.md#plans). When you redeploy, the container runs with the CPU‑to‑memory ratio defined by its profile, so it enforces the size you specified.
 
-If you define **multiple runtimes** in an application's `.applications.<app_name>.stack.runtimes` key, you must [change your plan size](/administration/pricing.md#plans) to Medium (`M`) or larger.
+If you define **multiple runtimes** in an application's `stack.runtimes` key, you must [change your plan size](/administration/pricing.md#plans) to Medium (`M`) or larger.
 
 
 ### Downsize a disk
@@ -279,24 +279,23 @@ The following sample configuration includes two applications:
   In this app, PHP is the primary runtime and is started automatically (PHP-FPM also starts automatically when PHP is the primary runtime). For details, see the [PHP as a primary runtime](#php-as-a-primary-runtime) section in this topic.
 
 
-```yaml {configFile="app"}
-applications:
-  frontend:
-    # this app uses the single-runtime image with a specific node.js runtime
-    type: 'nodejs:{{% latest "nodejs" %}}'
-  backend:
-    # this app uses the composable image and specifies two runtimes
-    type: "composable:{{% latest composable %}}"
-    stack:
-      runtimes:
-        - "php@8.4":
-            extensions:
-              - apcu
-              - sodium
-              - xsl
-              - pdo_sqlite
-        - "python@3.13"
-      packages:
-        - "python313Packages.yq" # python package specific
+```yaml {configFile="apps"}
+frontend:
+  # this app uses the single-runtime image with a specific node.js runtime
+  type: 'nodejs:{{% latest "nodejs" %}}'
+backend:
+  # this app uses the composable image and specifies two runtimes
+  type: "composable:{{% latest composable %}}"
+  stack:
+    runtimes:
+      - "php@8.4":
+          extensions:
+            - apcu
+            - sodium
+            - xsl
+            - pdo_sqlite
+      - "python@3.13"
+    packages:
+      - "python313Packages.yq" # python package specific
 ```
 

--- a/sites/platform/src/create-apps/app-reference/single-runtime-image.md
+++ b/sites/platform/src/create-apps/app-reference/single-runtime-image.md
@@ -126,24 +126,23 @@ The format for package names and version constraints are defined by the specific
 An example of dependencies in multiple languages:
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'nodejs:{{% latest "nodejs" %}}'
-    source:
-      root: "/"
-    dependencies:
-      php: # Specify one Composer package per line.
-        drush/drush: '8.0.0'
-        composer/composer: '^2'
-      python2: # Specify one Python 2 package per line.
-        behave: '*'
-        requests: '*'
-      python3: # Specify one Python 3 package per line.
-        numpy: '*'
-      ruby: # Specify one Bundler package per line.
-        sass: '3.4.7'
-      nodejs: # Specify one NPM package per line.
-        pm2: '^4.5.0'
+name: {{% variable "APP_NAME" %}}
+type: 'nodejs:{{% latest "nodejs" %}}'
+source:
+  root: "/"
+dependencies:
+  php: # Specify one Composer package per line.
+    drush/drush: '8.0.0'
+    composer/composer: '^2'
+  python2: # Specify one Python 2 package per line.
+    behave: '*'
+    requests: '*'
+  python3: # Specify one Python 3 package per line.
+    numpy: '*'
+  ruby: # Specify one Bundler package per line.
+    sass: '3.4.7'
+  nodejs: # Specify one NPM package per line.
+    pm2: '^4.5.0'
 ```
 
 ## `runtime` {#runtime}
@@ -171,32 +170,30 @@ See [how to configure extensions with the composable image](/create-apps/app-ref
 You can enable [PHP extensions](/languages/php/extensions.md) just with a list of extensions:
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'php:{{% latest "php" %}}'
-    source:
-      root: "/"
-    runtime:
-      extensions:
-        - geoip
-        - tidy
+name: {{% variable "APP_NAME" %}}
+type: 'php:{{% latest "php" %}}'
+source:
+  root: "/"
+runtime:
+  extensions:
+    - geoip
+    - tidy
 ```
 
 Alternatively, if you need to include configuration options, use a dictionary for that extension:
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'php:{{% latest "php" %}}'
-    source:
-      root: "/"
-    runtime:
-      extensions:
-        - geoip
-        - name: blackfire
-          configuration:
-            server_id: foo
-            server_token: bar
+name: {{% variable "APP_NAME" %}}
+type: 'php:{{% latest "php" %}}'
+source:
+  root: "/"
+runtime:
+  extensions:
+    - geoip
+    - name: blackfire
+      configuration:
+        server_id: foo
+        server_token: bar
 ```
 
 In this case, the `name` property is required.
@@ -224,23 +221,22 @@ The following sample configuration includes two applications:
   In this app, PHP is the primary runtime and is started automatically (PHP-FPM also starts automatically when PHP is the primary runtime). For details, see the [PHP as a primary runtime](/create-apps/app-reference/composable-image.md#php-as-a-primary-runtime) section in the Composable image topic.
 
 
-```yaml {configFile="app"}
-applications:
-  frontend:
-    # this app uses the single-runtime image with a specific node.js runtime
-    type: 'nodejs:{{% latest "nodejs" %}}'
-  backend:
-    # this app uses the composable image and specifies two runtimes
-    type: "composable:8.4"
-    stack:
-      runtimes:
-        - "php@8.4":
-            extensions:
-              - apcu
-              - sodium
-              - xsl
-              - pdo_sqlite
-        - "python@3.13"
-      packages:
-        - "python313Packages.yq" # python package specific
+```yaml {configFile="apps"}
+frontend:
+  # this app uses the single-runtime image with a specific node.js runtime
+  type: 'nodejs:{{% latest "nodejs" %}}'
+backend:
+  # this app uses the composable image and specifies two runtimes
+  type: "composable:8.4"
+  stack:
+    runtimes:
+      - "php@8.4":
+          extensions:
+            - apcu
+            - sodium
+            - xsl
+            - pdo_sqlite
+      - "python@3.13"
+    packages:
+      - "python313Packages.yq" # python package specific
 ```

--- a/sites/platform/src/create-apps/image-properties/access.md
+++ b/sites/platform/src/create-apps/image-properties/access.md
@@ -26,13 +26,12 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "python:{{% latest "python" %}}"
-    source:
-      root: "/"
-    access:
-      ssh: admin
+name: {{% variable "APP_NAME" %}}
+type: "python:{{% latest "python" %}}"
+source:
+  root: "/"
+access:
+  ssh: admin
 ```
 
 <--->
@@ -41,16 +40,15 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "python@{{% latest python %}}" ]
-    access:
-      ssh: admin
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "python@{{% latest python %}}" ]
+  access:
+    ssh: admin
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/create-apps/image-properties/additional_hosts.md
+++ b/sites/platform/src/create-apps/image-properties/additional_hosts.md
@@ -23,14 +23,13 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'nodejs:{{% latest "nodejs" %}}'
-    source:
-      root: "/"
-    additional_hosts:
-      api.example.com: "192.0.2.23"
-      web.example.com: "203.0.113.42"
+name: {{% variable "APP_NAME" %}}
+type: 'nodejs:{{% latest "nodejs" %}}'
+source:
+  root: "/"
+additional_hosts:
+  api.example.com: "192.0.2.23"
+  web.example.com: "203.0.113.42"
 ```
 
 <--->
@@ -39,17 +38,16 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "nodejs@{{% latest nodejs %}}" ]
-    additional_hosts:
-      api.example.com: "192.0.2.23"
-      web.example.com: "203.0.113.42"
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "nodejs@{{% latest nodejs %}}" ]
+  additional_hosts:
+    api.example.com: "192.0.2.23"
+    web.example.com: "203.0.113.42"
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/create-apps/image-properties/crons.md
+++ b/sites/platform/src/create-apps/image-properties/crons.md
@@ -48,18 +48,17 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'nodejs:{{% latest "nodejs" %}}'  
-    source:
-      root: "/"
-    crons:
-      mycommand:
-        spec: 'H * * * *'
-        commands:
-          start: sleep 60 && echo sleep-60-finished && date
-          stop: killall sleep
-        shutdown_timeout: 18
+name: {{% variable "APP_NAME" %}}
+type: 'nodejs:{{% latest "nodejs" %}}'  
+source:
+  root: "/"
+crons:
+  mycommand:
+    spec: 'H * * * *'
+    commands:
+      start: sleep 60 && echo sleep-60-finished && date
+      stop: killall sleep
+    shutdown_timeout: 18
 ```
 <--->
 
@@ -67,21 +66,20 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack:
-      runtimes: [ 'nodejs:{{% latest "nodejs" %}}' ]
-    crons:
-      mycommand:
-        spec: 'H * * * *'
-        commands:
-          start: sleep 60 && echo sleep-60-finished && date
-          stop: killall sleep
-        shutdown_timeout: 18
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack:
+    runtimes: [ 'nodejs:{{% latest "nodejs" %}}' ]
+  crons:
+    mycommand:
+      spec: 'H * * * *'
+      commands:
+        start: sleep 60 && echo sleep-60-finished && date
+        stop: killall sleep
+      shutdown_timeout: 18
 ```
 
 {{< /codetabs >}}
@@ -288,19 +286,18 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  myapp:
-    source:
-      root: "/"
-    type: 'php:{{% latest "php" %}}'
-    crons:
-      update:
-        spec: '0 0 * * *'
-        commands:
-          start: |
-            if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
-              {{% vendor/cli %}} source-operation:run update --no-wait --yes
-            fi
+name: myapp
+source:
+  root: "/"
+type: 'php:{{% latest "php" %}}'
+crons:
+  update:
+    spec: '0 0 * * *'
+    commands:
+      start: |
+        if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
+          {{% vendor/cli %}} source-operation:run update --no-wait --yes
+        fi
 ```
 <--->
 
@@ -308,23 +305,22 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  myapp:
-    source:
-      root: "/"
-    type: "composable:{{% latest composable %}}"
-    stack: 
-      runtimes: [ "php@{{% latest php %}}" ]
-    crons:
-      update:
-        spec: '0 0 * * *'
-        commands:
-          start: |
-            if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
-              {{% vendor/cli %}} backup:create --yes --no-wait
-              {{% vendor/cli %}} source-operation:run update --no-wait --yes
-            fi
+```yaml {configFile="apps"}
+myapp:
+  source:
+    root: "/"
+  type: "composable:{{% latest composable %}}"
+  stack: 
+    runtimes: [ "php@{{% latest php %}}" ]
+  crons:
+    update:
+      spec: '0 0 * * *'
+      commands:
+        start: |
+          if [ "$PLATFORM_ENVIRONMENT_TYPE" = production ]; then
+            {{% vendor/cli %}} backup:create --yes --no-wait
+            {{% vendor/cli %}} source-operation:run update --no-wait --yes
+          fi
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/create-apps/image-properties/firewall.md
+++ b/sites/platform/src/create-apps/image-properties/firewall.md
@@ -35,14 +35,13 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'python:{{% latest "python" %}}'
-    source:
-      root: "/"
-    firewall:
-      outbound:
-        - ips: [ "0.0.0.0/0" ]
+name: {{% variable "APP_NAME" %}}
+type: 'python:{{% latest "python" %}}'
+source:
+  root: "/"
+firewall:
+  outbound:
+    - ips: [ "0.0.0.0/0" ]
 ```
 
 <--->
@@ -51,17 +50,16 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "python@{{% latest python %}}" ]
-    firewall:
-      outbound:
-        - ips: [ "0.0.0.0/0" ]
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "python@{{% latest python %}}" ]
+  firewall:
+    outbound:
+      - ips: [ "0.0.0.0/0" ]
 ```
 
 {{< /codetabs >}}
@@ -86,16 +84,15 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'python:{{% latest "python" %}}'
-    source:
-      root: "/"
-    firewall:
-      outbound:
-        - ips: [ "1.2.3.4/32" ]
-          ports: [ 443 ]
-        - ports: [ 80 ]
+name: {{% variable "APP_NAME" %}}
+type: 'python:{{% latest "python" %}}'
+source:
+  root: "/"
+firewall:
+  outbound:
+    - ips: [ "1.2.3.4/32" ]
+      ports: [ 443 ]
+    - ports: [ 80 ]
 ```
 
 <--->
@@ -104,19 +101,18 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "python@{{% latest python %}}" ]
-    firewall:
-      outbound:
-        - ips: [ "1.2.3.4/32" ]
-          ports: [ 443 ]
-        - ports: [ 80 ]
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "python@{{% latest python %}}" ]
+  firewall:
+    outbound:
+      - ips: [ "1.2.3.4/32" ]
+        ports: [ 443 ]
+      - ports: [ 80 ]
 ```
 
 {{< /codetabs >}}
@@ -146,19 +142,18 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'python:{{% latest "python" %}}'
-    source:
-      root: "/"
-    firewall:
-      outbound:
-        - protocol: tcp
-          domains: [ "api.stripe.com", "api.twilio.com" ]
-          ports: [ 80, 443 ]
-        - protocol: tcp
-          ips: [ "1.2.3.4/29","2.3.4.5" ]
-          ports: [ 22 ]
+name: {{% variable "APP_NAME" %}}
+type: 'python:{{% latest "python" %}}'
+source:
+  root: "/"
+firewall:
+  outbound:
+    - protocol: tcp
+      domains: [ "api.stripe.com", "api.twilio.com" ]
+      ports: [ 80, 443 ]
+    - protocol: tcp
+      ips: [ "1.2.3.4/29","2.3.4.5" ]
+      ports: [ 22 ]
 ```
 
 <--->
@@ -167,22 +162,21 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "python@{{% latest python %}}" ]
-    firewall:
-      outbound:
-        - protocol: tcp
-          domains: [ "api.stripe.com", "api.twilio.com" ]
-          ports: [ 80, 443 ]
-        - protocol: tcp
-          ips: [ "1.2.3.4/29","2.3.4.5" ]
-          ports: [ 22 ]
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "python@{{% latest python %}}" ]
+  firewall:
+    outbound:
+      - protocol: tcp
+        domains: [ "api.stripe.com", "api.twilio.com" ]
+        ports: [ 80, 443 ]
+      - protocol: tcp
+        ips: [ "1.2.3.4/29","2.3.4.5" ]
+        ports: [ 22 ]
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/create-apps/image-properties/mounts.md
+++ b/sites/platform/src/create-apps/image-properties/mounts.md
@@ -109,20 +109,19 @@ The locations of mounts as they are visible to application containers can overla
 For example:
 
 ```yaml {configFile="apps"}
-applications:
-  myapp:
-    # ...
-    mounts:
-      'var/cache_a':
-        source: service
-        service: ns_service
-        source_path: cacheA
-      'var/cache_b':
-        source: tmp
-        source_path: cacheB
-      'var/cache_c':
-        source: local
-        source_path: cacheC
+myapp:
+  # ...
+  mounts:
+    'var/cache_a':
+      source: service
+      service: ns_service
+      source_path: cacheA
+    'var/cache_b':
+      source: tmp
+      source_path: cacheB
+    'var/cache_c':
+      source: local
+      source_path: cacheC
 ```
 
 In this case, it does not matter that each mount is of a different `source` type.
@@ -131,20 +130,19 @@ Each mount is restricted to a subfolder within `var`, and all is well.
 The following, however, is not allowed and will result in a failure:
 
 ```yaml {configFile="apps"}
-applications:
-  myapp:
-    # ...
-    mounts:
-      'var/':
-        source: service
-        service: ns_service
-        source_path: cacheA
-      'var/cache_b':
-        source: tmp
-        source_path: cacheB
-      'var/cache_c':
-        source: local
-        source_path: cacheC
+myapp:
+  # ...
+  mounts:
+    'var/':
+      source: service
+      service: ns_service
+      source_path: cacheA
+    'var/cache_b':
+      source: tmp
+      source_path: cacheB
+    'var/cache_c':
+      source: local
+      source_path: cacheC
 ```
 
 The `service` mount type specifically exists to share data between instances of the same application, whereas `tmp` and `instance` are meant to restrict data to build time and runtime of a single application instance, respectively.

--- a/sites/platform/src/create-apps/image-properties/variables.md
+++ b/sites/platform/src/create-apps/image-properties/variables.md
@@ -21,7 +21,7 @@ All other variables are available in the [`PLATFORM_VARIABLES` environment varia
 The following example sets two variables:
 
 - A variable named `env:AUTHOR` with the value `Juan` that's available in the environment as `AUTHOR`
-- A variable named `d8config:system.site:name` with the value `My site rocks`
+- A variable named `d8config:system.site:name` with the value `Example Site`
   that's available in the `PLATFORM_VARIABLES` environment variable
 
 {{< codetabs >}}
@@ -31,16 +31,15 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  myapp:
-    type: 'python:{{% latest "python" %}}'
-    source:
-      root: "/"
-    variables:
-      env:
-        AUTHOR: 'Juan'
-      d8config:
-        "system.site:name": 'My site rocks'
+name: myapp
+type: 'python:{{% latest "python" %}}'
+source:
+  root: "/"
+variables:
+  env:
+    AUTHOR: 'Juan'
+  d8config:
+    "system.site:name": 'Example Site'
 ```
 
 <--->
@@ -49,19 +48,18 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  myapp:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "python@{{% latest python %}}" ]
-    variables:
-      env:
-        AUTHOR: 'Juan'
-      d8config:
-        "system.site:name": 'My site rocks'
+```yaml {configFile="apps"}
+myapp:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "python@{{% latest python %}}" ]
+  variables:
+    env:
+      AUTHOR: 'Juan'
+    d8config:
+      "system.site:name": 'Example Site'
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/create-apps/image-properties/web.md
+++ b/sites/platform/src/create-apps/image-properties/web.md
@@ -72,16 +72,16 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-name: {{% variable "APP_NAME" %}}:   
-type: "python:{{% latest "python" %}}"    
+name: {{% variable "APP_NAME" %}}
+type: "python:{{% latest "python" %}}"
 source:
   root: "/"
 web:
   commands:
     start: 'uwsgi --ini conf/server.ini'
     post_start: |
-    date
-    curl -sS --retry 20 --retry-delay 1 --retry-connrefused localhost -o /dev/null
+      date
+      curl -sS --retry 20 --retry-delay 1 --retry-connrefused localhost -o /dev/null
 ```
 
 <--->
@@ -101,8 +101,8 @@ title=Composable image
     commands:
       start: 'uwsgi --ini conf/server.ini'
       post_start: |
-      date
-      curl -sS --retry 20 --retry-delay 1 --retry-connrefused localhost -o /dev/null
+        date
+        curl -sS --retry 20 --retry-delay 1 --retry-connrefused localhost -o /dev/null
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/create-apps/image-properties/workers.md
+++ b/sites/platform/src/create-apps/image-properties/workers.md
@@ -36,17 +36,16 @@ Each worker can differ from the `web` instance in all properties _except_ for:
 A worker named `queue` that was small and had a different start command could look like this:
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'python:{{% latest "python" %}}'
-    source:
-      root: "/"
-    workers:
-      queue:
-        size: S
-        commands:
-          start: |
-            ./worker.sh        
+name: {{% variable "APP_NAME" %}}
+type: 'python:{{% latest "python" %}}'
+source:
+  root: "/"
+workers:
+  queue:
+    size: S
+    commands:
+      start: |
+        ./worker.sh        
 ```
     
 <--->
@@ -67,20 +66,19 @@ Each worker can differ from the `web` instance in all properties _except_ for:
 
 A worker named `queue` that was small and had a different start command could look like this:
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: [ "python@{{% latest python %}}" ]
-    workers:
-      queue:
-        size: S
-        commands:
-          start: |
-            ./worker.sh        
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: [ "python@{{% latest python %}}" ]
+  workers:
+    queue:
+      size: S
+      commands:
+        start: |
+          ./worker.sh        
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/define-routes/_index.md
+++ b/sites/platform/src/define-routes/_index.md
@@ -79,11 +79,10 @@ Sticky routing ensures that all requests from a specific client are consistently
 At {{% vendor/name %}}, sticky routing is implemented using a hash of the client’s IP address. This ensures requests from the same IP are generally routed to the same container.
 
 ```yaml {configFile="routes"}
-routes:
-  "https://{default}/":
-    type: upstream
-    upstream: app:http
-    sticky: true
+"https://{default}/":
+  type: upstream
+  upstream: app:http
+  sticky: true
 ```
 This enables sticky routing at the router level.
 

--- a/sites/platform/src/define-routes/https.md
+++ b/sites/platform/src/define-routes/https.md
@@ -164,12 +164,11 @@ tls:
 If you want to request a client certificate without _requiring_ the client to send one, you can set this by using `request` as a value for `client_authentication`:
 
 ```yaml {configFile="routes"}
-routes:
-  "https://{default}/":
-    # ...
-    tls:
-      client_authentication: "request"
-    # ...
+"https://{default}/":
+  # ...
+  tls:
+    client_authentication: "request"
+  # ...
 ```
 
 Requests on routes with mTLS configured that are passed through to your app will contain additional headers such as `X-Client-Verify` (with values like `Success` or `None` depending on whether a client certificate was presented and validated or not) and `X-Client-Cert` (with information about the client certificate that was used) that your application can use as required.

--- a/sites/platform/src/development/sanitize-db/postgresql-symfony.md
+++ b/sites/platform/src/development/sanitize-db/postgresql-symfony.md
@@ -96,10 +96,10 @@ Set up a script by following these steps:
     hooks:
       build: ...
       deploy: |
-      if [ "$PLATFORM_ENVIRONMENT_TYPE" != production ]; then
-        # The sanitization of the database should happen here (since it's non-production)
-        php bin/console app:sanitize-data
-      fi
+        if [ "$PLATFORM_ENVIRONMENT_TYPE" != production ]; then
+          # The sanitization of the database should happen here (since it's non-production)
+          php bin/console app:sanitize-data
+        fi
     ```
 
     To sanitize only on the initial deploy and not all future deploys, on sanitization create a file on a mount. Then add a check for the file as in the following example:

--- a/sites/platform/src/development/variables/_index.md
+++ b/sites/platform/src/development/variables/_index.md
@@ -182,11 +182,10 @@ To use variables across environments, set them in your [app configuration](/crea
 For example, to change the PHP memory limit for all environments, use the following configuration:
 
 ```yaml {configFile="app"}
-applications:
-  {{< variable "APP_NAME" >}}:
-    variables:
-      php:
-        memory_limit: "256M"
+name: {{< variable "APP_NAME" >}}
+variables:
+  php:
+    memory_limit: "256M"
 ```
 
 ### Framework-specific variables

--- a/sites/platform/src/guides/strapi/database-configuration/postgresql.md
+++ b/sites/platform/src/guides/strapi/database-configuration/postgresql.md
@@ -18,9 +18,9 @@ To configure a PostgreSQL database for Strapi on {{% vendor/name %}}, follow the
 1. In your `{{< vendor/configfile "services" >}}` file, add the following:
 
    ```yaml {configFile="services"}
-   	postgres:
-      type: postgresql:13
-        disk: 512
+   postgres:
+     type: postgresql:13
+     disk: 512
    ```
 
 1. In your `{{< vendor/configfile "app" >}}` file, replace the relationship name to match the PostgreSQL database you added:

--- a/sites/platform/src/languages/php/_index.md
+++ b/sites/platform/src/languages/php/_index.md
@@ -284,7 +284,7 @@ type: 'php:{{% latest "php" %}}'
 dependencies:
   php:
     require:
-      "third-party/required-plugin"": "^3.0"
+      "third-party/required-plugin": "^3.0"
 ```
 
 2. Add each additional property as a block at the same indentation as the `require` block:

--- a/sites/platform/src/languages/php/_index.md
+++ b/sites/platform/src/languages/php/_index.md
@@ -236,33 +236,31 @@ By default, PHP builds fail if a dependency in a project has a known vulnerabili
 
 Examples: 
 ```yaml {configFile="app"}
-applications:
-  # The app's name, which must be unique within the project.
-  myapp:
-    type: 'php:{{% latest "php" %}}'
-    <snip>
-    dependencies:
-      php:
-        config:
-          audit:
-            ignore:  # ignore these security advisories
-              - "PKSA-yhcn-xrg3-68b1"
-              - "PKSA-2wrf-1mxk-1pky"
+# The app's name, which must be unique within the project.
+name: myapp
+type: 'php:{{% latest "php" %}}'
+<snip>
+dependencies:
+  php:
+    config:
+      audit:
+        ignore:  # ignore these security advisories
+          - "PKSA-yhcn-xrg3-68b1"
+          - "PKSA-2wrf-1mxk-1pky"
 ```
 
 ```yaml {configFile="app"}
-applications:
-  # The app's name, which must be unique within the project.
-  myapp:
-    type: 'php:{{% latest "php" %}}'
-    <snip>
-    dependencies:
-      php:
-        config:
-          audit:
-            ignore-severity:
-              low:
-                apply: all   # ignore all low severity findings
+# The app's name, which must be unique within the project.
+name: myapp
+type: 'php:{{% latest "php" %}}'
+<snip>
+dependencies:
+  php:
+    config:
+      audit:
+        ignore-severity:
+          low:
+            apply: all   # ignore all low severity findings
 ```
 
 Related information: 
@@ -279,32 +277,30 @@ To add additional composer schema properties:
 1. Set an explicit `require` block:
 
 ```yaml {configFile="app"}
-applications:
-  # The app's name, which must be unique within the project.
-  myapp:
-    type: 'php:{{% latest "php" %}}'
-    <snip>
-    dependencies:
-      php:
-        require:
-          "third-party/required-plugin"": "^3.0"
+# The app's name, which must be unique within the project.
+name: myapp
+type: 'php:{{% latest "php" %}}'
+<snip>
+dependencies:
+  php:
+    require:
+      "third-party/required-plugin"": "^3.0"
 ```
 
 2. Add each additional property as a block at the same indentation as the `require` block:
 
 ```yaml {configFile="app"}
-applications:
-  # The app's name, which must be unique within the project.
-  myapp:
-    type: 'php:{{% latest "php" %}}'
-    <snip>
-    dependencies:
-      php:
-        require:
-          symfony/runtime: '*'
-        config:
-          "allow-plugins":
-            symfony/runtime: true
+# The app's name, which must be unique within the project.
+name: myapp
+type: 'php:{{% latest "php" %}}'
+<snip>
+dependencies:
+  php:
+    require:
+      symfony/runtime: '*'
+    config:
+      "allow-plugins":
+        symfony/runtime: true
 ```
 
 

--- a/sites/platform/src/languages/php/extensions.md
+++ b/sites/platform/src/languages/php/extensions.md
@@ -25,19 +25,18 @@ title=Single-runtime image
 +++
 
 ```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: 'php:{{% latest "php" %}}'
-    source:
-      root: "/"
-    runtime:
-      extensions:
-        - raphf
-        - http
-        - igbinary
-        - redis
-      disabled_extensions:
-        - sqlite3
+name: {{% variable "APP_NAME" %}}
+type: 'php:{{% latest "php" %}}'
+source:
+  root: "/"
+runtime:
+  extensions:
+    - raphf
+    - http
+    - igbinary
+    - redis
+  disabled_extensions:
+    - sqlite3
 ```
 
 <--->
@@ -46,21 +45,20 @@ applications:
 title=Composable image
 +++
 
-```yaml {configFile="app"}
-applications:
-  {{% variable "APP_NAME" %}}:
-    type: "composable:{{% latest composable %}}"
-    source:
-      root: "/"
-    stack: 
-      runtimes: "php@{{% latest php %}}"
-        extensions:
-          - raphf
-          - http
-          - igbinary
-          - redis
-        disabled_extensions:
-          - sqlite3
+```yaml {configFile="apps"}
+{{% variable "APP_NAME" %}}:
+  type: "composable:{{% latest composable %}}"
+  source:
+    root: "/"
+  stack: 
+    runtimes: "php@{{% latest php %}}"
+      extensions:
+        - raphf
+        - http
+        - igbinary
+        - redis
+      disabled_extensions:
+        - sqlite3
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/languages/php/extensions.md
+++ b/sites/platform/src/languages/php/extensions.md
@@ -51,14 +51,15 @@ title=Composable image
   source:
     root: "/"
   stack: 
-    runtimes: "php@{{% latest php %}}"
-      extensions:
-        - raphf
-        - http
-        - igbinary
-        - redis
-      disabled_extensions:
-        - sqlite3
+    runtimes:
+      - "php@{{% latest php %}}":
+          extensions:
+            - raphf
+            - http
+            - igbinary
+            - redis
+          disabled_extensions:
+            - sqlite3
 ```
 
 {{< /codetabs >}}

--- a/sites/platform/src/languages/php/frankenphp.md
+++ b/sites/platform/src/languages/php/frankenphp.md
@@ -88,104 +88,102 @@ FrankenPHP is available as a package in {{% vendor/name %}} composable stacks.
 
 ### Classic mode configuration
 
-```yaml {configFile="app"}
-applications:
-  app:
-    type: "composable:25.11"
-    source:
-      root: "/"
+```yaml {configFile="apps"}
+app:
+  type: "composable:25.11"
+  source:
+    root: "/"
 
-    stack:
-      runtimes:
-        - "php@8.4":
-            extensions:
-              - apcu
-              - blackfire
-              - ctype
-              - iconv
-              - mbstring
-              - pdo_pgsql
-              - sodium
-              - xsl
-        - "nodejs@22"
-      packages:
-        - "frankenphp"
+  stack:
+    runtimes:
+      - "php@8.4":
+          extensions:
+            - apcu
+            - blackfire
+            - ctype
+            - iconv
+            - mbstring
+            - pdo_pgsql
+            - sodium
+            - xsl
+      - "nodejs@22"
+    packages:
+      - "frankenphp"
 
-    variables:
-      php:
-        opcache.preload: config/preload.php
-      env:
-        APP_RUNTIME: 'Runtime\\FrankenPhpSymfony\\Runtime'
-        # composer require runtime/frankenphp-symfony
+  variables:
+    php:
+      opcache.preload: config/preload.php
+    env:
+      APP_RUNTIME: 'Runtime\\FrankenPhpSymfony\\Runtime'
+      # composer require runtime/frankenphp-symfony
 
-    web:
-      upstream:
-        socket_family: tcp
-        protocol: http
+  web:
+    upstream:
+      socket_family: tcp
+      protocol: http
 
-      commands:
-        start: frankenphp php-server --listen=localhost:$PORT --root=$PLATFORM_DOCUMENT_ROOT index.php
+    commands:
+      start: frankenphp php-server --listen=localhost:$PORT --root=$PLATFORM_DOCUMENT_ROOT index.php
 
-      locations:
-        "/":
-          root: "public"
-          expires: 1h
-          passthru: true
-          allow: true
-          scripts: true
-          request_buffering:
-            enabled: false
+    locations:
+      "/":
+        root: "public"
+        expires: 1h
+        passthru: true
+        allow: true
+        scripts: true
+        request_buffering:
+          enabled: false
 
 ```
 ### Worker mode configuration
 
-```yaml {configFile="app"}
-applications:
-  app:
-    type: "composable:25.11"
-    source:
-      root: "/"
+```yaml {configFile="apps"}
+app:
+  type: "composable:25.11"
+  source:
+    root: "/"
 
-    stack:
-      runtimes:
-        - "php@8.4":
-            extensions:
-              - apcu
-              - blackfire
-              - ctype
-              - iconv
-              - mbstring
-              - pdo_pgsql
-              - sodium
-              - xsl
-        - "nodejs@22"
-      packages:
-        - "frankenphp"
+  stack:
+    runtimes:
+      - "php@8.4":
+          extensions:
+            - apcu
+            - blackfire
+            - ctype
+            - iconv
+            - mbstring
+            - pdo_pgsql
+            - sodium
+            - xsl
+      - "nodejs@22"
+    packages:
+      - "frankenphp"
 
-    variables:
-      php:
-        opcache.preload: config/preload.php
-      env:
-        APP_RUNTIME: 'Runtime\\FrankenPhpSymfony\\Runtime'
-        # composer require runtime/frankenphp-symfony
+  variables:
+    php:
+      opcache.preload: config/preload.php
+    env:
+      APP_RUNTIME: 'Runtime\\FrankenPhpSymfony\\Runtime'
+      # composer require runtime/frankenphp-symfony
 
-    web:
-      upstream:
-        socket_family: tcp
-        protocol: http
+  web:
+    upstream:
+      socket_family: tcp
+      protocol: http
 
-      commands:
-        start: frankenphp php-server --worker $PLATFORM_DOCUMENT_ROOT/index.php --listen=localhost:$PORT --root=$PLATFORM_DOCUMENT_ROOT
+    commands:
+      start: frankenphp php-server --worker $PLATFORM_DOCUMENT_ROOT/index.php --listen=localhost:$PORT --root=$PLATFORM_DOCUMENT_ROOT
 
-      locations:
-        "/":
-          root: "public"
-          expires: 1h
-          passthru: true
-          allow: true
-          scripts: true
-          request_buffering:
-            enabled: false
+    locations:
+      "/":
+        root: "public"
+        expires: 1h
+        passthru: true
+        allow: true
+        scripts: true
+        request_buffering:
+          enabled: false
 
 ```
 ### Using the latest FrankenPHP version

--- a/sites/platform/src/languages/php/troubleshoot.md
+++ b/sites/platform/src/languages/php/troubleshoot.md
@@ -23,16 +23,15 @@ If advisories were published after the most recent PHP app deployment, the build
 **Important: Upsun advises against disabling security blocking.** However, as a last resort, the feature can be disabled as a workaround while you fix issues with dependencies.  
 
 ```yaml {configFile="app"}
-applications:
 # The app's name, which must be unique within the project.
-myapp:
-  type: 'php:{{% latest "php" %}}'
-  <snip>
-  dependencies:
-    php:
-      config:
-        audit:
-          block-insecure: false
+name: myapp
+type: 'php:{{% latest "php" %}}'
+<snip>
+dependencies:
+  php:
+    config:
+      audit:
+        block-insecure: false
 ```      
 
 ## Server reached `max_children`

--- a/sites/platform/src/learn/tutorials/upgrade-runtimes-services.md
+++ b/sites/platform/src/learn/tutorials/upgrade-runtimes-services.md
@@ -135,9 +135,8 @@ PostgreSQL 10 and later, for example, include a built-in upgrade utility that ru
 1. Update the `type` key for your service:
 
    ```yaml {configFile="services"}
-   services:
-     database:
-       type: postgresql:{{% latest "postgresql" %}}
+   database:
+     type: postgresql:{{% latest "postgresql" %}}
    ```
 
 2. Push to a non-production branch. If you don't already have one, create it first:
@@ -186,9 +185,8 @@ export your data, provision a new service at the target version, and import the 
    Renaming forces {{% vendor/name %}} to create a fresh service container.
 
    ```yaml {configFile="services"}
-   services:
-     database-target:
-       type: postgresql:{{% latest "postgresql" %}}
+   database-target:
+     type: postgresql:{{% latest "postgresql" %}}
    ```
 
 3. Update the `relationships` of any application that references the old service name:

--- a/sites/platform/src/learn/tutorials/upgrade-runtimes-services.md
+++ b/sites/platform/src/learn/tutorials/upgrade-runtimes-services.md
@@ -83,9 +83,8 @@ Updating to a new version means changing that value and pushing it.
 1. Check the supported versions on the runtime page under [Languages](/languages/_index.md), then update the `type` key with the correct version number:
 
    ```yaml {configFile="app"}
-   applications:
-     myapp:
-       type: 'php:{{% latest "php" %}}'
+   name: myapp
+   type: 'php:{{% latest "php" %}}'
    ```
 
 2. Push to a non-production branch. If you don't already have one, create it first:
@@ -195,12 +194,11 @@ export your data, provision a new service at the target version, and import the 
 3. Update the `relationships` of any application that references the old service name:
 
    ```yaml {configFile="app"}
-   applications:
-     myapp:
-       relationships:
-         database:
-           service: database-target
-           endpoint: postgresql
+   name: myapp
+   relationships:
+     database:
+       service: database-target
+       endpoint: postgresql
    ```
 
 4. Push to a non-production branch and import your data into the new service.


### PR DESCRIPTION
## Summary

In Upsun Fixed, config files don't wrap entries in a top-level key named after the file: a `.platform.app.yaml` file has the app's properties directly at the top level, `.platform/applications.yaml` and `.platform/services.yaml` use each app/service's name as a top-level mapping key, and `.platform/routes.yaml` uses each route pattern as a top-level key. That convention applies only to Fixed — Flex docs live in the Mintlify repo and keep the wrapper style there. A number of YAML examples under `sites/platform/src` still showed the Flex-style wrapper, and validating them surfaced several unrelated pre-existing YAML bugs along the way. This PR fixes both.

## Changes

**1. Remove the `applications:` wrapper** (`57c3a3b1a`)
- Single-app `.platform.app.yaml` examples: properties promoted to the top level with an explicit `name: <app>` key.
- Multi-app `.platform/applications.yaml` examples (and, per existing repo convention, the "Composable image" tab of paired codetabs): each app name promoted to a top-level key, `configFile` tag corrected from `"app"` to `"apps"` where applicable.
- Corrected two prose references to the old wrapper structure in `composable-image.md`.
- Split two examples in `valkey.md` that combined app + service config under one tag into separate `app`/`services` blocks.
- `variables.md`: swapped the placeholder site name `My site rocks` for `Example Site`.

**2. Fix invalid YAML found while validating #1** (`81f925e63`)
- `languages/php/_index.md`: stray quote breaking a `require` block.
- `languages/php/extensions.md`: `stack.runtimes` written as a scalar with child keys (invalid YAML).

**3. Remove the `services:`/`routes:` wrapper** (`2c185d0c0`)
- Same anti-pattern, extended to `.platform/services.yaml` (`upgrade-runtimes-services.md`, `solr.md`, `valkey.md`, `postgresql-readonly-replication.md`, `mysql-readonly-replication.md`) and `.platform/routes.yaml` (`define-routes/_index.md`, `define-routes/https.md`).
- Confirmed against `add-services/_index.md` (services.yaml's authoritative example) and the unanimous convention across the rest of `define-routes/` (routes.yaml).

**4. Fix additional pre-existing invalid YAML found during validation** (`bab62b31f`)
- `mysql/_index.md`: `configuration:`/`endpoints:` over-indented under `disk:`.
- `redis.md`: `passthru:` over-indented under `root:`.
- `strapi/database-configuration/postgresql.md`: stray tab character plus misaligned `disk:`.
- `sanitize-db/postgresql-symfony.md`: `deploy:` block scalar not indented under its key, so the script doesn't attach to it.
- `create-apps/image-properties/web.md`: same block-scalar bug on `post_start:` in both codetabs, plus a stray trailing colon on `name:` left over from PR #5721.

## Testing

- `npm run lint:markdown` (eslint) passes on all touched files.
- Parsed every touched YAML code block with `js-yaml` to confirm no syntax errors remain.

## Reviewers: please advise

`languages/java/migration.md` has footnote markers (`[1]`, `[2]`, `[3]`) literally embedded inside its YAML code fences (e.g. `type: 'java:<VERSION>' [1]`, `build: [2]`), where a numbered list below is meant to explain them. This makes the example invalid if copy-pasted, and there's also a numbering mismatch (footnote 4 is orphaned — nothing in the code references it). Fixing this means rewriting the example with real values rather than a one-line syntax fix, so I left it out of this PR pending a decision on the intended content. Flagging here rather than guessing.

## Notes

- Left untouched: `services:` wrapper in Docker Compose examples (`guides/django/local/{ddev,tethered}.md`) — Compose's own spec legitimately uses that key, unrelated to Platform.sh config.
- Left untouched: TYPO3's own site-config `routes:` key in `guides/typo3/deploy/customize.md` — a different `routes:` entirely, internal to TYPO3, not `.platform/routes.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)